### PR TITLE
chore: Enable compatibility with sha2 v0.10.6

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -25,7 +25,7 @@ rand = { version = "0.8.5", optional = true }
 ruint = { version = "1.8.0", features = ["serde"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_repr = { version = "0.1", optional = true }
-sha2 = "0.10.7"
+sha2 = "0.10.6"
 thiserror = "1.0.40"
 
 [dev-dependencies]


### PR DESCRIPTION
In the Sovereign SDK, we use sha2 `v0.10.6`. This change makes Lumina compatible with that version while still allowing consumers to rely on the newer version if they desire (see Cargo's [Semver policy](https://doc.rust-lang.org/cargo/reference/semver.html)).