### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "cid",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.21.5",
  "bech32",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "backoff",

--- a/blockstore/CHANGELOG.md
+++ b/blockstore/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/blockstore-v0.1.0...blockstore-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/blockstore-v0.1.0) - 2024-01-12
 
 ### Added

--- a/blockstore/Cargo.toml
+++ b/blockstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.0...lumina-node-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-v0.1.0) - 2024-01-12
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.0...celestia-proto-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-proto-v0.1.0) - 2024-01-12
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.0...celestia-rpc-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-rpc-v0.1.0) - 2024-01-12
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.0...celestia-types-v0.1.1) - 2024-01-15
+
+### Other
+- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-types-v0.1.0) - 2024-01-12
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-cli`: 0.1.0
* `celestia-rpc`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `celestia-types`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `celestia-proto`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-node`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-node-wasm`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `blockstore`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/blockstore-v0.1.0...blockstore-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `lumina-cli`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-cli-v0.1.0) - 2024-01-12

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- error message for missing token and cleanups ([#168](https://github.com/eigerco/lumina/pull/168))
- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.0...celestia-rpc-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `celestia-types`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.0...celestia-types-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.0...celestia-proto-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `lumina-node`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.0...lumina-node-v0.1.1) - 2024-01-15

### Other
- add authors and homepage ([#180](https://github.com/eigerco/lumina/pull/180))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-wasm-v0.1.0) - 2024-01-12

### Added
- Return bootstrap peers as iterator and filter relevant ones ([#147](https://github.com/eigerco/lumina/pull/147))
- *(node)* Implement running node in browser ([#112](https://github.com/eigerco/lumina/pull/112))

### Other
- add missing metadata to the toml files ([#170](https://github.com/eigerco/lumina/pull/170))
- document public api ([#161](https://github.com/eigerco/lumina/pull/161))
- rename the node implementation to Lumina ([#156](https://github.com/eigerco/lumina/pull/156))
- switch browser logging to tracing-web ([#150](https://github.com/eigerco/lumina/pull/150))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).