### PR TITLE
feat: Add requesting storage persistence for more quota

### DIFF
--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -56,6 +56,7 @@ web-sys = { version = "0.3.69", features = [
   "Navigator",
   "SharedWorker",
   "SharedWorkerGlobalScope",
+  "StorageManager",
   "Worker",
   "WorkerGlobalScope",
   "WorkerOptions",

--- a/node-wasm/src/error.rs
+++ b/node-wasm/src/error.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::describe::WasmDescribe;
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::JsValue;
 
 /// Alias for a `Result` with the error type [`Error`].
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -47,16 +47,6 @@ impl Error {
         let e = js_sys::Error::new(&context.to_string());
         e.set_cause(&self.0);
         Error(e.into())
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(error) = self.0.dyn_ref::<js_sys::Error>() {
-            write!(f, "{} ({})", error.name(), error.message())
-        } else {
-            write!(f, "{:?}", self.0.as_string())
-        }
     }
 }
 

--- a/node-wasm/src/error.rs
+++ b/node-wasm/src/error.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::describe::WasmDescribe;
-use wasm_bindgen::{JsValue, JsCast};
+use wasm_bindgen::{JsCast, JsValue};
 
 /// Alias for a `Result` with the error type [`Error`].
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/node-wasm/src/error.rs
+++ b/node-wasm/src/error.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::describe::WasmDescribe;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsValue, JsCast};
 
 /// Alias for a `Result` with the error type [`Error`].
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -47,6 +47,16 @@ impl Error {
         let e = js_sys::Error::new(&context.to_string());
         e.set_cause(&self.0);
         Error(e.into())
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(error) = self.0.dyn_ref::<js_sys::Error>() {
+            write!(f, "{} ({})", error.name(), error.message())
+        } else {
+            write!(f, "{:?}", self.0.as_string())
+        }
     }
 }
 

--- a/node-wasm/src/utils.rs
+++ b/node-wasm/src/utils.rs
@@ -166,7 +166,7 @@ pub(crate) async fn request_storage_persistence() -> Result<(), Error> {
         warn!("Error during persistant storage request");
     });
 
-    // don't drop the promise, we'll log the result and hope user clicked the right button
+    // don't drop the promise, we'll log the result and hope the user clicked the right button
     let _promise = get_navigator()?
         .storage()
         .persist()?

--- a/node-wasm/src/utils.rs
+++ b/node-wasm/src/utils.rs
@@ -167,9 +167,12 @@ pub(crate) async fn request_storage_persistence() -> Result<(), Error> {
     });
 
     // don't drop the promise, we'll log the result and hope user clicked the right button
-    let _promise = get_navigator()?.storage().persist()?.then2(&fullfiled, &rejected);
+    let _promise = get_navigator()?
+        .storage()
+        .persist()?
+        .then2(&fullfiled, &rejected);
 
-    // stop rust from dropping them 
+    // stop rust from dropping them
     fullfiled.forget();
     rejected.forget();
 

--- a/node-wasm/src/utils.rs
+++ b/node-wasm/src/utils.rs
@@ -5,6 +5,7 @@ use lumina_node::network;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use tracing::{info, warn};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::format::Pretty;
 use tracing_subscriber::fmt::time::UtcTime;
@@ -148,6 +149,31 @@ where
             JsResult::Err(e) => Err(e),
         }
     }
+}
+
+/// Request persistent storage from user for us, which has side effect of increasing the quota we
+/// have. This function doesn't `await` on JavaScript promise, as that would block until user
+/// either allows or blocks our request in a prompt (and we cannot do much with the result anyway).
+pub(crate) async fn request_storage_persistence() -> Result<(), Error> {
+    let fullfiled = Closure::once(move |granted: JsValue| {
+        if granted.is_truthy() {
+            info!("Storage persistence acquired: {:?}", granted);
+        } else {
+            warn!("User rejected storage persistance request")
+        }
+    });
+    let rejected = Closure::once(move |_ev: JsValue| {
+        warn!("Error during persistant storage request");
+    });
+
+    // don't drop the promise, we'll log the result and hope user clicked the right button
+    let _promise = get_navigator()?.storage().persist()?.then2(&fullfiled, &rejected);
+
+    // stop rust from dropping them 
+    fullfiled.forget();
+    rejected.forget();
+
+    Ok(())
 }
 
 const CHROME_USER_AGENT_DETECTION_STR: &str = "Chrome/";

--- a/node-wasm/src/worker/channel.rs
+++ b/node-wasm/src/worker/channel.rs
@@ -161,7 +161,7 @@ impl AnyWorker {
 
     fn setup_on_error_callback(&self) -> Closure<dyn Fn(MessageEvent)> {
         let onerror = Closure::new(|ev: MessageEvent| {
-            error!("received error from Worker: {:?}", ev.to_string());
+            error!("received error from Worker: {:?}", Error::from_js_value(ev));
         });
         match self {
             AnyWorker::SharedWorker(worker) => {

--- a/node-wasm/src/worker/channel.rs
+++ b/node-wasm/src/worker/channel.rs
@@ -161,7 +161,7 @@ impl AnyWorker {
 
     fn setup_on_error_callback(&self) -> Closure<dyn Fn(MessageEvent)> {
         let onerror = Closure::new(|ev: MessageEvent| {
-            error!("received error from Worker: {:?}", Error::from_js_value(ev));
+            error!("received error from Worker: {:?}", ev);
         });
         match self {
             AnyWorker::SharedWorker(worker) => {


### PR DESCRIPTION
related #317 

[MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria) isn't exact on the details (as detail vary by browser), but requesting persistent storage on firefox raises the quota limit (and eliminates quota issues on my machine).
Browsers should also try more to keep our data from being removed.

Node that this will display prompt on Firefox, while chromium based browsers use heuristics to figure out whether to grant the storage.

![image](https://github.com/eigerco/lumina/assets/9157240/b9f9d595-0676-41fd-a8cb-11b84627f6b0)
