### PR TITLE
chore(node): Fix unused `mocked` clippy

### DIFF
--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -265,7 +265,7 @@ impl P2p {
     }
 
     /// Creates and starts a new mocked p2p handler.
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(test)]
     pub fn mocked() -> (Self, crate::test_utils::MockP2pHandle) {
         let (cmd_tx, cmd_rx) = mpsc::channel(16);
         let (peer_tracker_tx, peer_tracker_rx) = watch::channel(PeerTrackerInfo::default());


### PR DESCRIPTION
Seems related to 1.80.1: https://doc.rust-lang.org/stable/releases.html#version-1801-2024-08-08