### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "celestia-proto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.6.1"
-lumina-node = { version = "0.2.0", path = "node" }
-lumina-node-wasm = { version = "0.1.1", path = "node-wasm" }
-celestia-proto = { version = "0.2.0", path = "proto" }
-celestia-rpc = { version = "0.2.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.2.0", path = "types", default-features = false }
+lumina-node = { version = "0.3.0", path = "node" }
+lumina-node-wasm = { version = "0.2.0", path = "node-wasm" }
+celestia-proto = { version = "0.3.0", path = "proto" }
+celestia-rpc = { version = "0.3.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.3.0", path = "types", default-features = false }
 libp2p = "0.54.0"
 nmt-rs = "0.2.1"
 celestia-tendermint = { version = "0.32.1", default-features = false }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.2.0...lumina-cli-v0.3.0) - 2024-08-13
+
+### Added
+- feat!(node): make syncer batch sizes configurable ([#327](https://github.com/eigerco/lumina/pull/327))
+- add support for dnsaddr resolving in browser ([#319](https://github.com/eigerco/lumina/pull/319))
+- *(node)* Generate syncing related events ([#312](https://github.com/eigerco/lumina/pull/312))
+- *(wasm)* Run Lumina in a Shared Worker ([#265](https://github.com/eigerco/lumina/pull/265))
+- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
+- *(node)* Generate events for data sampling that can be used by front-end ([#276](https://github.com/eigerco/lumina/pull/276))
+
+### Fixed
+- *(node-wasm)* require serving and providing worker script ([#313](https://github.com/eigerco/lumina/pull/313))
+
+### Other
+- remove genesis hash from node configuration ([#316](https://github.com/eigerco/lumina/pull/316))
+- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.1.0...lumina-cli-v0.2.0) - 2024-04-18
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.1.1...lumina-node-wasm-v0.2.0) - 2024-08-13
+
+### Added
+- *(node-wasm)* [**breaking**] Add websocket support ([#341](https://github.com/eigerco/lumina/pull/341))
+- feat!(node): make syncer batch sizes configurable ([#327](https://github.com/eigerco/lumina/pull/327))
+- add support for dnsaddr resolving in browser ([#319](https://github.com/eigerco/lumina/pull/319))
+- Add requesting storage persistence for more quota ([#318](https://github.com/eigerco/lumina/pull/318))
+- *(node)* Generate syncing related events ([#312](https://github.com/eigerco/lumina/pull/312))
+- *(wasm)* Run Lumina in a Shared Worker ([#265](https://github.com/eigerco/lumina/pull/265))
+- *(node)* [**breaking**] Make HeaderSession operate on a single header range again ([#303](https://github.com/eigerco/lumina/pull/303))
+- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
+- *(node-wasm)* Add human readable message on node events ([#294](https://github.com/eigerco/lumina/pull/294))
+- *(node-wasm)* Implement easier way for handling JS errors. ([#284](https://github.com/eigerco/lumina/pull/284))
+- *(node)* Generate events for data sampling that can be used by front-end ([#276](https://github.com/eigerco/lumina/pull/276))
+- *(node/daser)* [**breaking**] Implement backward sampling and sampling window ([#269](https://github.com/eigerco/lumina/pull/269))
+
+### Fixed
+- *(node-wasm)* Fix high memory consumption ([#356](https://github.com/eigerco/lumina/pull/356))
+- *(node)* [**breaking**] Do not skip header-sub reports when store writes are slow ([#333](https://github.com/eigerco/lumina/pull/333))
+- *(node)* Patch unreleased libp2p version to include syncing bug fixes ([#290](https://github.com/eigerco/lumina/pull/290))
+- *(node-wasm)* require serving and providing worker script ([#313](https://github.com/eigerco/lumina/pull/313))
+- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))
+
+### Other
+- *(node)* [**breaking**] Hide internal components ([#342](https://github.com/eigerco/lumina/pull/342))
+- remove genesis hash from node configuration ([#316](https://github.com/eigerco/lumina/pull/316))
+- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.1.0...lumina-node-wasm-v0.1.1) - 2024-04-18
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.2.0...lumina-node-v0.3.0) - 2024-08-13
+
+### Added
+- *(node)* Add tail header removal from store  ([#328](https://github.com/eigerco/lumina/pull/328))
+- *(node-wasm)* [**breaking**] Add websocket support ([#341](https://github.com/eigerco/lumina/pull/341))
+- *(node)* Trigger dial on bootnodes when all peers disconnect ([#349](https://github.com/eigerco/lumina/pull/349))
+- *(node)* Add `ConnectingToBootnodes` event ([#348](https://github.com/eigerco/lumina/pull/348))
+- *(node)* [**breaking**] Refactor errors and stop Syncer on fatal ones ([#332](https://github.com/eigerco/lumina/pull/332))
+- feat!(node): make syncer batch sizes configurable ([#327](https://github.com/eigerco/lumina/pull/327))
+- *(node)* [**breaking**] Refactor `BlockRanges` and optimize data sampling queue population ([#320](https://github.com/eigerco/lumina/pull/320))
+- add support for dnsaddr resolving in browser ([#319](https://github.com/eigerco/lumina/pull/319))
+- *(node)* Add syncing window for header sync ([#309](https://github.com/eigerco/lumina/pull/309))
+- *(node)* Generate syncing related events ([#312](https://github.com/eigerco/lumina/pull/312))
+- *(wasm)* Run Lumina in a Shared Worker ([#265](https://github.com/eigerco/lumina/pull/265))
+- *(node)* Always start data sampling of new HEAD immediately ([#306](https://github.com/eigerco/lumina/pull/306))
+- Add `#[track_caller]` on test utils and spawn utils ([#305](https://github.com/eigerco/lumina/pull/305))
+- *(node)* [**breaking**] Make HeaderSession operate on a single header range again ([#303](https://github.com/eigerco/lumina/pull/303))
+- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
+- *(node)* Close connections that failed on ping ([#289](https://github.com/eigerco/lumina/pull/289))
+- *(node)* [**breaking**] Generate events on peer connection/disconnection ([#291](https://github.com/eigerco/lumina/pull/291))
+- *(node)* Generate events for data sampling that can be used by front-end ([#276](https://github.com/eigerco/lumina/pull/276))
+- *(node/daser)* [**breaking**] Implement backward sampling and sampling window ([#269](https://github.com/eigerco/lumina/pull/269))
+
+### Fixed
+- *(node)* Compare only header hashes on syncer init ([#363](https://github.com/eigerco/lumina/pull/363))
+- *(node)* Anchor syncing on already existing header ranges ([#355](https://github.com/eigerco/lumina/pull/355))
+- *(node)* Make `yield_now` to yield execution back to JavaScript's event loop ([#354](https://github.com/eigerco/lumina/pull/354))
+- Fix clippy issues ([#350](https://github.com/eigerco/lumina/pull/350))
+- *(node)* [**breaking**] Relax initialization if HEAD is the same as the stored one ([#347](https://github.com/eigerco/lumina/pull/347))
+- Increase waiting of peers in peer_discovery test case ([#345](https://github.com/eigerco/lumina/pull/345))
+- *(node)* [**breaking**] Do not skip header-sub reports when store writes are slow ([#333](https://github.com/eigerco/lumina/pull/333))
+- *(node)* Allow syncing from header-sub as soon as node is connected ([#324](https://github.com/eigerco/lumina/pull/324))
+- *(node)* Patch unreleased libp2p version to include syncing bug fixes ([#290](https://github.com/eigerco/lumina/pull/290))
+- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))
+
+### Other
+- *(node)* [**breaking**] Upgrade libp2p to 0.54.0 ([#362](https://github.com/eigerco/lumina/pull/362))
+- *(node)* Fix unused `mocked` clippy ([#359](https://github.com/eigerco/lumina/pull/359))
+- *(node-wasm)* Upgrade libp2p-websocket-websys ([#357](https://github.com/eigerco/lumina/pull/357))
+- *(node)* [**breaking**] Hide internal components ([#342](https://github.com/eigerco/lumina/pull/342))
+- *(node)* rewording of the events display ([#329](https://github.com/eigerco/lumina/pull/329))
+- remove genesis hash from node configuration ([#316](https://github.com/eigerco/lumina/pull/316))
+- *(node)* Add comments about header validation ([#308](https://github.com/eigerco/lumina/pull/308))
+- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
+- *(node)* Replace `instant` crate with `web-time` ([#280](https://github.com/eigerco/lumina/pull/280))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.1.1...lumina-node-v0.2.0) - 2024-04-18
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.2.0...celestia-proto-v0.3.0) - 2024-08-13
+
+### Fixed
+- *(types)* [**breaking**] Align byzantine fraud proofs with Go's implementation ([#338](https://github.com/eigerco/lumina/pull/338))
+
+### Other
+- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.1.1...celestia-proto-v0.2.0) - 2024-04-18
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.2.0...celestia-rpc-v0.3.0) - 2024-08-13
+
+### Added
+- Add `#[track_caller]` on test utils and spawn utils ([#305](https://github.com/eigerco/lumina/pull/305))
+- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
+- *(rpc)* Implement WASM Client ([#210](https://github.com/eigerco/lumina/pull/210))
+- feat!(types): Add Blob::index field introduced in celestia 0.13 ([#274](https://github.com/eigerco/lumina/pull/274))
+
+### Fixed
+- *(rpc)* Increase max response size ([#336](https://github.com/eigerco/lumina/pull/336))
+- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))
+
+### Other
+- Upgrade jsonprsee to 0.24.2 ([#360](https://github.com/eigerco/lumina/pull/360))
+- [**breaking**] Upgrade to nmt-rs 0.2.0 ([#322](https://github.com/eigerco/lumina/pull/322))
+- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.1.1...celestia-rpc-v0.2.0) - 2024-04-18
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.2.0...celestia-types-v0.3.0) - 2024-08-13
+
+### Added
+- *(node)* Add syncing window for header sync ([#309](https://github.com/eigerco/lumina/pull/309))
+- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
+- feat!(types): Add Blob::index field introduced in celestia 0.13 ([#274](https://github.com/eigerco/lumina/pull/274))
+
+### Fixed
+- Fix clippy issues ([#350](https://github.com/eigerco/lumina/pull/350))
+- *(types)* [**breaking**] Align byzantine fraud proofs with Go's implementation ([#338](https://github.com/eigerco/lumina/pull/338))
+- Upgrade `time` crate to fix rust-lang/rust[#125319](https://github.com/eigerco/lumina/pull/125319) ([#285](https://github.com/eigerco/lumina/pull/285))
+- PAY_FOR_BLOB namespace ([#278](https://github.com/eigerco/lumina/pull/278))
+- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))
+
+### Other
+- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.1.1...celestia-types-v0.2.0) - 2024-04-18
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.2.0 -> 0.3.0
* `celestia-rpc`: 0.2.0 -> 0.3.0
* `celestia-types`: 0.2.0 -> 0.3.0
* `celestia-proto`: 0.2.0 -> 0.3.0
* `lumina-node`: 0.2.0 -> 0.3.0
* `lumina-node-wasm`: 0.1.1 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.2.0...lumina-cli-v0.3.0) - 2024-08-13

### Added
- feat!(node): make syncer batch sizes configurable ([#327](https://github.com/eigerco/lumina/pull/327))
- add support for dnsaddr resolving in browser ([#319](https://github.com/eigerco/lumina/pull/319))
- *(node)* Generate syncing related events ([#312](https://github.com/eigerco/lumina/pull/312))
- *(wasm)* Run Lumina in a Shared Worker ([#265](https://github.com/eigerco/lumina/pull/265))
- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
- *(node)* Generate events for data sampling that can be used by front-end ([#276](https://github.com/eigerco/lumina/pull/276))

### Fixed
- *(node-wasm)* require serving and providing worker script ([#313](https://github.com/eigerco/lumina/pull/313))

### Other
- remove genesis hash from node configuration ([#316](https://github.com/eigerco/lumina/pull/316))
- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.2.0...celestia-rpc-v0.3.0) - 2024-08-13

### Added
- Add `#[track_caller]` on test utils and spawn utils ([#305](https://github.com/eigerco/lumina/pull/305))
- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
- *(rpc)* Implement WASM Client ([#210](https://github.com/eigerco/lumina/pull/210))
- feat!(types): Add Blob::index field introduced in celestia 0.13 ([#274](https://github.com/eigerco/lumina/pull/274))

### Fixed
- *(rpc)* Increase max response size ([#336](https://github.com/eigerco/lumina/pull/336))
- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))

### Other
- Upgrade jsonprsee to 0.24.2 ([#360](https://github.com/eigerco/lumina/pull/360))
- [**breaking**] Upgrade to nmt-rs 0.2.0 ([#322](https://github.com/eigerco/lumina/pull/322))
- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
</blockquote>

## `celestia-types`
<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.2.0...celestia-types-v0.3.0) - 2024-08-13

### Added
- *(node)* Add syncing window for header sync ([#309](https://github.com/eigerco/lumina/pull/309))
- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
- feat!(types): Add Blob::index field introduced in celestia 0.13 ([#274](https://github.com/eigerco/lumina/pull/274))

### Fixed
- Fix clippy issues ([#350](https://github.com/eigerco/lumina/pull/350))
- *(types)* [**breaking**] Align byzantine fraud proofs with Go's implementation ([#338](https://github.com/eigerco/lumina/pull/338))
- Upgrade `time` crate to fix rust-lang/rust[#125319](https://github.com/eigerco/lumina/pull/125319) ([#285](https://github.com/eigerco/lumina/pull/285))
- PAY_FOR_BLOB namespace ([#278](https://github.com/eigerco/lumina/pull/278))
- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))

### Other
- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.2.0...celestia-proto-v0.3.0) - 2024-08-13

### Fixed
- *(types)* [**breaking**] Align byzantine fraud proofs with Go's implementation ([#338](https://github.com/eigerco/lumina/pull/338))

### Other
- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
</blockquote>

## `lumina-node`
<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.2.0...lumina-node-v0.3.0) - 2024-08-13

### Added
- *(node)* Add tail header removal from store  ([#328](https://github.com/eigerco/lumina/pull/328))
- *(node-wasm)* [**breaking**] Add websocket support ([#341](https://github.com/eigerco/lumina/pull/341))
- *(node)* Trigger dial on bootnodes when all peers disconnect ([#349](https://github.com/eigerco/lumina/pull/349))
- *(node)* Add `ConnectingToBootnodes` event ([#348](https://github.com/eigerco/lumina/pull/348))
- *(node)* [**breaking**] Refactor errors and stop Syncer on fatal ones ([#332](https://github.com/eigerco/lumina/pull/332))
- feat!(node): make syncer batch sizes configurable ([#327](https://github.com/eigerco/lumina/pull/327))
- *(node)* [**breaking**] Refactor `BlockRanges` and optimize data sampling queue population ([#320](https://github.com/eigerco/lumina/pull/320))
- add support for dnsaddr resolving in browser ([#319](https://github.com/eigerco/lumina/pull/319))
- *(node)* Add syncing window for header sync ([#309](https://github.com/eigerco/lumina/pull/309))
- *(node)* Generate syncing related events ([#312](https://github.com/eigerco/lumina/pull/312))
- *(wasm)* Run Lumina in a Shared Worker ([#265](https://github.com/eigerco/lumina/pull/265))
- *(node)* Always start data sampling of new HEAD immediately ([#306](https://github.com/eigerco/lumina/pull/306))
- Add `#[track_caller]` on test utils and spawn utils ([#305](https://github.com/eigerco/lumina/pull/305))
- *(node)* [**breaking**] Make HeaderSession operate on a single header range again ([#303](https://github.com/eigerco/lumina/pull/303))
- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
- *(node)* Close connections that failed on ping ([#289](https://github.com/eigerco/lumina/pull/289))
- *(node)* [**breaking**] Generate events on peer connection/disconnection ([#291](https://github.com/eigerco/lumina/pull/291))
- *(node)* Generate events for data sampling that can be used by front-end ([#276](https://github.com/eigerco/lumina/pull/276))
- *(node/daser)* [**breaking**] Implement backward sampling and sampling window ([#269](https://github.com/eigerco/lumina/pull/269))

### Fixed
- *(node)* Compare only header hashes on syncer init ([#363](https://github.com/eigerco/lumina/pull/363))
- *(node)* Anchor syncing on already existing header ranges ([#355](https://github.com/eigerco/lumina/pull/355))
- *(node)* Make `yield_now` to yield execution back to JavaScript's event loop ([#354](https://github.com/eigerco/lumina/pull/354))
- Fix clippy issues ([#350](https://github.com/eigerco/lumina/pull/350))
- *(node)* [**breaking**] Relax initialization if HEAD is the same as the stored one ([#347](https://github.com/eigerco/lumina/pull/347))
- Increase waiting of peers in peer_discovery test case ([#345](https://github.com/eigerco/lumina/pull/345))
- *(node)* [**breaking**] Do not skip header-sub reports when store writes are slow ([#333](https://github.com/eigerco/lumina/pull/333))
- *(node)* Allow syncing from header-sub as soon as node is connected ([#324](https://github.com/eigerco/lumina/pull/324))
- *(node)* Patch unreleased libp2p version to include syncing bug fixes ([#290](https://github.com/eigerco/lumina/pull/290))
- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))

### Other
- *(node)* [**breaking**] Upgrade libp2p to 0.54.0 ([#362](https://github.com/eigerco/lumina/pull/362))
- *(node)* Fix unused `mocked` clippy ([#359](https://github.com/eigerco/lumina/pull/359))
- *(node-wasm)* Upgrade libp2p-websocket-websys ([#357](https://github.com/eigerco/lumina/pull/357))
- *(node)* [**breaking**] Hide internal components ([#342](https://github.com/eigerco/lumina/pull/342))
- *(node)* rewording of the events display ([#329](https://github.com/eigerco/lumina/pull/329))
- remove genesis hash from node configuration ([#316](https://github.com/eigerco/lumina/pull/316))
- *(node)* Add comments about header validation ([#308](https://github.com/eigerco/lumina/pull/308))
- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
- *(node)* Replace `instant` crate with `web-time` ([#280](https://github.com/eigerco/lumina/pull/280))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.1.1...lumina-node-wasm-v0.2.0) - 2024-08-13

### Added
- *(node-wasm)* [**breaking**] Add websocket support ([#341](https://github.com/eigerco/lumina/pull/341))
- feat!(node): make syncer batch sizes configurable ([#327](https://github.com/eigerco/lumina/pull/327))
- add support for dnsaddr resolving in browser ([#319](https://github.com/eigerco/lumina/pull/319))
- Add requesting storage persistence for more quota ([#318](https://github.com/eigerco/lumina/pull/318))
- *(node)* Generate syncing related events ([#312](https://github.com/eigerco/lumina/pull/312))
- *(wasm)* Run Lumina in a Shared Worker ([#265](https://github.com/eigerco/lumina/pull/265))
- *(node)* [**breaking**] Make HeaderSession operate on a single header range again ([#303](https://github.com/eigerco/lumina/pull/303))
- *(node/syncer)* [**breaking**] Implement backwards header sync ([#279](https://github.com/eigerco/lumina/pull/279))
- *(node-wasm)* Add human readable message on node events ([#294](https://github.com/eigerco/lumina/pull/294))
- *(node-wasm)* Implement easier way for handling JS errors. ([#284](https://github.com/eigerco/lumina/pull/284))
- *(node)* Generate events for data sampling that can be used by front-end ([#276](https://github.com/eigerco/lumina/pull/276))
- *(node/daser)* [**breaking**] Implement backward sampling and sampling window ([#269](https://github.com/eigerco/lumina/pull/269))

### Fixed
- *(node-wasm)* Fix high memory consumption ([#356](https://github.com/eigerco/lumina/pull/356))
- *(node)* [**breaking**] Do not skip header-sub reports when store writes are slow ([#333](https://github.com/eigerco/lumina/pull/333))
- *(node)* Patch unreleased libp2p version to include syncing bug fixes ([#290](https://github.com/eigerco/lumina/pull/290))
- *(node-wasm)* require serving and providing worker script ([#313](https://github.com/eigerco/lumina/pull/313))
- new lints coming with 1.78 and 1.80-nightly ([#275](https://github.com/eigerco/lumina/pull/275))

### Other
- *(node)* [**breaking**] Hide internal components ([#342](https://github.com/eigerco/lumina/pull/342))
- remove genesis hash from node configuration ([#316](https://github.com/eigerco/lumina/pull/316))
- [**breaking**] Upgrade dependencies but exclude the ones that are patched by risc0 ([#292](https://github.com/eigerco/lumina/pull/292))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).