### PR TITLE
`types` crate `no_std` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha2 0.10.8",
- "thiserror",
  "wasm-bindgen-test",
 ]
 

--- a/node/src/syncer.rs
+++ b/node/src/syncer.rs
@@ -46,8 +46,8 @@ pub enum SyncerError {
     Store(#[from] StoreError),
 
     /// An error propagated from the [`celestia_types`].
-    #[error(transparent)]
-    Celestia(#[from] celestia_types::Error),
+    #[error(" Celestia error: {0}")]
+    Celestia(celestia_types::Error),
 
     /// The worker has died.
     #[error("Worker died")]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -35,7 +35,6 @@ ruint = { version = "1.8.0", features = ["serde"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_repr = { version = "0.1", optional = true }
 sha2 = "0.10.6"
-thiserror = { version = "1.0.40", default-features = false }
 
 [dev-dependencies]
 ed25519-consensus = "2.1.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -35,7 +35,7 @@ ruint = { version = "1.8.0", features = ["serde"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_repr = { version = "0.1", optional = true }
 sha2 = "0.10.6"
-thiserror = "1.0.40"
+thiserror = { version = "1.0.40", default-features = false }
 
 [dev-dependencies]
 ed25519-consensus = "2.1.0"
@@ -51,9 +51,10 @@ getrandom = { version = "0.2.10", features = ["js"] }
 wasm-bindgen-test = "0.3"
 
 [features]
-default = ["p2p"]
+default = ["p2p", "std"]
 p2p = ["dep:libp2p-identity", "dep:multiaddr", "dep:serde_repr"]
 test-utils = ["dep:ed25519-consensus", "dep:rand"]
+std = []
 wasm-bindgen = ["celestia-tendermint/wasm-bindgen"]
 
 [package.metadata.docs.rs]

--- a/types/src/blob.rs
+++ b/types/src/blob.rs
@@ -10,6 +10,7 @@ pub use self::commitment::Commitment;
 use crate::consts::appconsts;
 use crate::nmt::Namespace;
 use crate::serializers::none_as_negative_one;
+use crate::types::Vec;
 use crate::{bail_validation, Error, Result, Share};
 
 /// Options for configuring the blob submission to the network.

--- a/types/src/data_availability_header.rs
+++ b/types/src/data_availability_header.rs
@@ -10,6 +10,7 @@ use crate::consts::data_availability_header::{
 use crate::hash::Hash;
 use crate::nmt::{NamespacedHash, NamespacedHashExt};
 use crate::rsmt2d::AxisType;
+use crate::types::Vec;
 use crate::{bail_validation, Error, Result, ValidateBasic, ValidationError};
 
 /// Header with commitments of the data availability.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -1,172 +1,193 @@
-use crate::consts::appconsts;
+use core::fmt::Display;
+
+use crate::types::String;
 
 /// Alias for a `Result` with the error type [`celestia_types::Error`].
 ///
 /// [`celestia_types::Error`]: crate::Error
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// Representation of all the errors that can occur when interacting with [`celestia_types`].
 ///
 /// [`celestia_types`]: crate
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum Error {
     /// Unsupported namespace version.
-    #[error("Unsupported namespace version: {0}")]
     UnsupportedNamespaceVersion(u8),
 
     /// Invalid namespace size.
-    #[error("Invalid namespace size")]
     InvalidNamespaceSize,
 
     /// Error propagated from the [`celestia_tendermint`].
-    #[error(transparent)]
-    Tendermint(#[from] celestia_tendermint::Error),
+    Tendermint(celestia_tendermint::Error),
 
     /// Error propagated from the [`celestia_tendermint_proto`].
-    #[error(transparent)]
-    Protobuf(#[from] celestia_tendermint_proto::Error),
+    Protobuf(celestia_tendermint_proto::Error),
 
     /// Error propagated from the [`cid::multihash`].
-    #[error(transparent)]
-    Multihash(#[from] cid::multihash::Error),
+    Multihash(cid::multihash::Error),
 
     /// Error returned when trying to compute new or parse existing CID. See [`blockstore::block`]
-    #[error(transparent)]
-    CidError(#[from] blockstore::block::CidError),
+    CidError(blockstore::block::CidError),
 
     /// Missing header.
-    #[error("Missing header")]
     MissingHeader,
 
     /// Missing commit.
-    #[error("Missing commit")]
     MissingCommit,
 
     /// Missing validator set.
-    #[error("Missing validator set")]
     MissingValidatorSet,
 
     /// Missing data availability header.
-    #[error("Missing data availability header")]
     MissingDataAvailabilityHeader,
 
     /// Missing proof.
-    #[error("Missing proof")]
     MissingProof,
 
     /// Wrong proof type.
-    #[error("Wrong proof type")]
     WrongProofType,
 
     /// Unsupported share version.
-    #[error("Unsupported share version: {0}")]
     UnsupportedShareVersion(u8),
 
     /// Invalid share size.
-    #[error("Invalid share size: {0}")]
     InvalidShareSize(usize),
 
     /// Invalid nmt leaf size.
-    #[error("Invalid nmt leaf size: {0}")]
     InvalidNmtLeafSize(usize),
 
     /// Invalid nmt node order.
-    #[error("Invalid nmt node order")]
     InvalidNmtNodeOrder,
 
     /// Share sequence length exceeded.
-    #[error(
-        "Sequence len must fit into {} bytes, got value {0}",
-        appconsts::SEQUENCE_LEN_BYTES
-    )]
     ShareSequenceLenExceeded(usize),
 
     /// Invalid namespace in version 0.
-    #[error("Invalid namespace v0")]
     InvalidNamespaceV0,
 
     /// Invalid namespace in version 255.
-    #[error("Invalid namespace v255")]
     InvalidNamespaceV255,
 
     /// Invalid namespaced hash.
-    #[error(transparent)]
-    InvalidNamespacedHash(#[from] nmt_rs::InvalidNamespacedHash),
+    InvalidNamespacedHash(nmt_rs::InvalidNamespacedHash),
 
     /// Invalid index of signature in commit.
-    #[error("Invalid index of signature in commit {0}, height {1}")]
     InvalidSignatureIndex(usize, u64),
 
     /// Invalid axis.
-    #[error("Invalid axis type: {0}")]
     InvalidAxis(i32),
 
     /// Range proof verification error.
-    #[error("Range proof verification failed: {0:?}")]
     RangeProofError(nmt_rs::simple_merkle::error::RangeProofError),
 
     /// Row root computed from shares doesn't match one received in `DataAvailabilityHeaderz
-    #[error("Computed root doesn't match received one")]
     RootMismatch,
 
     /// Unexpected signature in absent commit.
-    #[error("Unexpected absent commit signature")]
     UnexpectedAbsentSignature,
 
     /// Error that happened during validation.
-    #[error("Validation error: {0}")]
-    Validation(#[from] ValidationError),
+    Validation(ValidationError),
 
     /// Error that happened during verification.
-    #[error("Verification error: {0}")]
-    Verification(#[from] VerificationError),
+    Verification(VerificationError),
 
     /// Max share version exceeded.
-    #[error(
-        "Share version has to be at most {}, got {0}",
-        appconsts::MAX_SHARE_VERSION
-    )]
     MaxShareVersionExceeded(u8),
 
     /// An error related to the namespaced merkle tree.
-    #[error("Nmt error: {0}")]
     Nmt(&'static str),
 
     /// Invalid address bech32 prefix.
-    #[error("Invalid address prefix: {0}")]
     InvalidAddressPrefix(String),
 
     /// Invalid size of the address.
-    #[error("Invalid address size: {0}")]
     InvalidAddressSize(usize),
 
     /// Invalid address.
-    #[error("Invalid address: {0}")]
     InvalidAddress(String),
 
     /// Invalid balance denomination.
-    #[error("Invalid balance denomination: {0}")]
     InvalidBalanceDenomination(String),
 
     /// Invalid balance amount.
-    #[error("Invalid balance amount: {0}")]
     InvalidBalanceAmount(String),
 
     /// Unsupported fraud proof type.
-    #[error("Unsupported fraud proof type: {0}")]
     UnsupportedFraudProofType(String),
 
     /// Data square index out of range.
-    #[error("Data square index out of range: {0}")]
     EdsIndexOutOfRange(usize),
 
     /// Could not create EDS, provided number of shares doesn't form a pefect square
-    #[error("Invalid dimensions of EDS")]
     EdsInvalidDimentions,
 
     /// Zero block height.
-    #[error("Invalid zero block height")]
     ZeroBlockHeight,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::UnsupportedNamespaceVersion(version) => {
+                write!(f, "Unsupported namespace version: {}", version)
+            }
+            Error::InvalidNamespaceSize => write!(f, "Invalid namespace size"),
+            Error::MissingHeader => write!(f, "Missing header"),
+            Error::MissingCommit => write!(f, "Missing commit"),
+            Error::MissingValidatorSet => write!(f, "Missing validator set"),
+            Error::MissingDataAvailabilityHeader => write!(f, "Missing data availability header"),
+            Error::MissingProof => write!(f, "Missing proof"),
+            Error::WrongProofType => write!(f, "Wrong proof type"),
+            Error::UnsupportedShareVersion(version) => {
+                write!(f, "Unsupported share version: {}", version)
+            }
+            Error::InvalidShareSize(size) => write!(f, "Invalid share size: {}", size),
+            Error::InvalidNmtLeafSize(size) => write!(f, "Invalid nmt leaf size: {}", size),
+            Error::InvalidNmtNodeOrder => write!(f, "Invalid nmt node order"),
+            Error::ShareSequenceLenExceeded(len) => {
+                write!(f, "Share sequence length exceeded: {}", len)
+            }
+            Error::InvalidNamespaceV0 => write!(f, "Invalid namespace in version 0"),
+            Error::InvalidNamespaceV255 => write!(f, "Invalid namespace in version 255"),
+            Error::InvalidNamespacedHash(e) => write!(f, "Invalid namespaced hash: {}", e),
+            Error::InvalidSignatureIndex(index, len) => {
+                write!(f, "Invalid signature index: {} (len: {})", index, len)
+            }
+            Error::InvalidAxis(axis) => write!(f, "Invalid axis: {}", axis),
+            Error::RangeProofError(e) => write!(f, "Range proof error: {:?}", e),
+            Error::RootMismatch => write!(f, "Root mismatch"),
+            Error::UnexpectedAbsentSignature => write!(f, "Unexpected absent signature"),
+            Error::MaxShareVersionExceeded(version) => {
+                write!(f, "Max share version exceeded: {}", version)
+            }
+            Error::Nmt(e) => write!(f, "Nmt error: {}", e),
+            Error::Multihash(e) => write!(f, "Multihash error: {}", e),
+            Error::CidError(e) => write!(f, "CidError: {}", e),
+            Error::InvalidAddressPrefix(prefix) => {
+                write!(f, "Invalid address bech32 prefix: {}", prefix)
+            }
+            Error::InvalidAddressSize(size) => write!(f, "Invalid address size: {}", size),
+            Error::InvalidAddress(address) => write!(f, "Invalid address: {}", address),
+            Error::InvalidBalanceDenomination(denomination) => {
+                write!(f, "Invalid balance denomination: {}", denomination)
+            }
+            Error::InvalidBalanceAmount(amount) => {
+                write!(f, "Invalid balance amount: {}", amount)
+            }
+            Error::UnsupportedFraudProofType(ty) => {
+                write!(f, "Unsupported fraud proof type: {}", ty)
+            }
+            Error::EdsIndexOutOfRange(index) => write!(f, "EDS index out of range: {}", index),
+            Error::EdsInvalidDimentions => write!(f, "EDS invalid dimentions"),
+            Error::ZeroBlockHeight => write!(f, "Zero block height"),
+            Error::Tendermint(error) => write!(f, "Tendermint error: {error}"),
+            Error::Protobuf(error) => write!(f, "Protobuf error: {error}"),
+            Error::Validation(error) => write!(f, "Validation error: {error}"),
+            Error::Verification(error) => write!(f, "Verification error: {error}"),
+        }
+    }
 }
 
 /// Representation of the errors that can occur when validating data.
@@ -174,15 +195,32 @@ pub enum Error {
 /// See [`ValidateBasic`]
 ///
 /// [`ValidateBasic`]: crate::ValidateBasic
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum ValidationError {
     /// Not enough voting power for a commit.
-    #[error("Not enought voting power (got {0}, needed {1})")]
     NotEnoughVotingPower(u64, u64),
 
     /// Other errors that can happen during validation.
-    #[error("{0}")]
     Other(String),
+}
+
+impl Display for ValidationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ValidationError::NotEnoughVotingPower(voting_power, threshold) => write!(
+                f,
+                "Not enough voting power: {} < {}",
+                voting_power, threshold
+            ),
+            ValidationError::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl From<ValidationError> for Error {
+    fn from(error: ValidationError) -> Self {
+        Error::Validation(error)
+    }
 }
 
 /// Representation of the errors that can occur when verifying data.
@@ -190,23 +228,52 @@ pub enum ValidationError {
 /// See [`ExtendedHeader::verify`].
 ///
 /// [`ExtendedHeader::verify`]: crate::ExtendedHeader::verify
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum VerificationError {
     /// Not enough voting power for a commit.
-    #[error("Not enought voting power (got {0}, needed {1})")]
     NotEnoughVotingPower(u64, u64),
 
     /// Other errors that can happen during verification.
-    #[error("{0}")]
     Other(String),
+}
+
+impl Display for VerificationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            VerificationError::NotEnoughVotingPower(voting_power, threshold) => write!(
+                f,
+                "Not enough voting power: {} < {}",
+                voting_power, threshold
+            ),
+            VerificationError::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl From<VerificationError> for Error {
+    fn from(error: VerificationError) -> Self {
+        Error::Verification(error)
+    }
+}
+
+impl From<celestia_tendermint::Error> for Error {
+    fn from(error: celestia_tendermint::Error) -> Self {
+        Error::Tendermint(error)
+    }
+}
+
+impl From<celestia_tendermint_proto::Error> for Error {
+    fn from(error: celestia_tendermint_proto::Error) -> Self {
+        Error::Protobuf(error)
+    }
 }
 
 macro_rules! validation_error {
     ($fmt:literal $(,)?) => {
-        $crate::ValidationError::Other(std::format!($fmt))
+        $crate::ValidationError::Other(format!($fmt))
     };
     ($fmt:literal, $($arg:tt)*) => {
-        $crate::ValidationError::Other(std::format!($fmt, $($arg)*))
+        $crate::ValidationError::Other(format!($fmt, $($arg)*))
     };
 }
 
@@ -218,10 +285,10 @@ macro_rules! bail_validation {
 
 macro_rules! verification_error {
     ($fmt:literal $(,)?) => {
-        $crate::VerificationError::Other(std::format!($fmt))
+        $crate::VerificationError::Other(format!($fmt))
     };
     ($fmt:literal, $($arg:tt)*) => {
-        $crate::VerificationError::Other(std::format!($fmt, $($arg)*))
+        $crate::VerificationError::Other(format!($fmt, $($arg)*))
     };
 }
 

--- a/types/src/extended_header.rs
+++ b/types/src/extended_header.rs
@@ -1,6 +1,6 @@
-use std::fmt::{Display, Formatter};
+use core::fmt::{Display, Formatter};
 #[cfg(any(not(target_arch = "wasm32"), feature = "wasm-bindgen"))]
-use std::time::Duration;
+use core::time::Duration;
 
 use celestia_proto::header::pb::ExtendedHeader as RawExtendedHeader;
 use celestia_tendermint::block::header::Header;
@@ -65,7 +65,7 @@ pub struct ExtendedHeader {
 }
 
 impl Display for ExtendedHeader {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "hash: {}; height: {}", self.hash(), self.height())
     }
 }
@@ -73,7 +73,7 @@ impl Display for ExtendedHeader {
 impl ExtendedHeader {
     /// Decode protobuf encoded header and then validate it.
     pub fn decode_and_validate(bytes: &[u8]) -> Result<Self> {
-        let header = ExtendedHeader::decode(bytes)?;
+        let header = ExtendedHeader::decode(bytes).map_err(Error::Protobuf)?;
         header.validate()?;
         Ok(header)
     }
@@ -280,7 +280,7 @@ impl ExtendedHeader {
     /// # Example
     ///
     /// ```
-    /// # use std::ops::Range;
+    /// # use core::ops::Range;
     /// # use celestia_types::ExtendedHeader;
     /// # let s = include_str!("../test_data/chain3/extended_header_block_1_to_256.json");
     /// # let headers: Vec<ExtendedHeader> = serde_json::from_str(s).unwrap();
@@ -331,7 +331,7 @@ impl ExtendedHeader {
     /// # Example
     ///
     /// ```
-    /// # use std::ops::Range;
+    /// # use core::ops::Range;
     /// # use celestia_types::ExtendedHeader;
     /// # let s = include_str!("../test_data/chain3/extended_header_block_1_to_256.json");
     /// # let headers: Vec<ExtendedHeader> = serde_json::from_str(s).unwrap();
@@ -408,6 +408,7 @@ impl From<ExtendedHeader> for RawExtendedHeader {
 mod tests {
     use super::*;
     use crate::test_utils::{invalidate, unverify};
+    use crate::types::Vec;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/types/src/fraud_proof.rs
+++ b/types/src/fraud_proof.rs
@@ -2,7 +2,7 @@
 //!
 //! A fraud proof is a proof of the detected malicious action done to the network.
 
-use std::convert::Infallible;
+use core::convert::Infallible;
 
 use celestia_tendermint::block::Height;
 use celestia_tendermint::Hash;
@@ -10,6 +10,7 @@ use celestia_tendermint_proto::Protobuf;
 use serde::{Deserialize, Serialize, Serializer};
 
 pub use crate::byzantine::BadEncodingFraudProof;
+use crate::types::{String, ToOwned, Vec};
 use crate::{Error, ExtendedHeader, Result};
 
 /// A proof of the malicious actions done to the network.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docs_rs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
 
 pub mod blob;
 mod block;
@@ -26,6 +31,7 @@ mod sync;
 #[cfg_attr(docs_rs, doc(cfg(feature = "test-utils")))]
 pub mod test_utils;
 pub mod trust_level;
+mod types;
 mod validate;
 mod validator_set;
 

--- a/types/src/namespaced_data.rs
+++ b/types/src/namespaced_data.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::nmt::{Namespace, NamespaceProof, NS_SIZE};
 use crate::row::RowId;
+use crate::types::{ToString, Vec};
 use crate::{DataAvailabilityHeader, Error, Result};
 
 /// The size of the [`NamespacedDataId`] hash in `multihash`.
@@ -112,7 +113,8 @@ impl TryFrom<RawNamespacedData> for NamespacedData {
             return Err(Error::MissingProof);
         };
 
-        let namespaced_data_id = NamespacedDataId::decode(&namespaced_data.data_id)?;
+        let namespaced_data_id =
+            NamespacedDataId::decode(&namespaced_data.data_id).map_err(Error::CidError)?;
 
         Ok(NamespacedData {
             namespaced_data_id,

--- a/types/src/nmt.rs
+++ b/types/src/nmt.rs
@@ -35,6 +35,7 @@ pub use self::namespace_proof::{NamespaceProof, EMPTY_LEAVES};
 pub use self::namespaced_hash::{
     NamespacedHashExt, RawNamespacedHash, HASH_SIZE, NAMESPACED_HASH_SIZE,
 };
+use crate::types::ToString;
 use crate::{Error, Result};
 
 /// Namespace version size in bytes.
@@ -368,7 +369,7 @@ impl From<nmt_rs::NamespaceId<NS_SIZE>> for Namespace {
     }
 }
 
-impl std::ops::Deref for Namespace {
+impl core::ops::Deref for Namespace {
     type Target = nmt_rs::NamespaceId<NS_SIZE>;
 
     fn deref(&self) -> &Self::Target {

--- a/types/src/nmt/namespace_proof.rs
+++ b/types/src/nmt/namespace_proof.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use celestia_proto::proof::pb::Proof as RawProof;
 use celestia_tendermint_proto::Protobuf;
@@ -6,6 +6,7 @@ use nmt_rs::simple_merkle::proof::Proof as NmtProof;
 use serde::{Deserialize, Serialize};
 
 use crate::nmt::{NamespacedHash, NamespacedHashExt, NamespacedSha2Hasher, NS_SIZE};
+use crate::types::Vec;
 use crate::{Error, Result};
 
 type NmtNamespaceProof = nmt_rs::nmt_proof::NamespaceProof<NamespacedSha2Hasher, NS_SIZE>;

--- a/types/src/nmt/namespaced_hash.rs
+++ b/types/src/nmt/namespaced_hash.rs
@@ -1,4 +1,5 @@
 use crate::nmt::{NamespacedHash, NamespacedSha2Hasher, NS_SIZE};
+use crate::types::Vec;
 use crate::{Error, Result};
 
 use nmt_rs::simple_merkle::tree::MerkleHash;
@@ -38,7 +39,9 @@ impl NamespacedHashExt for NamespacedHash {
     }
 
     fn from_raw(bytes: &[u8]) -> Result<NamespacedHash> {
-        Ok(bytes.try_into()?)
+        Ok(bytes
+            .try_into()
+            .map_err(|hash| Error::InvalidNamespacedHash(hash))?)
     }
 
     fn to_vec(&self) -> Vec<u8> {

--- a/types/src/p2p.rs
+++ b/types/src/p2p.rs
@@ -1,9 +1,9 @@
 //! Types related to the p2p layer of nodes in Celestia.
 
+use crate::types::{HashMap, String, Vec};
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::collections::HashMap;
 
 /// An id and addresses of a peer in p2p network.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/types/src/rsmt2d.rs
+++ b/types/src/rsmt2d.rs
@@ -1,4 +1,4 @@
-use std::result::Result as StdResult;
+use core::result::Result as StdResult;
 
 use nmt_rs::NamespaceMerkleHasher;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::namespaced_data::{NamespacedData, NamespacedDataId};
 use crate::nmt::{Namespace, NamespacedSha2Hasher, Nmt, NS_SIZE};
 use crate::row::RowId;
+use crate::types::{String, Vec};
 use crate::{DataAvailabilityHeader, Error, Result};
 
 /// Represents either column or row of the [`ExtendedDataSquare`].

--- a/types/src/sample.rs
+++ b/types/src/sample.rs
@@ -7,7 +7,7 @@
 //! [`Share`]: crate::Share
 //! [`ExtendedDataSquare`]: crate::rsmt2d::ExtendedDataSquare
 
-use std::mem::size_of;
+use core::mem::size_of;
 
 use blockstore::block::CidError;
 use bytes::{BufMut, BytesMut};
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::nmt::{Namespace, NamespaceProof, NamespacedSha2Hasher, Nmt, NS_SIZE};
 use crate::row::RowId;
 use crate::rsmt2d::{AxisType, ExtendedDataSquare};
+use crate::types::Vec;
 use crate::{DataAvailabilityHeader, Error, Result};
 
 /// The size of the [`SampleId`] hash in `multihash`.
@@ -186,7 +187,7 @@ impl TryFrom<RawSample> for Sample {
             return Err(Error::MissingProof);
         };
 
-        let sample_id = SampleId::decode(&sample.sample_id)?;
+        let sample_id = SampleId::decode(&sample.sample_id).map_err(Error::CidError)?;
         let sample_proof_type = u8::try_from(sample.sample_type)
             .map_err(|_| Error::InvalidAxis(sample.sample_type))?
             .try_into()?;

--- a/types/src/share.rs
+++ b/types/src/share.rs
@@ -12,6 +12,7 @@ use crate::nmt::{
     Namespace, NamespaceProof, NamespacedSha2Hasher, NMT_CODEC, NMT_ID_SIZE, NMT_MULTIHASH_CODE,
     NS_SIZE,
 };
+use crate::types::Vec;
 use crate::{Error, Result};
 
 mod info_byte;

--- a/types/src/state/address.rs
+++ b/types/src/state/address.rs
@@ -1,5 +1,5 @@
-use std::fmt::Display;
-use std::str::FromStr;
+use core::fmt::Display;
+use core::str::FromStr;
 
 use bech32::{FromBase32, ToBase32};
 use celestia_tendermint::account::Id;
@@ -7,6 +7,7 @@ use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 
 use crate::consts::cosmos::*;
+use crate::types::{String, ToOwned, ToString, Vec};
 use crate::{Error, Result};
 
 /// A generic representation of an address in Celestia network.
@@ -119,7 +120,7 @@ impl FromStr for AddressKind {
 impl private::Sealed for Address {}
 
 impl Display for Address {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Address::AccAddress(v) => <AccAddress as Display>::fmt(v, f),
             Address::ValAddress(v) => <ValAddress as Display>::fmt(v, f),
@@ -179,7 +180,7 @@ impl AddressTrait for AccAddress {
 impl private::Sealed for AccAddress {}
 
 impl Display for AccAddress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s = address_to_string(self);
         f.write_str(&s)
     }
@@ -235,7 +236,7 @@ impl AddressTrait for ValAddress {
 impl private::Sealed for ValAddress {}
 
 impl Display for ValAddress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s = address_to_string(self);
         f.write_str(&s)
     }
@@ -291,7 +292,7 @@ impl AddressTrait for ConsAddress {
 impl private::Sealed for ConsAddress {}
 
 impl Display for ConsAddress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s = address_to_string(self);
         f.write_str(&s)
     }

--- a/types/src/state/balance.rs
+++ b/types/src/state/balance.rs
@@ -2,6 +2,7 @@ use celestia_proto::cosmos::base::v1beta1::Coin as RawCoin;
 use serde::{Deserialize, Serialize};
 
 use crate::state::Uint;
+use crate::types::{String, ToOwned, ToString};
 use crate::{Error, Result};
 
 /// Representation of the account's balance.

--- a/types/src/state/tx.rs
+++ b/types/src/state/tx.rs
@@ -1,6 +1,8 @@
 use celestia_proto::cosmos::base::abci::v1beta1::TxResponse as RawTxResponse;
 use serde::{Deserialize, Serialize};
 
+use crate::types::Vec;
+
 /// Raw transaction data.
 ///
 /// # Note

--- a/types/src/sync.rs
+++ b/types/src/sync.rs
@@ -2,6 +2,8 @@ use celestia_tendermint::hash::Hash;
 use celestia_tendermint::time::Time;
 use serde::{Deserialize, Serialize};
 
+use crate::types::String;
+
 /// A state of the blockchain synchronization.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncState {

--- a/types/src/test_utils.rs
+++ b/types/src/test_utils.rs
@@ -15,6 +15,7 @@ use crate::block::{CommitExt, GENESIS_HEIGHT};
 use crate::consts::version;
 use crate::hash::{Hash, HashExt};
 use crate::nmt::{NamespacedHash, NamespacedHashExt};
+use crate::types::{ToOwned, Vec};
 use crate::{DataAvailabilityHeader, ExtendedHeader, ValidatorSet};
 
 /// [`ExtendedHeader`] generator for testing purposes.

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -1,0 +1,27 @@
+#[cfg(not(feature = "std"))]
+pub use alloc::collections::{
+    btree_map, btree_set, BTreeMap, BTreeMap as HashMap, BTreeSet, BTreeSet as HashSet,
+};
+
+#[cfg(not(feature = "std"))]
+pub use alloc::vec::{self as vec, Vec};
+
+#[cfg(feature = "std")]
+pub use std::collections::{
+    btree_map, btree_set, BTreeMap, BTreeMap as HashMap, BTreeSet as HashSet,
+};
+
+#[cfg(feature = "std")]
+pub use std::vec::{self as vec, Vec};
+
+#[cfg(not(feature = "std"))]
+pub use alloc::string::{String, ToString};
+
+#[cfg(feature = "std")]
+pub use std::string::{String, ToString};
+
+#[cfg(not(feature = "std"))]
+pub use alloc::borrow::ToOwned;
+
+#[cfg(feature = "std")]
+pub use std::borrow::ToOwned;

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -7,9 +7,7 @@ pub use alloc::collections::{
 pub use alloc::vec::{self as vec, Vec};
 
 #[cfg(feature = "std")]
-pub use std::collections::{
-    btree_map, btree_set, BTreeMap, BTreeMap as HashMap, BTreeSet as HashSet,
-};
+pub use std::collections::{btree_map, btree_set, HashMap, HashSet};
 
 #[cfg(feature = "std")]
 pub use std::vec::{self as vec, Vec};

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
-
 use celestia_tendermint::block::CommitSig;
 use celestia_tendermint::crypto::default::signature::Verifier;
 use celestia_tendermint::validator::{Info, Set};
 use celestia_tendermint::{account, block, chain};
+
+use crate::types::HashMap;
 
 use crate::trust_level::TrustLevelRatio;
 use crate::{
@@ -163,6 +163,8 @@ mod tests {
     use super::*;
 
     use celestia_tendermint_proto::v0_34::types::ValidatorSet as RawValidatorSet;
+
+    use crate::types::ToString;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;


### PR DESCRIPTION
This PR proposes the introduction of `no_std` support for the `types` crate. This will allow it to be used in `no_std` targets. To achieve this change we have had to remove the usage of `thiserror` in the `types` crate as well as introduce the usage of alloc for `no_std` environment. I wanted to gauge support for this change. If we have support then I will clean it up and make it ready for merge.