### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,28 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/blockstore/CHANGELOG.md
+++ b/blockstore/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/blockstore-v0.1.0) - 2024-01-12
+
+### Added
+- Add in-memory blockstore ([#160](https://github.com/eigerco/lumina/pull/160))
+
+### Other
+- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
+- document public api ([#161](https://github.com/eigerco/lumina/pull/161))

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-cli-v0.1.0) - 2024-01-12
+
+### Other
+- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
+- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
+- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
+- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-wasm-v0.1.0) - 2024-01-12
+
+### Added
+- Return bootstrap peers as iterator and filter relevant ones ([#147](https://github.com/eigerco/lumina/pull/147))
+- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))
+
+### Other
+- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
+- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
+- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
+- switch browser logging to tracing-web ([#150](https://github.com/eigerco/lumina/pull/150))

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-v0.1.0) - 2024-01-12
+
+### Added
+- Return bootstrap peers as iterator and filter relevant ones ([#147](https://github.com/eigerco/lumina/pull/147))
+- Bootstrap more aggresively when too few peers ([#146](https://github.com/eigerco/lumina/pull/146))
+- *(types)* Add `wasm-bindgen` feature flag ([#143](https://github.com/eigerco/lumina/pull/143))
+- *(node)* Implement sessions ([#130](https://github.com/eigerco/lumina/pull/130))
+- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))
+- *(node)* Use Kademlia bootstrap to recover connections and refresh routing table ([#120](https://github.com/eigerco/lumina/pull/120))
+- *(rpc)* create wrappers for jsonrpsee clients ([#114](https://github.com/eigerco/lumina/pull/114))
+- *(node)* Implement persistent header storage in browser using IndexedDB ([#102](https://github.com/eigerco/lumina/pull/102))
+- Improve performance of Exchange ([#104](https://github.com/eigerco/lumina/pull/104))
+- Choose transport based on target_arch and improve TCP connections ([#103](https://github.com/eigerco/lumina/pull/103))
+- *(node)* Implement Syncer ([#94](https://github.com/eigerco/lumina/pull/94))
+- Add trusted peers and keep track of multiple connections per peer ([#92](https://github.com/eigerco/lumina/pull/92))
+- Forward only verified and new HeaderSub messages ([#89](https://github.com/eigerco/lumina/pull/89))
+- Store improvements ([#88](https://github.com/eigerco/lumina/pull/88))
+- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
+- Peer discovery with Kademlia ([#79](https://github.com/eigerco/lumina/pull/79))
+- *(node)* Add state of peer in PeerTracker ([#82](https://github.com/eigerco/lumina/pull/82))
+- *(node/exchange)* Request HEAD from multiple peers and choose the best result ([#67](https://github.com/eigerco/lumina/pull/67))
+- *(node)* Implement exchange client ([#63](https://github.com/eigerco/lumina/pull/63))
+- *(exchange)* Add pre-allocating the buffer for reading in HeaderCodec ([#64](https://github.com/eigerco/lumina/pull/64))
+- *(node)* hide all services behind traits ([#54](https://github.com/eigerco/lumina/pull/54))
+- add RPC calls for p2p module and tests for them ([#52](https://github.com/eigerco/lumina/pull/52))
+- *(p2p)* add NetworkInfo command ([#45](https://github.com/eigerco/lumina/pull/45))
+- Support WASM for Web in celestia-node ([#44](https://github.com/eigerco/lumina/pull/44))
+- Implement initial architecture of node crate ([#42](https://github.com/eigerco/lumina/pull/42))
+
+### Fixed
+- Use pre-defined DNS nameservers ([#129](https://github.com/eigerco/lumina/pull/129))
+- *(node)* Allow HeaderSub reinitialization ([#128](https://github.com/eigerco/lumina/pull/128))
+- *(node/syncer)* Stop fetching header when all peers disconnected ([#111](https://github.com/eigerco/lumina/pull/111))
+- Yield between multiple `ExtendedHeader::validate` ([#107](https://github.com/eigerco/lumina/pull/107))
+- *(node)* Adjust PeerTrackerInfo when peer trust is changed ([#105](https://github.com/eigerco/lumina/pull/105))
+- *(node)* Remove keep_alive::Behaviour ([#95](https://github.com/eigerco/lumina/pull/95))
+- *(node/exchange)* Forward handling of pending connections to req_resp ([#80](https://github.com/eigerco/lumina/pull/80))
+- Use `get_header_by_height(0)` to get the HEAD ([#71](https://github.com/eigerco/lumina/pull/71))
+
+### Other
+- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
+- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
+- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
+- update bootstrap nodes to lumina ([#163](https://github.com/eigerco/lumina/pull/163))
+- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
+- hide p2p and syncer components from public node api ([#127](https://github.com/eigerco/lumina/pull/127))
+- Upgrade libp2p to v0.53.0 ([#126](https://github.com/eigerco/lumina/pull/126))
+- rename Exchange to HeaderEx ([#122](https://github.com/eigerco/lumina/pull/122))
+- *(node)* Optimize transport for memory and bandwitdh ([#113](https://github.com/eigerco/lumina/pull/113))
+- Produce an error if bootnode multiaddr do not have peer ID ([#106](https://github.com/eigerco/lumina/pull/106))
+- Implement persistent storage for native builds using sled  ([#97](https://github.com/eigerco/lumina/pull/97))
+- trim the features of workspace dependencies ([#99](https://github.com/eigerco/lumina/pull/99))
+- Add integration tests for exchange server/client ([#93](https://github.com/eigerco/lumina/pull/93))
+- Implement ExchangeServerHandler ([#72](https://github.com/eigerco/lumina/pull/72))
+- Write test cases for invalid and bad headers ([#87](https://github.com/eigerco/lumina/pull/87))
+- Remove flume crate ([#86](https://github.com/eigerco/lumina/pull/86))
+- Split gossipsub code in smaller functions ([#81](https://github.com/eigerco/lumina/pull/81))
+- Implement header Store ([#73](https://github.com/eigerco/lumina/pull/73))
+- Migrate from `log` to `tracing` ([#55](https://github.com/eigerco/lumina/pull/55))

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-proto-v0.1.0) - 2024-01-12
+
+### Added
+- *(node)* Add shwap data types ([#169](https://github.com/eigerco/lumina/pull/169))
+- *(node)* Implement persistent header storage in browser using IndexedDB ([#102](https://github.com/eigerco/lumina/pull/102))
+- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
+- *(proto)* add cosmos Tx and celestia MsgPayForBlobs ([#75](https://github.com/eigerco/lumina/pull/75))
+- Implement initial architecture of node crate ([#42](https://github.com/eigerco/lumina/pull/42))
+- *(fraud)* Add fraud proof trait and byzantine encoding fraud ([#32](https://github.com/eigerco/lumina/pull/32))
+- Add State RPC and types ([#31](https://github.com/eigerco/lumina/pull/31))
+- align namespaced shares deserialization with latest celestia  ([#20](https://github.com/eigerco/lumina/pull/20))
+- *(rpc)* Create celestia-rpc crate and add integration tests ([#17](https://github.com/eigerco/lumina/pull/17))
+- *(proto)* add `empty_as_none` serializer ([#18](https://github.com/eigerco/lumina/pull/18))
+- add NamespacedShares type ([#7](https://github.com/eigerco/lumina/pull/7))
+- *(proto)* vendor protobuf definitions
+
+### Fixed
+- temporary backward compatibility for json proofs ([#96](https://github.com/eigerco/lumina/pull/96))
+
+### Other
+- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
+- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
+- Pin celestia-app version to 1.4 when updating protobuf, update protobufs ([#175](https://github.com/eigerco/lumina/pull/175))
+- update celestia node to 0.11.0-rc15 ([#101](https://github.com/eigerco/lumina/pull/101))
+- Update protobuf definitions ([#40](https://github.com/eigerco/lumina/pull/40))
+- align to celestia node v0.11-rc ([#65](https://github.com/eigerco/lumina/pull/65))
+- fix format ([#34](https://github.com/eigerco/lumina/pull/34))
+- vendor cosmos protobuf definitions ([#30](https://github.com/eigerco/lumina/pull/30))
+- *(license)* Set Apache 2.0 license ([#6](https://github.com/eigerco/lumina/pull/6))
+- Implement Celestia types
+- initial commit

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-rpc-v0.1.0) - 2024-01-12
+
+### Added
+- *(types)* Add `wasm-bindgen` feature flag ([#143](https://github.com/eigerco/lumina/pull/143))
+- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))
+- *(rpc)* align to celestia-node 0.12.0 ([#125](https://github.com/eigerco/lumina/pull/125))
+- *(rpc)* create wrappers for jsonrpsee clients ([#114](https://github.com/eigerco/lumina/pull/114))
+- *(node)* Implement Syncer ([#94](https://github.com/eigerco/lumina/pull/94))
+- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
+- add RPC calls for p2p module and tests for them ([#52](https://github.com/eigerco/lumina/pull/52))
+- Implement initial architecture of node crate ([#42](https://github.com/eigerco/lumina/pull/42))
+- *(fraud)* Add fraud proof trait and byzantine encoding fraud ([#32](https://github.com/eigerco/lumina/pull/32))
+- Add State RPC and types ([#31](https://github.com/eigerco/lumina/pull/31))
+- *(rpc)* Add all calls for Blob, Share, and Header ([#24](https://github.com/eigerco/lumina/pull/24))
+- align namespaced shares deserialization with latest celestia  ([#20](https://github.com/eigerco/lumina/pull/20))
+- serialize proof and commitment ([#19](https://github.com/eigerco/lumina/pull/19))
+- *(rpc)* Create celestia-rpc crate and add integration tests ([#17](https://github.com/eigerco/lumina/pull/17))
+
+### Fixed
+- *(types)* fix the json representation of SubmitOptions ([#66](https://github.com/eigerco/lumina/pull/66))
+- make celestia-rpc to compile in wasm32 target ([#46](https://github.com/eigerco/lumina/pull/46))
+
+### Other
+- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
+- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
+- add validation of EDS in tests ([#165](https://github.com/eigerco/lumina/pull/165))
+- Make sure we run clippy for wasm and fix wasm build/lints ([#115](https://github.com/eigerco/lumina/pull/115))
+- Migrate to nmt-rs of crates.io ([#144](https://github.com/eigerco/lumina/pull/144))
+- Upgrade libp2p to v0.53.0 ([#126](https://github.com/eigerco/lumina/pull/126))
+- update celestia node to 0.11.0-rc15 ([#101](https://github.com/eigerco/lumina/pull/101))
+- trim the features of workspace dependencies ([#99](https://github.com/eigerco/lumina/pull/99))
+- align to celestia node v0.11-rc ([#65](https://github.com/eigerco/lumina/pull/65))
+- Migrate from `log` to `tracing` ([#55](https://github.com/eigerco/lumina/pull/55))
+- update jsonrpsee to 0.20 ([#41](https://github.com/eigerco/lumina/pull/41))

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-types-v0.1.0) - 2024-01-12
+
+### Added
+- *(node)* Add shwap data types ([#169](https://github.com/eigerco/lumina/pull/169))
+- Add in-memory blockstore ([#160](https://github.com/eigerco/lumina/pull/160))
+- expose Cid related types in public api ([#167](https://github.com/eigerco/lumina/pull/167))
+- *(types)* Add `wasm-bindgen` feature flag ([#143](https://github.com/eigerco/lumina/pull/143))
+- *(node)* Implement persistent header storage in browser using IndexedDB ([#102](https://github.com/eigerco/lumina/pull/102))
+- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
+- Peer discovery with Kademlia ([#79](https://github.com/eigerco/lumina/pull/79))
+- *(types)* expose commitment creation for shares ([#78](https://github.com/eigerco/lumina/pull/78))
+- *(types)* allow dereferencing namespace to nmt_rs one ([#77](https://github.com/eigerco/lumina/pull/77))
+- *(node)* Implement exchange client ([#63](https://github.com/eigerco/lumina/pull/63))
+- add RPC calls for p2p module and tests for them ([#52](https://github.com/eigerco/lumina/pull/52))
+- update SyncState to the latest serialization ([#36](https://github.com/eigerco/lumina/pull/36))
+- *(fraud)* Add an error for unsupported fraud proof types ([#35](https://github.com/eigerco/lumina/pull/35))
+- *(fraud)* Add fraud proof trait and byzantine encoding fraud ([#32](https://github.com/eigerco/lumina/pull/32))
+- Add State RPC and types ([#31](https://github.com/eigerco/lumina/pull/31))
+- *(rpc)* Add all calls for Blob, Share, and Header ([#24](https://github.com/eigerco/lumina/pull/24))
+- align namespaced shares deserialization with latest celestia  ([#20](https://github.com/eigerco/lumina/pull/20))
+- serialize proof and commitment ([#19](https://github.com/eigerco/lumina/pull/19))
+- *(rpc)* Create celestia-rpc crate and add integration tests ([#17](https://github.com/eigerco/lumina/pull/17))
+- implement Blob commitment calculation ([#10](https://github.com/eigerco/lumina/pull/10))
+- *(types)* implement `ExtendedHeader::verify` ([#9](https://github.com/eigerco/lumina/pull/9))
+- *(ext-header)* Implement validate method ([#8](https://github.com/eigerco/lumina/pull/8))
+- add NamespacedShares type ([#7](https://github.com/eigerco/lumina/pull/7))
+- *(types)* add initial `Blob` implementation
+
+### Fixed
+- handling of the namespaces in v255 ([#164](https://github.com/eigerco/lumina/pull/164))
+- Yield between multiple `ExtendedHeader::validate` ([#107](https://github.com/eigerco/lumina/pull/107))
+- *(types)* fix the json representation of SubmitOptions ([#66](https://github.com/eigerco/lumina/pull/66))
+- *(types)* Propagate and validate the share version from blob
+
+### Other
+- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
+- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
+- Enable compatibility with sha2 v0.10.6 ([#171](https://github.com/eigerco/lumina/pull/171))
+- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
+- use Share instead of u8 slice in commitment ([#166](https://github.com/eigerco/lumina/pull/166))
+- Add Multihash for NMT node data ([#153](https://github.com/eigerco/lumina/pull/153))
+- Migrate to nmt-rs of crates.io ([#144](https://github.com/eigerco/lumina/pull/144))
+- hide p2p and syncer components from public node api ([#127](https://github.com/eigerco/lumina/pull/127))
+- Upgrade libp2p to v0.53.0 ([#126](https://github.com/eigerco/lumina/pull/126))
+- trim the features of workspace dependencies ([#99](https://github.com/eigerco/lumina/pull/99))
+- Write test cases for invalid and bad headers ([#87](https://github.com/eigerco/lumina/pull/87))
+- Add missing Clone and Copy in P2P types ([#84](https://github.com/eigerco/lumina/pull/84))
+- Update protobuf definitions ([#40](https://github.com/eigerco/lumina/pull/40))
+- switch to upstream nmt-rs ([#74](https://github.com/eigerco/lumina/pull/74))
+- derive Hash for accounts and Namespace ([#76](https://github.com/eigerco/lumina/pull/76))
+- Implement header Store ([#73](https://github.com/eigerco/lumina/pull/73))
+- align to celestia node v0.11-rc ([#65](https://github.com/eigerco/lumina/pull/65))
+- *(types)* remove obsolete NotEnoughVotingPower error
+- *(types)* simplify validation error
+- *(license)* Set Apache 2.0 license ([#6](https://github.com/eigerco/lumina/pull/6))
+- Implement Celestia types
+- initial commit


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.1.0
* `lumina-cli`: 0.1.0
* `celestia-rpc`: 0.1.0
* `celestia-types`: 0.1.0
* `celestia-proto`: 0.1.0
* `lumina-node`: 0.1.0
* `lumina-node-wasm`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `blockstore`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/blockstore-v0.1.0) - 2024-01-12

### Added
- Add in-memory blockstore ([#160](https://github.com/eigerco/lumina/pull/160))

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
</blockquote>

## `lumina-cli`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-cli-v0.1.0) - 2024-01-12

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-rpc-v0.1.0) - 2024-01-12

### Added
- *(types)* Add `wasm-bindgen` feature flag ([#143](https://github.com/eigerco/lumina/pull/143))
- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))
- *(rpc)* align to celestia-node 0.12.0 ([#125](https://github.com/eigerco/lumina/pull/125))
- *(rpc)* create wrappers for jsonrpsee clients ([#114](https://github.com/eigerco/lumina/pull/114))
- *(node)* Implement Syncer ([#94](https://github.com/eigerco/lumina/pull/94))
- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
- add RPC calls for p2p module and tests for them ([#52](https://github.com/eigerco/lumina/pull/52))
- Implement initial architecture of node crate ([#42](https://github.com/eigerco/lumina/pull/42))
- *(fraud)* Add fraud proof trait and byzantine encoding fraud ([#32](https://github.com/eigerco/lumina/pull/32))
- Add State RPC and types ([#31](https://github.com/eigerco/lumina/pull/31))
- *(rpc)* Add all calls for Blob, Share, and Header ([#24](https://github.com/eigerco/lumina/pull/24))
- align namespaced shares deserialization with latest celestia  ([#20](https://github.com/eigerco/lumina/pull/20))
- serialize proof and commitment ([#19](https://github.com/eigerco/lumina/pull/19))
- *(rpc)* Create celestia-rpc crate and add integration tests ([#17](https://github.com/eigerco/lumina/pull/17))

### Fixed
- *(types)* fix the json representation of SubmitOptions ([#66](https://github.com/eigerco/lumina/pull/66))
- make celestia-rpc to compile in wasm32 target ([#46](https://github.com/eigerco/lumina/pull/46))

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- add validation of EDS in tests ([#165](https://github.com/eigerco/lumina/pull/165))
- Make sure we run clippy for wasm and fix wasm build/lints ([#115](https://github.com/eigerco/lumina/pull/115))
- Migrate to nmt-rs of crates.io ([#144](https://github.com/eigerco/lumina/pull/144))
- Upgrade libp2p to v0.53.0 ([#126](https://github.com/eigerco/lumina/pull/126))
- update celestia node to 0.11.0-rc15 ([#101](https://github.com/eigerco/lumina/pull/101))
- trim the features of workspace dependencies ([#99](https://github.com/eigerco/lumina/pull/99))
- align to celestia node v0.11-rc ([#65](https://github.com/eigerco/lumina/pull/65))
- Migrate from `log` to `tracing` ([#55](https://github.com/eigerco/lumina/pull/55))
- update jsonrpsee to 0.20 ([#41](https://github.com/eigerco/lumina/pull/41))
</blockquote>

## `celestia-types`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-types-v0.1.0) - 2024-01-12

### Added
- *(node)* Add shwap data types ([#169](https://github.com/eigerco/lumina/pull/169))
- Add in-memory blockstore ([#160](https://github.com/eigerco/lumina/pull/160))
- expose Cid related types in public api ([#167](https://github.com/eigerco/lumina/pull/167))
- *(types)* Add `wasm-bindgen` feature flag ([#143](https://github.com/eigerco/lumina/pull/143))
- *(node)* Implement persistent header storage in browser using IndexedDB ([#102](https://github.com/eigerco/lumina/pull/102))
- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
- Peer discovery with Kademlia ([#79](https://github.com/eigerco/lumina/pull/79))
- *(types)* expose commitment creation for shares ([#78](https://github.com/eigerco/lumina/pull/78))
- *(types)* allow dereferencing namespace to nmt_rs one ([#77](https://github.com/eigerco/lumina/pull/77))
- *(node)* Implement exchange client ([#63](https://github.com/eigerco/lumina/pull/63))
- add RPC calls for p2p module and tests for them ([#52](https://github.com/eigerco/lumina/pull/52))
- update SyncState to the latest serialization ([#36](https://github.com/eigerco/lumina/pull/36))
- *(fraud)* Add an error for unsupported fraud proof types ([#35](https://github.com/eigerco/lumina/pull/35))
- *(fraud)* Add fraud proof trait and byzantine encoding fraud ([#32](https://github.com/eigerco/lumina/pull/32))
- Add State RPC and types ([#31](https://github.com/eigerco/lumina/pull/31))
- *(rpc)* Add all calls for Blob, Share, and Header ([#24](https://github.com/eigerco/lumina/pull/24))
- align namespaced shares deserialization with latest celestia  ([#20](https://github.com/eigerco/lumina/pull/20))
- serialize proof and commitment ([#19](https://github.com/eigerco/lumina/pull/19))
- *(rpc)* Create celestia-rpc crate and add integration tests ([#17](https://github.com/eigerco/lumina/pull/17))
- implement Blob commitment calculation ([#10](https://github.com/eigerco/lumina/pull/10))
- *(types)* implement `ExtendedHeader::verify` ([#9](https://github.com/eigerco/lumina/pull/9))
- *(ext-header)* Implement validate method ([#8](https://github.com/eigerco/lumina/pull/8))
- add NamespacedShares type ([#7](https://github.com/eigerco/lumina/pull/7))
- *(types)* add initial `Blob` implementation

### Fixed
- handling of the namespaces in v255 ([#164](https://github.com/eigerco/lumina/pull/164))
- Yield between multiple `ExtendedHeader::validate` ([#107](https://github.com/eigerco/lumina/pull/107))
- *(types)* fix the json representation of SubmitOptions ([#66](https://github.com/eigerco/lumina/pull/66))
- *(types)* Propagate and validate the share version from blob

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- Enable compatibility with sha2 v0.10.6 ([#171](https://github.com/eigerco/lumina/pull/171))
- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
- use Share instead of u8 slice in commitment ([#166](https://github.com/eigerco/lumina/pull/166))
- Add Multihash for NMT node data ([#153](https://github.com/eigerco/lumina/pull/153))
- Migrate to nmt-rs of crates.io ([#144](https://github.com/eigerco/lumina/pull/144))
- hide p2p and syncer components from public node api ([#127](https://github.com/eigerco/lumina/pull/127))
- Upgrade libp2p to v0.53.0 ([#126](https://github.com/eigerco/lumina/pull/126))
- trim the features of workspace dependencies ([#99](https://github.com/eigerco/lumina/pull/99))
- Write test cases for invalid and bad headers ([#87](https://github.com/eigerco/lumina/pull/87))
- Add missing Clone and Copy in P2P types ([#84](https://github.com/eigerco/lumina/pull/84))
- Update protobuf definitions ([#40](https://github.com/eigerco/lumina/pull/40))
- switch to upstream nmt-rs ([#74](https://github.com/eigerco/lumina/pull/74))
- derive Hash for accounts and Namespace ([#76](https://github.com/eigerco/lumina/pull/76))
- Implement header Store ([#73](https://github.com/eigerco/lumina/pull/73))
- align to celestia node v0.11-rc ([#65](https://github.com/eigerco/lumina/pull/65))
- *(types)* remove obsolete NotEnoughVotingPower error
- *(types)* simplify validation error
- *(license)* Set Apache 2.0 license ([#6](https://github.com/eigerco/lumina/pull/6))
- Implement Celestia types
- initial commit
</blockquote>

## `celestia-proto`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-proto-v0.1.0) - 2024-01-12

### Added
- *(node)* Add shwap data types ([#169](https://github.com/eigerco/lumina/pull/169))
- *(node)* Implement persistent header storage in browser using IndexedDB ([#102](https://github.com/eigerco/lumina/pull/102))
- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
- *(proto)* add cosmos Tx and celestia MsgPayForBlobs ([#75](https://github.com/eigerco/lumina/pull/75))
- Implement initial architecture of node crate ([#42](https://github.com/eigerco/lumina/pull/42))
- *(fraud)* Add fraud proof trait and byzantine encoding fraud ([#32](https://github.com/eigerco/lumina/pull/32))
- Add State RPC and types ([#31](https://github.com/eigerco/lumina/pull/31))
- align namespaced shares deserialization with latest celestia  ([#20](https://github.com/eigerco/lumina/pull/20))
- *(rpc)* Create celestia-rpc crate and add integration tests ([#17](https://github.com/eigerco/lumina/pull/17))
- *(proto)* add `empty_as_none` serializer ([#18](https://github.com/eigerco/lumina/pull/18))
- add NamespacedShares type ([#7](https://github.com/eigerco/lumina/pull/7))
- *(proto)* vendor protobuf definitions

### Fixed
- temporary backward compatibility for json proofs ([#96](https://github.com/eigerco/lumina/pull/96))

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- Pin celestia-app version to 1.4 when updating protobuf, update protobufs ([#175](https://github.com/eigerco/lumina/pull/175))
- update celestia node to 0.11.0-rc15 ([#101](https://github.com/eigerco/lumina/pull/101))
- Update protobuf definitions ([#40](https://github.com/eigerco/lumina/pull/40))
- align to celestia node v0.11-rc ([#65](https://github.com/eigerco/lumina/pull/65))
- fix format ([#34](https://github.com/eigerco/lumina/pull/34))
- vendor cosmos protobuf definitions ([#30](https://github.com/eigerco/lumina/pull/30))
- *(license)* Set Apache 2.0 license ([#6](https://github.com/eigerco/lumina/pull/6))
- Implement Celestia types
- initial commit
</blockquote>

## `lumina-node`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-v0.1.0) - 2024-01-12

### Added
- Return bootstrap peers as iterator and filter relevant ones ([#147](https://github.com/eigerco/lumina/pull/147))
- Bootstrap more aggresively when too few peers ([#146](https://github.com/eigerco/lumina/pull/146))
- *(types)* Add `wasm-bindgen` feature flag ([#143](https://github.com/eigerco/lumina/pull/143))
- *(node)* Implement sessions ([#130](https://github.com/eigerco/lumina/pull/130))
- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))
- *(node)* Use Kademlia bootstrap to recover connections and refresh routing table ([#120](https://github.com/eigerco/lumina/pull/120))
- *(rpc)* create wrappers for jsonrpsee clients ([#114](https://github.com/eigerco/lumina/pull/114))
- *(node)* Implement persistent header storage in browser using IndexedDB ([#102](https://github.com/eigerco/lumina/pull/102))
- Improve performance of Exchange ([#104](https://github.com/eigerco/lumina/pull/104))
- Choose transport based on target_arch and improve TCP connections ([#103](https://github.com/eigerco/lumina/pull/103))
- *(node)* Implement Syncer ([#94](https://github.com/eigerco/lumina/pull/94))
- Add trusted peers and keep track of multiple connections per peer ([#92](https://github.com/eigerco/lumina/pull/92))
- Forward only verified and new HeaderSub messages ([#89](https://github.com/eigerco/lumina/pull/89))
- Store improvements ([#88](https://github.com/eigerco/lumina/pull/88))
- Improve verification and implement verification in Exchange client ([#85](https://github.com/eigerco/lumina/pull/85))
- Peer discovery with Kademlia ([#79](https://github.com/eigerco/lumina/pull/79))
- *(node)* Add state of peer in PeerTracker ([#82](https://github.com/eigerco/lumina/pull/82))
- *(node/exchange)* Request HEAD from multiple peers and choose the best result ([#67](https://github.com/eigerco/lumina/pull/67))
- *(node)* Implement exchange client ([#63](https://github.com/eigerco/lumina/pull/63))
- *(exchange)* Add pre-allocating the buffer for reading in HeaderCodec ([#64](https://github.com/eigerco/lumina/pull/64))
- *(node)* hide all services behind traits ([#54](https://github.com/eigerco/lumina/pull/54))
- add RPC calls for p2p module and tests for them ([#52](https://github.com/eigerco/lumina/pull/52))
- *(p2p)* add NetworkInfo command ([#45](https://github.com/eigerco/lumina/pull/45))
- Support WASM for Web in celestia-node ([#44](https://github.com/eigerco/lumina/pull/44))
- Implement initial architecture of node crate ([#42](https://github.com/eigerco/lumina/pull/42))

### Fixed
- Use pre-defined DNS nameservers ([#129](https://github.com/eigerco/lumina/pull/129))
- *(node)* Allow HeaderSub reinitialization ([#128](https://github.com/eigerco/lumina/pull/128))
- *(node/syncer)* Stop fetching header when all peers disconnected ([#111](https://github.com/eigerco/lumina/pull/111))
- Yield between multiple `ExtendedHeader::validate` ([#107](https://github.com/eigerco/lumina/pull/107))
- *(node)* Adjust PeerTrackerInfo when peer trust is changed ([#105](https://github.com/eigerco/lumina/pull/105))
- *(node)* Remove keep_alive::Behaviour ([#95](https://github.com/eigerco/lumina/pull/95))
- *(node/exchange)* Forward handling of pending connections to req_resp ([#80](https://github.com/eigerco/lumina/pull/80))
- Use `get_header_by_height(0)` to get the HEAD ([#71](https://github.com/eigerco/lumina/pull/71))

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
- update bootstrap nodes to lumina ([#163](https://github.com/eigerco/lumina/pull/163))
- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
- hide p2p and syncer components from public node api ([#127](https://github.com/eigerco/lumina/pull/127))
- Upgrade libp2p to v0.53.0 ([#126](https://github.com/eigerco/lumina/pull/126))
- rename Exchange to HeaderEx ([#122](https://github.com/eigerco/lumina/pull/122))
- *(node)* Optimize transport for memory and bandwitdh ([#113](https://github.com/eigerco/lumina/pull/113))
- Produce an error if bootnode multiaddr do not have peer ID ([#106](https://github.com/eigerco/lumina/pull/106))
- Implement persistent storage for native builds using sled  ([#97](https://github.com/eigerco/lumina/pull/97))
- trim the features of workspace dependencies ([#99](https://github.com/eigerco/lumina/pull/99))
- Add integration tests for exchange server/client ([#93](https://github.com/eigerco/lumina/pull/93))
- Implement ExchangeServerHandler ([#72](https://github.com/eigerco/lumina/pull/72))
- Write test cases for invalid and bad headers ([#87](https://github.com/eigerco/lumina/pull/87))
- Remove flume crate ([#86](https://github.com/eigerco/lumina/pull/86))
- Split gossipsub code in smaller functions ([#81](https://github.com/eigerco/lumina/pull/81))
- Implement header Store ([#73](https://github.com/eigerco/lumina/pull/73))
- Migrate from `log` to `tracing` ([#55](https://github.com/eigerco/lumina/pull/55))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-wasm-v0.1.0) - 2024-01-12

### Added
- Return bootstrap peers as iterator and filter relevant ones ([#147](https://github.com/eigerco/lumina/pull/147))
- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
- switch browser logging to tracing-web ([#150](https://github.com/eigerco/lumina/pull/150))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).