### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-tendermint"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c452fbfbc7b397f5ee39be36bfbbb1870898f8644f88da96fcdbda9015397d51"
+checksum = "95f93b5cbbd62b6cfde961889bf05d5fe19e70d8500c4465694306ed2695ac23"
 dependencies = [
  "bytes",
  "celestia-tendermint-proto",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-tendermint-proto"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670067a9fb113fe86cb5f1b3db08c718da158a40beed6d167027ae7723fb5642"
+checksum = "b8f7d49c1ececa30a4587c5fe8a4035b786b78a3253ed0f9636de591b3dc2b37"
 dependencies = [
  "bytes",
  "flex-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "cid",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.21.5",
  "bech32",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ resolver = "2"
 members = ["blockstore", "cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
-lumina-node = { version = "0.1.0", path = "node" }
+lumina-node = { version = "0.1.1", path = "node" }
 lumina-node-wasm = { version = "0.1.0", path = "node-wasm" }
-celestia-proto = { version = "0.1.0", path = "proto" }
-celestia-rpc = { version = "0.1.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.1.0", path = "types", default-features = false }
+celestia-proto = { version = "0.1.1", path = "proto" }
+celestia-rpc = { version = "0.1.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.1.1", path = "types", default-features = false }
 libp2p = "0.53.1"
 nmt-rs = "0.1.0"
-celestia-tendermint = { version = "0.32.0", default-features = false }
-celestia-tendermint-proto = "0.32.0"
-blockstore = { version = "0.1.0", path = "blockstore" }
+celestia-tendermint = { version = "0.32.1", default-features = false }
+celestia-tendermint-proto = "0.32.1"
+blockstore = { version = "0.1.1", path = "blockstore" }
 
 [patch.crates-io]
 # Uncomment to apply local changes

--- a/blockstore/CHANGELOG.md
+++ b/blockstore/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/blockstore-v0.1.0...blockstore-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/blockstore-v0.1.0) - 2024-01-12
 
 ### Added

--- a/blockstore/Cargo.toml
+++ b/blockstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.0...lumina-node-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-v0.1.0) - 2024-01-12
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.0...celestia-proto-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-proto-v0.1.0) - 2024-01-12
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.0...celestia-rpc-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-rpc-v0.1.0) - 2024-01-12
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.0...celestia-types-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-types-v0.1.0) - 2024-01-12
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-cli`: 0.1.0
* `celestia-rpc`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `celestia-types`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `celestia-proto`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-node`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-node-wasm`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `blockstore`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/blockstore-v0.1.0...blockstore-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `lumina-cli`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-cli-v0.1.0) - 2024-01-12

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.0...celestia-rpc-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `celestia-types`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.0...celestia-types-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.0...celestia-proto-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `lumina-node`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.0...lumina-node-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-wasm-v0.1.0) - 2024-01-12

### Added
- Return bootstrap peers as iterator and filter relevant ones ([#147](https://github.com/eigerco/lumina/pull/147))
- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
- switch browser logging to tracing-web ([#150](https://github.com/eigerco/lumina/pull/150))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).