### PR TITLE
fix(types)!: Align byzantine fraud proofs with Go's implementation

### DIFF
--- a/proto/vendor/google/api/annotations.proto
+++ b/proto/vendor/google/api/annotations.proto
@@ -1,4 +1,4 @@
-// Copyright 2015 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/proto/vendor/google/api/http.proto
+++ b/proto/vendor/google/api/http.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/proto/vendor/share/eds/byzantine/pb/share.proto
+++ b/proto/vendor/share/eds/byzantine/pb/share.proto
@@ -6,6 +6,7 @@ import "pb/proof.proto";
 message Share {
   bytes Data = 1;
   proof.pb.Proof Proof = 2;
+  axis ProofAxis = 3;
 }
 
 enum axis {

--- a/proto/vendor/tendermint/abci/types.proto
+++ b/proto/vendor/tendermint/abci/types.proto
@@ -127,11 +127,11 @@ message RequestApplySnapshotChunk {
 }
 
 message RequestPrepareProposal {
-  // block_data is an array of transactions that will be included in a block,
-  // sent to the app for possible modifications.
-  // applications can not exceed the size of the data passed to it.
+  // BlockData is a slice of candidate transactions that may be included in a
+  // block. BlockData is sent to the application so that the application can
+  // filter and re-arrange the slice of candidate transactions.
   tendermint.types.Data block_data = 1;
-  // If an application decides to populate block_data with extra information, they can not exceed this value.
+  // BlockDataSize is the maximum size (in bytes) that BlockData should be.
   int64 block_data_size = 2;
   // chain_id is a unique identifier for the blockchain network this proposal
   // belongs to (e.g. mocha-1).

--- a/proto/vendor/tendermint/store/types.proto
+++ b/proto/vendor/tendermint/store/types.proto
@@ -7,3 +7,13 @@ message BlockStoreState {
   int64 base   = 1;
   int64 height = 2;
 }
+
+// TxInfo describes the location of a tx inside a committed block
+// as well as the result of executing the transaction.
+message TxInfo {
+  int64 height    = 1;
+  uint32 index    = 2;
+  // The response code of executing the tx. 0 means
+  // successfully executed, all others are error codes.
+  uint32 code     = 3;
+}

--- a/tools/update-proto-vendor.sh
+++ b/tools/update-proto-vendor.sh
@@ -23,21 +23,21 @@ rm -rf ../target/proto-vendor-src
 mkdir -p ../target/proto-vendor-src
 
 extract_urls ../target/proto-vendor-src \
-    https://github.com/celestiaorg/celestia-app/archive/refs/tags/v1.4.0.tar.gz \
+    https://github.com/celestiaorg/celestia-app/archive/refs/tags/v1.12.0.tar.gz \
     https://github.com/celestiaorg/celestia-core/archive/refs/heads/v0.34.x-celestia.tar.gz \
     https://github.com/celestiaorg/celestia-node/archive/refs/heads/main.tar.gz \
     https://github.com/celestiaorg/cosmos-sdk/archive/refs/heads/release/v0.46.x-celestia.tar.gz \
-    https://github.com/celestiaorg/nmt/archive/refs/heads/master.tar.gz \
-    https://github.com/cosmos/cosmos-proto/archive/refs/tags/v1.0.0-alpha4.tar.gz \
+    https://github.com/celestiaorg/nmt/archive/refs/heads/main.tar.gz \
+    https://github.com/cosmos/cosmos-proto/archive/refs/tags/v1.0.0-alpha7.tar.gz \
     https://github.com/cosmos/gogoproto/archive/refs/tags/v1.4.11.tar.gz \
     https://github.com/celestiaorg/go-header/archive/refs/heads/main.tar.gz \
     https://github.com/googleapis/googleapis/archive/refs/heads/master.tar.gz \
-    https://codeload.github.com/celestiaorg/celestia-node/zip/refs/heads/hlib/v2-prototype
+    https://github.com/celestiaorg/celestia-node/archive/refs/heads/shwap-prototype.tar.gz
 
 mkdir -p vendor
 
 rm -rf vendor/celestia
-cp -r ../target/proto-vendor-src/celestia-app-1.4.0/proto/celestia vendor
+cp -r ../target/proto-vendor-src/celestia-app-1.12.0/proto/celestia vendor
 
 rm -rf vendor/go-header
 mkdir -p vendor/go-header/p2p
@@ -48,7 +48,7 @@ mkdir -p vendor/cosmos
 cp -r ../target/proto-vendor-src/cosmos-sdk-release-v0.46.x-celestia/proto/cosmos/{base,staking,crypto,tx} vendor/cosmos
 
 rm -rf vendor/cosmos_proto
-cp -r ../target/proto-vendor-src/cosmos-proto-1.0.0-alpha4/proto/cosmos_proto vendor
+cp -r ../target/proto-vendor-src/cosmos-proto-1.0.0-alpha7/proto/cosmos_proto vendor
 
 rm -rf vendor/gogoproto
 mkdir -p vendor/gogoproto
@@ -72,10 +72,10 @@ for pb_dir in ../target/proto-vendor-src/celestia-node-main/share/*/*/pb; do
 done
 
 # TODO: replace with version from main, once it is merged
-# https://github.com/celestiaorg/celestia-node/pull/2675
+# https://github.com/celestiaorg/celestia-node/pull/3184
 rm -rf vendor/share/p2p/shwap
 mkdir -p vendor/share/p2p/shwap/pb
-cp ../target/proto-vendor-src/celestia-node-hlib-v2-prototype/share/shwap/pb/shwap_pb.proto \
+cp ../target/proto-vendor-src/celestia-node-shwap-prototype/share/shwap/pb/shwap_pb.proto \
     vendor/share/p2p/shwap/pb/shwap.proto
 
 rm -rf vendor/tendermint
@@ -83,6 +83,6 @@ cp -r ../target/proto-vendor-src/celestia-core-0.34.x-celestia/proto/tendermint 
 
 rm -rf vendor/nmt
 mkdir -p vendor/nmt
-cp -r ../target/proto-vendor-src/nmt-master/pb vendor/nmt
+cp -r ../target/proto-vendor-src/nmt-main/pb vendor/nmt
 
 find vendor -name '*.go' -delete

--- a/types/src/byzantine.rs
+++ b/types/src/byzantine.rs
@@ -2,21 +2,14 @@ use celestia_proto::share::eds::byzantine::pb::BadEncoding as RawBadEncodingFrau
 use celestia_proto::share::eds::byzantine::pb::Share as RawShareWithProof;
 use celestia_tendermint::{block::Height, Hash};
 use celestia_tendermint_proto::Protobuf;
-use cid::CidGeneric;
 use serde::{Deserialize, Serialize};
 
 use crate::bail_validation;
 use crate::consts::appconsts;
 use crate::fraud_proof::FraudProof;
-use crate::nmt::{
-    Namespace, NamespaceProof, NamespacedHash, NamespacedHashExt, Nmt, NmtExt, NMT_CODEC,
-    NMT_ID_SIZE, NMT_MULTIHASH_CODE, NS_SIZE,
-};
+use crate::nmt::{Namespace, NamespaceProof, Nmt, NmtExt, NS_SIZE};
 use crate::rsmt2d::AxisType;
 use crate::{Error, ExtendedHeader, Result};
-
-type Cid = CidGeneric<NMT_ID_SIZE>;
-type Multihash = multihash::Multihash<NMT_ID_SIZE>;
 
 /// A proof that the block producer incorrectly encoded [`ExtendedDataSquare`].
 ///
@@ -235,9 +228,7 @@ impl TryFrom<RawShareWithProof> for ShareWithProof {
             return Err(Error::WrongProofType);
         }
 
-        let proof_axis = u8::try_from(value.proof_axis)
-            .map_err(|_| Error::InvalidAxis(value.proof_axis))?
-            .try_into()?;
+        let proof_axis = value.proof_axis.try_into()?;
 
         Ok(Self {
             leaf,
@@ -263,9 +254,7 @@ impl TryFrom<RawBadEncodingFraudProof> for BadEncodingFraudProof {
     type Error = Error;
 
     fn try_from(value: RawBadEncodingFraudProof) -> Result<Self, Self::Error> {
-        let axis = u8::try_from(value.axis)
-            .map_err(|_| Error::InvalidAxis(value.axis))?
-            .try_into()?;
+        let axis = value.axis.try_into()?;
 
         let index = u16::try_from(value.index).map_err(|_| Error::EdsInvalidDimentions)?;
 

--- a/types/src/byzantine.rs
+++ b/types/src/byzantine.rs
@@ -359,10 +359,10 @@ pub(crate) mod test_utils {
 
         // collect the shares for fraud proof
         for share_idx in 0..square_width {
-            let proof_axis = match rng.gen_range(0..=1) {
-                0 => AxisType::Row,
-                1 => AxisType::Col,
-                _ => unreachable!(),
+            let proof_axis = if rand::random() {
+                AxisType::Row
+            } else {
+                AxisType::Col
             };
 
             let mut nmt = match (axis, proof_axis) {

--- a/types/src/byzantine.rs
+++ b/types/src/byzantine.rs
@@ -70,53 +70,66 @@ impl FraudProof for BadEncodingFraudProof {
             );
         }
 
-        let merkle_row_roots = header.dah.row_roots();
-        let merkle_col_roots = header.dah.column_roots();
-
         // NOTE: shouldn't ever happen as header should be validated before
-        if merkle_row_roots.len() != merkle_col_roots.len() {
+        if header.dah.row_roots().len() != header.dah.column_roots().len() {
             bail_validation!(
                 "dah rows len ({}) != dah columns len ({})",
-                merkle_row_roots.len(),
-                merkle_col_roots.len(),
+                header.dah.row_roots().len(),
+                header.dah.column_roots().len(),
             );
         }
 
-        if usize::from(self.index) >= merkle_row_roots.len() {
+        let square_width = usize::from(header.dah.square_width());
+        let ods_width = square_width / 2;
+
+        if usize::from(self.index) >= square_width {
             bail_validation!(
-                "fraud proof index ({}) >= dah rows len ({})",
+                "fraud proof index ({}) >= dah square width ({})",
                 self.index,
-                merkle_row_roots.len()
+                square_width,
             );
         }
 
-        if self.shares.len() != merkle_row_roots.len() {
+        if self.shares.len() != square_width {
             bail_validation!(
-                "fraud proof shares len ({}) != dah rows len ({})",
+                "fraud proof shares len ({}) != dah square width ({})",
                 self.shares.len(),
-                merkle_row_roots.len()
+                square_width,
             );
         }
 
-        let root = match self.axis {
-            AxisType::Row => merkle_row_roots[usize::from(self.index)].clone(),
-            AxisType::Col => merkle_col_roots[usize::from(self.index)].clone(),
-        };
-
-        // verify if the root can be converted to a cid and back
-        let mh = Multihash::wrap(NMT_MULTIHASH_CODE, &root.to_array())?;
-        let cid = Cid::new_v1(NMT_CODEC, mh);
-        let root = NamespacedHash::try_from(cid.hash().digest())?;
+        let shares_count = self.shares.iter().filter(|s| s.is_some()).count();
+        if shares_count < ods_width {
+            bail_validation!(
+                "fraud proof non-nil shares count ({shares_count}) < dah ods width ({ods_width})"
+            );
+        }
 
         // verify that Merkle proofs correspond to particular shares.
-        for maybe_share in &self.shares {
+        for (share_idx, maybe_share) in self.shares.iter().enumerate() {
             let Some(share_with_proof) = maybe_share else {
                 continue;
             };
+
             let ShareWithProof {
                 leaf: NmtLeaf { namespace, share },
                 proof,
+                proof_axis,
             } = share_with_proof;
+
+            // unwraps are safe because we validated that index is in range
+            let root = match (self.axis, proof_axis) {
+                (AxisType::Row, AxisType::Row) => header.dah.row_root(self.index).unwrap(),
+                (AxisType::Row, AxisType::Col) => header.dah.column_root(share_idx as u16).unwrap(),
+                (AxisType::Col, AxisType::Row) => header.dah.row_root(share_idx as u16).unwrap(),
+                (AxisType::Col, AxisType::Col) => header.dah.column_root(self.index).unwrap(),
+            };
+
+            // verify if the root can be converted to a cid and back
+            let mh = Multihash::wrap(NMT_MULTIHASH_CODE, &root.to_array())?;
+            let cid = Cid::new_v1(NMT_CODEC, mh);
+            let root = NamespacedHash::try_from(cid.hash().digest())?;
+
             proof
                 .verify_range(&root, &[&share], **namespace)
                 .map_err(Error::RangeProofError)?;
@@ -133,7 +146,6 @@ impl FraudProof for BadEncodingFraudProof {
                     .unwrap_or_default()
             })
             .collect();
-        let ods_width = rebuilt_shares.len() / 2;
         if leopard_codec::reconstruct(&mut rebuilt_shares, ods_width).is_err() {
             // we couldn't reconstruct the data even tho we had enough *proven* shares
             // befp is legit
@@ -185,6 +197,7 @@ impl FraudProof for BadEncodingFraudProof {
 struct ShareWithProof {
     leaf: NmtLeaf,
     proof: NamespaceProof,
+    proof_axis: AxisType,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -227,7 +240,15 @@ impl TryFrom<RawShareWithProof> for ShareWithProof {
             return Err(Error::WrongProofType);
         }
 
-        Ok(Self { leaf, proof })
+        let proof_axis = u8::try_from(value.proof_axis)
+            .map_err(|_| Error::InvalidAxis(value.proof_axis))?
+            .try_into()?;
+
+        Ok(Self {
+            leaf,
+            proof,
+            proof_axis,
+        })
     }
 }
 
@@ -236,6 +257,7 @@ impl From<ShareWithProof> for RawShareWithProof {
         RawShareWithProof {
             data: value.leaf.to_vec(),
             proof: Some(value.proof.into()),
+            proof_axis: value.proof_axis as i32,
         }
     }
 }
@@ -346,13 +368,35 @@ pub(crate) mod test_utils {
         axis_idx: u16,
         axis: AxisType,
     ) -> BadEncodingFraudProof {
+        let mut rng = rand::thread_rng();
+
         let square_width = eds.square_width();
-        let mut nmt = eds.axis_nmt(axis, axis_idx).unwrap();
         let mut shares_with_proof: Vec<_> = Vec::with_capacity(square_width.into());
 
         // collect the shares for fraud proof
         for share_idx in 0..square_width {
-            let (share, proof) = nmt.get_index_with_proof(share_idx.into());
+            let proof_axis = match rng.gen_range(0..=1) {
+                0 => AxisType::Row,
+                1 => AxisType::Col,
+                _ => unreachable!(),
+            };
+
+            let mut nmt = match (axis, proof_axis) {
+                (AxisType::Row, AxisType::Row) => eds.row_nmt(axis_idx).unwrap(),
+                (AxisType::Row, AxisType::Col) => eds.column_nmt(share_idx).unwrap(),
+                (AxisType::Col, AxisType::Row) => eds.row_nmt(share_idx).unwrap(),
+                (AxisType::Col, AxisType::Col) => eds.column_nmt(axis_idx).unwrap(),
+            };
+
+            // The index of the share in the `nmt`.
+            let idx = match (axis, proof_axis) {
+                (AxisType::Row, AxisType::Row) => share_idx,
+                (AxisType::Row, AxisType::Col) => axis_idx,
+                (AxisType::Col, AxisType::Row) => axis_idx,
+                (AxisType::Col, AxisType::Col) => share_idx,
+            };
+
+            let (share, proof) = nmt.get_index_with_proof(idx.into());
 
             // it doesn't matter which is row and which is column as ods is first quadrant
             let ns = if is_ods_square(axis_idx, share_idx, square_width) {
@@ -371,6 +415,7 @@ pub(crate) mod test_utils {
                     ignore_max_ns: true,
                 }
                 .into(),
+                proof_axis,
             };
 
             shares_with_proof.push(Some(share_with_proof));

--- a/types/src/byzantine.rs
+++ b/types/src/byzantine.rs
@@ -94,7 +94,7 @@ impl FraudProof for BadEncodingFraudProof {
         let shares_count = self.shares.iter().filter(|s| s.is_some()).count();
         if shares_count < ods_width {
             bail_validation!(
-                "fraud proof non-nil shares count ({shares_count}) < dah ods width ({ods_width})"
+                "fraud proof present shares count ({shares_count}) < dah ods width ({ods_width})"
             );
         }
 

--- a/types/src/byzantine.rs
+++ b/types/src/byzantine.rs
@@ -352,8 +352,6 @@ pub(crate) mod test_utils {
         axis_idx: u16,
         axis: AxisType,
     ) -> BadEncodingFraudProof {
-        let mut rng = rand::thread_rng();
-
         let square_width = eds.square_width();
         let mut shares_with_proof: Vec<_> = Vec::with_capacity(square_width.into());
 

--- a/types/src/byzantine.rs
+++ b/types/src/byzantine.rs
@@ -125,11 +125,6 @@ impl FraudProof for BadEncodingFraudProof {
                 (AxisType::Col, AxisType::Col) => header.dah.column_root(self.index).unwrap(),
             };
 
-            // verify if the root can be converted to a cid and back
-            let mh = Multihash::wrap(NMT_MULTIHASH_CODE, &root.to_array())?;
-            let cid = Cid::new_v1(NMT_CODEC, mh);
-            let root = NamespacedHash::try_from(cid.hash().digest())?;
-
             proof
                 .verify_range(&root, &[&share], **namespace)
                 .map_err(Error::RangeProofError)?;

--- a/types/src/rsmt2d.rs
+++ b/types/src/rsmt2d.rs
@@ -23,14 +23,14 @@ pub enum AxisType {
     Col,
 }
 
-impl TryFrom<u8> for AxisType {
+impl TryFrom<i32> for AxisType {
     type Error = Error;
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(AxisType::Row),
             1 => Ok(AxisType::Col),
-            n => Err(Error::InvalidAxis(n.into())),
+            n => Err(Error::InvalidAxis(n)),
         }
     }
 }


### PR DESCRIPTION
Fixes #337 