### PR TITLE
chore: Pin celestia-app version to 1.4 when updating protobuf, update protobufs

### DIFF
--- a/proto/vendor/celestia/blob/v1/query.proto
+++ b/proto/vendor/celestia/blob/v1/query.proto
@@ -3,6 +3,7 @@ package celestia.blob.v1;
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
 import "celestia/blob/v1/params.proto";
 
 option go_package = "github.com/celestiaorg/celestia-app/x/blob/types";

--- a/proto/vendor/celestia/qgb/v1/query.proto
+++ b/proto/vendor/celestia/qgb/v1/query.proto
@@ -4,6 +4,7 @@ package celestia.qgb.v1;
 import "celestia/qgb/v1/genesis.proto";
 import "celestia/qgb/v1/types.proto";
 import "google/api/annotations.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
 import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 import "google/protobuf/any.proto";
@@ -29,6 +30,11 @@ service Query {
   rpc LatestAttestationNonce(QueryLatestAttestationNonceRequest)
       returns (QueryLatestAttestationNonceResponse) {
     option (google.api.http).get = "/qgb/v1/attestations/nonce/latest";
+  }
+  // EarliestAttestationNonce queries the earliest attestation nonce.
+  rpc EarliestAttestationNonce(QueryEarliestAttestationNonceRequest)
+      returns (QueryEarliestAttestationNonceResponse) {
+    option (google.api.http).get = "/qgb/v1/attestations/nonce/earliest";
   }
   // LatestValsetRequestBeforeNonce Queries latest Valset request before nonce.
   // And, even if the current nonce is a valset, it will return the previous
@@ -91,6 +97,11 @@ message QueryAttestationRequestByNonceResponse {
 message QueryLatestAttestationNonceRequest {}
 // QueryLatestAttestationNonceResponse latest attestation nonce response
 message QueryLatestAttestationNonceResponse { uint64 nonce = 1; }
+
+// QueryEarliestAttestationNonceRequest earliest attestation nonce request
+message QueryEarliestAttestationNonceRequest {}
+// QueryEarliestAttestationNonceResponse earliest attestation nonce response
+message QueryEarliestAttestationNonceResponse { uint64 nonce = 1; }
 
 // QueryLatestValsetRequestBeforeNonceRequest latest Valset request before
 // universal nonce request

--- a/tools/update-proto-vendor.sh
+++ b/tools/update-proto-vendor.sh
@@ -23,7 +23,7 @@ rm -rf ../target/proto-vendor-src
 mkdir -p ../target/proto-vendor-src
 
 extract_urls ../target/proto-vendor-src \
-    https://github.com/celestiaorg/celestia-app/archive/refs/heads/main.tar.gz \
+    https://github.com/celestiaorg/celestia-app/archive/refs/tags/v1.4.0.tar.gz \
     https://github.com/celestiaorg/celestia-core/archive/refs/heads/v0.34.x-celestia.tar.gz \
     https://github.com/celestiaorg/celestia-node/archive/refs/heads/main.tar.gz \
     https://github.com/celestiaorg/cosmos-sdk/archive/refs/heads/release/v0.46.x-celestia.tar.gz \
@@ -36,7 +36,7 @@ extract_urls ../target/proto-vendor-src \
 mkdir -p vendor
 
 rm -rf vendor/celestia
-cp -r ../target/proto-vendor-src/celestia-app-main/proto/celestia vendor
+cp -r ../target/proto-vendor-src/celestia-app-1.4.0/proto/celestia vendor
 
 rm -rf vendor/go-header
 mkdir -p vendor/go-header/p2p


### PR DESCRIPTION
Changed upgrade script to pull 1.4 version of the `celestia-app` as this is what `celestia-node` is using and protobufs there don't yet work with the ones on main.

Also ran update script for good measure.