### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.21.7",
  "bech32",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "celestia-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.5"
-lumina-node = { version = "0.1.0", path = "node" }
-lumina-node-wasm = { version = "0.1.0", path = "node-wasm" }
-celestia-proto = { version = "0.1.0", path = "proto" }
-celestia-rpc = { version = "0.1.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.1.0", path = "types", default-features = false }
+lumina-node = { version = "0.2.0", path = "node" }
+lumina-node-wasm = { version = "0.1.1", path = "node-wasm" }
+celestia-proto = { version = "0.2.0", path = "proto" }
+celestia-rpc = { version = "0.2.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.2.0", path = "types", default-features = false }
 libp2p = "0.53.2"
 nmt-rs = "0.1.0"
 celestia-tendermint = { version = "0.32.1", default-features = false }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.1.0...lumina-cli-v0.2.0) - 2024-04-18
+
+### Added
+- *(cli)* [**breaking**] Replace sled stores with redb stores ([#267](https://github.com/eigerco/lumina/pull/267))
+- feat!(node): use generic blockstore in node ([#218](https://github.com/eigerco/lumina/pull/218))
+
+### Other
+- Add note about WebTransport requiring Secure Context ([#211](https://github.com/eigerco/lumina/pull/211))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-cli-v0.1.0) - 2024-01-12
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.1.0...lumina-node-wasm-v0.1.1) - 2024-04-18
+
+### Added
+- Expose get_sampling_metadata in node and node-wasm ([#234](https://github.com/eigerco/lumina/pull/234))
+- *(blockstore)* add IndexedDb blockstore ([#221](https://github.com/eigerco/lumina/pull/221))
+- feat!(node): use generic blockstore in node ([#218](https://github.com/eigerco/lumina/pull/218))
+
+### Fixed
+- *(ci)* Fix release for lumina (cli) ([#190](https://github.com/eigerco/lumina/pull/190))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-wasm-v0.1.0) - 2024-01-12
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.1...lumina-node-v0.2.0) - 2024-04-18
+
+### Added
+- *(cli)* [**breaking**] Replace sled stores with redb stores ([#267](https://github.com/eigerco/lumina/pull/267))
+- *(node)* Implement `RedbStore` ([#266](https://github.com/eigerco/lumina/pull/266))
+- *(node/p2p)* Relax internal `Send` bounds ([#260](https://github.com/eigerco/lumina/pull/260))
+- [**breaking**] Refactor RowId/SampleId/NamespacedDataId related API ([#236](https://github.com/eigerco/lumina/pull/236))
+- Expose get_sampling_metadata in node and node-wasm ([#234](https://github.com/eigerco/lumina/pull/234))
+- *(node)* implement fraud-sub and services stopping on valid befp ([#233](https://github.com/eigerco/lumina/pull/233))
+- *(types)* add encoding check when verifying befp ([#231](https://github.com/eigerco/lumina/pull/231))
+- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))
+- *(blockstore)* add IndexedDb blockstore ([#221](https://github.com/eigerco/lumina/pull/221))
+- feat!(node): use generic blockstore in node ([#218](https://github.com/eigerco/lumina/pull/218))
+- *(node)* Extend header Store for use with DAS-er ([#209](https://github.com/eigerco/lumina/pull/209))
+- *(node)* Integrate bitswap protocol for shwap ([#202](https://github.com/eigerco/lumina/pull/202))
+- *(lumina-node)* update the bootstrap peers for testnets ([#184](https://github.com/eigerco/lumina/pull/184))
+
+### Fixed
+- fix!(node/sled_store): Use `transaction` when more than one value get read ([#230](https://github.com/eigerco/lumina/pull/230))
+
+### Other
+- *(node)* [**breaking**] Remove sled store implementation ([#268](https://github.com/eigerco/lumina/pull/268))
+- *(node)* Upgrade blockstore, beetswap, and leopard-codec ([#264](https://github.com/eigerco/lumina/pull/264))
+- *(node)* Upgrade blockstore and beetswap ([#259](https://github.com/eigerco/lumina/pull/259))
+- *(node)* minor cleanup of `parse_request` ([#258](https://github.com/eigerco/lumina/pull/258))
+- *(node)* fix unused warnings on HeaderRequestExt ([#220](https://github.com/eigerco/lumina/pull/220))
+- *(node)* Replace unmaintained tempdir and outdated quinn ([#214](https://github.com/eigerco/lumina/pull/214))
+- chore!(types): Shwap API changes for consistency  ([#212](https://github.com/eigerco/lumina/pull/212))
+- *(node)* Move p2p related files in p2p directory ([#208](https://github.com/eigerco/lumina/pull/208))
+- Update libp2p to 0.53.2 ([#203](https://github.com/eigerco/lumina/pull/203))
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.0...lumina-node-v0.1.1) - 2024-01-15
 
 ### Other

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.1...celestia-proto-v0.2.0) - 2024-04-18
+
+### Added
+- feat!(types): Align with Shwap spec ([#232](https://github.com/eigerco/lumina/pull/232))
+- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.0...celestia-proto-v0.1.1) - 2024-01-15
 
 ### Other

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.1...celestia-rpc-v0.2.0) - 2024-04-18
+
+### Added
+- [**breaking**] Refactor RowId/SampleId/NamespacedDataId related API ([#236](https://github.com/eigerco/lumina/pull/236))
+- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))
+
+### Other
+- chore!(types,rpc): compatibility with celestia-node 0.13.1 ([#239](https://github.com/eigerco/lumina/pull/239))
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.0...celestia-rpc-v0.1.1) - 2024-01-15
 
 ### Other

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.1...celestia-types-v0.2.0) - 2024-04-18
+
+### Added
+- *(types)* Add constructor for creating EDS of an empty block ([#241](https://github.com/eigerco/lumina/pull/241))
+- [**breaking**] Refactor RowId/SampleId/NamespacedDataId related API ([#236](https://github.com/eigerco/lumina/pull/236))
+- *(types)* add encoding check when verifying befp ([#231](https://github.com/eigerco/lumina/pull/231))
+- feat!(types): Align with Shwap spec ([#232](https://github.com/eigerco/lumina/pull/232))
+- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))
+
+### Fixed
+- *(types)* Fix typo in codec name ([#240](https://github.com/eigerco/lumina/pull/240))
+- row verification logic ([#235](https://github.com/eigerco/lumina/pull/235))
+- *(celestia-types)* switch codec and multihash codes in byzantine [#200](https://github.com/eigerco/lumina/pull/200)
+
+### Other
+- *(node)* Upgrade blockstore, beetswap, and leopard-codec ([#264](https://github.com/eigerco/lumina/pull/264))
+- chore!(types,rpc): compatibility with celestia-node 0.13.1 ([#239](https://github.com/eigerco/lumina/pull/239))
+- chore!(types): Shwap API changes for consistency  ([#212](https://github.com/eigerco/lumina/pull/212))
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.0...celestia-types-v0.1.1) - 2024-01-15
 
 ### Other

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.1.0 -> 0.2.0 (✓ API compatible changes)
* `celestia-rpc`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `celestia-types`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)
* `celestia-proto`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)
* `lumina-node`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)
* `lumina-node-wasm`: 0.1.0 -> 0.1.1

### ⚠️ `celestia-types` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NamespacedData.id in /tmp/.tmpjg83nW/lumina/types/src/namespaced_data.rs:47
  field Sample.id in /tmp/.tmpjg83nW/lumina/types/src/sample.rs:46
  field Sample.proof_type in /tmp/.tmpjg83nW/lumina/types/src/sample.rs:48
  field Row.id in /tmp/.tmpjg83nW/lumina/types/src/row.rs:43

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field NamespacedDataId.row_id in /tmp/.tmpjg83nW/lumina/types/src/namespaced_data.rs:35
  field SampleId.row_id in /tmp/.tmpjg83nW/lumina/types/src/sample.rs:37
  field SampleId.column_index in /tmp/.tmpjg83nW/lumina/types/src/sample.rs:38

--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant Error::EdsIndexOutOfRange in /tmp/.tmpjg83nW/lumina/types/src/error.rs:169

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:LeopardCodec in /tmp/.tmpjg83nW/lumina/types/src/error.rs:39
  variant Error:InvalidShwapProofType in /tmp/.tmpjg83nW/lumina/types/src/error.rs:110

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/inherent_method_missing.ron

Failed in:
  NamespacedDataId::size, previously in file /tmp/.tmplmfE32/celestia-types/src/namespaced_data.rs:159
  ExtendedDataSquare::square_len, previously in file /tmp/.tmplmfE32/celestia-types/src/rsmt2d.rs:195
  Row::validate, previously in file /tmp/.tmplmfE32/celestia-types/src/row.rs:63
  RowId::size, previously in file /tmp/.tmplmfE32/celestia-types/src/row.rs:146
  DataAvailabilityHeader::square_len, previously in file /tmp/.tmplmfE32/celestia-types/src/data_availability_header.rs:115
  SampleId::size, previously in file /tmp/.tmplmfE32/celestia-types/src/sample.rs:277
  NamespacedData::validate, previously in file /tmp/.tmplmfE32/celestia-types/src/namespaced_data.rs:87
  Sample::validate, previously in file /tmp/.tmplmfE32/celestia-types/src/sample.rs:145

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/method_parameter_count_changed.ron

Failed in:
  celestia_types::sample::Sample::new now takes 5 parameters instead of 4, in /tmp/.tmpjg83nW/lumina/types/src/sample.rs:97

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_types::blob::SubmitOptions, previously in file /tmp/.tmplmfE32/celestia-types/src/blob.rs:23

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field row of struct NamespacedDataId, previously in file /tmp/.tmplmfE32/celestia-types/src/namespaced_data.rs:38
  field namespace of struct NamespacedDataId, previously in file /tmp/.tmplmfE32/celestia-types/src/namespaced_data.rs:42
  field data_square of struct ExtendedDataSquare, previously in file /tmp/.tmplmfE32/celestia-types/src/rsmt2d.rs:138
  field codec of struct ExtendedDataSquare, previously in file /tmp/.tmplmfE32/celestia-types/src/rsmt2d.rs:140
  field row_id of struct Row, previously in file /tmp/.tmplmfE32/celestia-types/src/row.rs:48
  field block_height of struct RowId, previously in file /tmp/.tmplmfE32/celestia-types/src/row.rs:36
  field index of struct RowId, previously in file /tmp/.tmplmfE32/celestia-types/src/row.rs:40
  field row_roots of struct DataAvailabilityHeader, previously in file /tmp/.tmplmfE32/celestia-types/src/data_availability_header.rs:58
  field column_roots of struct DataAvailabilityHeader, previously in file /tmp/.tmplmfE32/celestia-types/src/data_availability_header.rs:62
  field row of struct SampleId, previously in file /tmp/.tmplmfE32/celestia-types/src/sample.rs:42
  field index of struct SampleId, previously in file /tmp/.tmplmfE32/celestia-types/src/sample.rs:44
  field namespaced_data_id of struct NamespacedData, previously in file /tmp/.tmplmfE32/celestia-types/src/namespaced_data.rs:53
  field sample_id of struct Sample, previously in file /tmp/.tmplmfE32/celestia-types/src/sample.rs:52
  field sample_proof_type of struct Sample, previously in file /tmp/.tmplmfE32/celestia-types/src/sample.rs:54

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field NamespacedDataId.namespace in file /tmp/.tmpjg83nW/lumina/types/src/namespaced_data.rs:34
  field ExtendedDataSquare.data_square in file /tmp/.tmpjg83nW/lumina/types/src/rsmt2d.rs:132
  field ExtendedDataSquare.codec in file /tmp/.tmpjg83nW/lumina/types/src/rsmt2d.rs:132
  field RowId.block_height in file /tmp/.tmpjg83nW/lumina/types/src/row.rs:33
  field RowId.index in file /tmp/.tmpjg83nW/lumina/types/src/row.rs:33
  field DataAvailabilityHeader.row_roots in file /tmp/.tmpjg83nW/lumina/types/src/data_availability_header.rs:54
  field DataAvailabilityHeader.column_roots in file /tmp/.tmpjg83nW/lumina/types/src/data_availability_header.rs:54
```

### ⚠️ `celestia-proto` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Sample.proof_type in /tmp/.tmpjg83nW/lumina/target/semver-checks/local-celestia_proto-0_1_1/target/semver-checks/target/debug/build/celestia-proto-5e774efa9a76e7f8/out/share.p2p.shwap.rs:24

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_missing.ron

Failed in:
  enum celestia_proto::share::p2p::shwap::SampleProofType, previously in file /tmp/.tmplmfE32/celestia-proto/target/semver-checks/local-celestia_proto-0_1_1/target/semver-checks/target/debug/build/celestia-proto-f2f4c515873be0f9/out/share.p2p.shwap.rs:40

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/inherent_method_missing.ron

Failed in:
  Sample::sample_type, previously in file /tmp/.tmplmfE32/celestia-proto/target/semver-checks/local-celestia_proto-0_1_1/target/semver-checks/target/debug/build/celestia-proto-f2f4c515873be0f9/out/share.p2p.shwap.rs:15
  Sample::set_sample_type, previously in file /tmp/.tmplmfE32/celestia-proto/target/semver-checks/local-celestia_proto-0_1_1/target/semver-checks/target/debug/build/celestia-proto-f2f4c515873be0f9/out/share.p2p.shwap.rs:15

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field sample_type of struct Sample, previously in file /tmp/.tmplmfE32/celestia-proto/target/semver-checks/local-celestia_proto-0_1_1/target/semver-checks/target/debug/build/celestia-proto-f2f4c515873be0f9/out/share.p2p.shwap.rs:20
```

### ⚠️ `lumina-node` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NodeConfig.blockstore in /tmp/.tmpjg83nW/lumina/node/src/node.rs:70
  field P2pArgs.blockstore in /tmp/.tmpjg83nW/lumina/node/src/p2p.rs:187

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_variant_added.ron

Failed in:
  variant NodeError:Daser in /tmp/.tmpjg83nW/lumina/node/src/node.rs:50
  variant StoreError:FatalDatabaseError in /tmp/.tmpjg83nW/lumina/node/src/store.rs:227
  variant P2pError:Bitswap in /tmp/.tmpjg83nW/lumina/node/src/p2p.rs:142
  variant P2pError:ProtoDecodeFailed in /tmp/.tmpjg83nW/lumina/node/src/p2p.rs:146
  variant P2pError:Cid in /tmp/.tmpjg83nW/lumina/node/src/p2p.rs:150
  variant P2pError:BitswapQueryTimeout in /tmp/.tmpjg83nW/lumina/node/src/p2p.rs:154

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_variant_missing.ron

Failed in:
  variant StoreError::BackingStoreError, previously in file /tmp/.tmplmfE32/lumina-node/src/store.rs:183
  variant StoreError::IoError, previously in file /tmp/.tmplmfE32/lumina-node/src/store.rs:191

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_missing.ron

Failed in:
  struct lumina_node::store::SledStore, previously in file /tmp/.tmplmfE32/lumina-node/src/store/sled_store.rs:27
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.1.0...lumina-cli-v0.2.0) - 2024-04-18

### Added
- *(cli)* [**breaking**] Replace sled stores with redb stores ([#267](https://github.com/eigerco/lumina/pull/267))
- feat!(node): use generic blockstore in node ([#218](https://github.com/eigerco/lumina/pull/218))

### Other
- Add note about WebTransport requiring Secure Context ([#211](https://github.com/eigerco/lumina/pull/211))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.1...celestia-rpc-v0.2.0) - 2024-04-18

### Added
- [**breaking**] Refactor RowId/SampleId/NamespacedDataId related API ([#236](https://github.com/eigerco/lumina/pull/236))
- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))

### Other
- chore!(types,rpc): compatibility with celestia-node 0.13.1 ([#239](https://github.com/eigerco/lumina/pull/239))
</blockquote>

## `celestia-types`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.1...celestia-types-v0.2.0) - 2024-04-18

### Added
- *(types)* Add constructor for creating EDS of an empty block ([#241](https://github.com/eigerco/lumina/pull/241))
- [**breaking**] Refactor RowId/SampleId/NamespacedDataId related API ([#236](https://github.com/eigerco/lumina/pull/236))
- *(types)* add encoding check when verifying befp ([#231](https://github.com/eigerco/lumina/pull/231))
- feat!(types): Align with Shwap spec ([#232](https://github.com/eigerco/lumina/pull/232))
- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))

### Fixed
- *(types)* Fix typo in codec name ([#240](https://github.com/eigerco/lumina/pull/240))
- row verification logic ([#235](https://github.com/eigerco/lumina/pull/235))
- *(celestia-types)* switch codec and multihash codes in byzantine [#200](https://github.com/eigerco/lumina/pull/200)

### Other
- *(node)* Upgrade blockstore, beetswap, and leopard-codec ([#264](https://github.com/eigerco/lumina/pull/264))
- chore!(types,rpc): compatibility with celestia-node 0.13.1 ([#239](https://github.com/eigerco/lumina/pull/239))
- chore!(types): Shwap API changes for consistency  ([#212](https://github.com/eigerco/lumina/pull/212))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.1...celestia-proto-v0.2.0) - 2024-04-18

### Added
- feat!(types): Align with Shwap spec ([#232](https://github.com/eigerco/lumina/pull/232))
- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))
</blockquote>

## `lumina-node`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.1...lumina-node-v0.2.0) - 2024-04-18

### Added
- *(cli)* [**breaking**] Replace sled stores with redb stores ([#267](https://github.com/eigerco/lumina/pull/267))
- *(node)* Implement `RedbStore` ([#266](https://github.com/eigerco/lumina/pull/266))
- *(node/p2p)* Relax internal `Send` bounds ([#260](https://github.com/eigerco/lumina/pull/260))
- [**breaking**] Refactor RowId/SampleId/NamespacedDataId related API ([#236](https://github.com/eigerco/lumina/pull/236))
- Expose get_sampling_metadata in node and node-wasm ([#234](https://github.com/eigerco/lumina/pull/234))
- *(node)* implement fraud-sub and services stopping on valid befp ([#233](https://github.com/eigerco/lumina/pull/233))
- *(types)* add encoding check when verifying befp ([#231](https://github.com/eigerco/lumina/pull/231))
- feat!(node): Implement DASer ([#223](https://github.com/eigerco/lumina/pull/223))
- *(blockstore)* add IndexedDb blockstore ([#221](https://github.com/eigerco/lumina/pull/221))
- feat!(node): use generic blockstore in node ([#218](https://github.com/eigerco/lumina/pull/218))
- *(node)* Extend header Store for use with DAS-er ([#209](https://github.com/eigerco/lumina/pull/209))
- *(node)* Integrate bitswap protocol for shwap ([#202](https://github.com/eigerco/lumina/pull/202))
- *(lumina-node)* update the bootstrap peers for testnets ([#184](https://github.com/eigerco/lumina/pull/184))

### Fixed
- fix!(node/sled_store): Use `transaction` when more than one value get read ([#230](https://github.com/eigerco/lumina/pull/230))

### Other
- *(node)* [**breaking**] Remove sled store implementation ([#268](https://github.com/eigerco/lumina/pull/268))
- *(node)* Upgrade blockstore, beetswap, and leopard-codec ([#264](https://github.com/eigerco/lumina/pull/264))
- *(node)* Upgrade blockstore and beetswap ([#259](https://github.com/eigerco/lumina/pull/259))
- *(node)* minor cleanup of `parse_request` ([#258](https://github.com/eigerco/lumina/pull/258))
- *(node)* fix unused warnings on HeaderRequestExt ([#220](https://github.com/eigerco/lumina/pull/220))
- *(node)* Replace unmaintained tempdir and outdated quinn ([#214](https://github.com/eigerco/lumina/pull/214))
- chore!(types): Shwap API changes for consistency  ([#212](https://github.com/eigerco/lumina/pull/212))
- *(node)* Move p2p related files in p2p directory ([#208](https://github.com/eigerco/lumina/pull/208))
- Update libp2p to 0.53.2 ([#203](https://github.com/eigerco/lumina/pull/203))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.1.0...lumina-node-wasm-v0.1.1) - 2024-04-18

### Added
- Expose get_sampling_metadata in node and node-wasm ([#234](https://github.com/eigerco/lumina/pull/234))
- *(blockstore)* add IndexedDb blockstore ([#221](https://github.com/eigerco/lumina/pull/221))
- feat!(node): use generic blockstore in node ([#218](https://github.com/eigerco/lumina/pull/218))

### Fixed
- *(ci)* Fix release for lumina (cli) ([#190](https://github.com/eigerco/lumina/pull/190))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).