### PR TITLE
chore: remove deny warnings from cargo udeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,5 +192,3 @@ jobs:
 
     - name: Check for unused dependencies
       run: cargo +nightly udeps --all-features --all-targets
-      env:
-        RUSTFLAGS: -D warnings


### PR DESCRIPTION
this step is failing again... If we will want to have warning-less compilation of nightly, we should add nightly clippy run