### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.6.1"
-lumina-node = { version = "0.3.0", path = "node" }
+lumina-node = { version = "0.3.1", path = "node" }
 lumina-node-wasm = { version = "0.2.0", path = "node-wasm" }
 celestia-proto = { version = "0.3.0", path = "proto" }
-celestia-rpc = { version = "0.3.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.3.0", path = "types", default-features = false }
+celestia-rpc = { version = "0.4.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.4.0", path = "types", default-features = false }
 libp2p = "0.54.0"
 nmt-rs = "0.2.1"
 celestia-tendermint = { version = "0.32.1", default-features = false }

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.3.0...lumina-node-v0.3.1) - 2024-08-22
+
+### Added
+- Header pruning ([#351](https://github.com/eigerco/lumina/pull/351))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.2.0...lumina-node-v0.3.0) - 2024-08-13
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.3.0...celestia-rpc-v0.4.0) - 2024-08-22
+
+### Added
+- updating API for parity with celestia-node v0.15.0 ([#340](https://github.com/eigerco/lumina/pull/340))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.2.0...celestia-rpc-v0.3.0) - 2024-08-13
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.3.0...celestia-types-v0.4.0) - 2024-08-22
+
+### Added
+- updating API for parity with celestia-node v0.15.0 ([#340](https://github.com/eigerco/lumina/pull/340))
+- Header pruning ([#351](https://github.com/eigerco/lumina/pull/351))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.2.0...celestia-types-v0.3.0) - 2024-08-13
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `celestia-rpc`: 0.3.0 -> 0.4.0
* `celestia-types`: 0.3.0 -> 0.4.0
* `lumina-node`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-rpc`
<blockquote>

## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.3.0...celestia-rpc-v0.4.0) - 2024-08-22

### Added
- updating API for parity with celestia-node v0.15.0 ([#340](https://github.com/eigerco/lumina/pull/340))
</blockquote>

## `celestia-types`
<blockquote>

## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.3.0...celestia-types-v0.4.0) - 2024-08-22

### Added
- updating API for parity with celestia-node v0.15.0 ([#340](https://github.com/eigerco/lumina/pull/340))
- Header pruning ([#351](https://github.com/eigerco/lumina/pull/351))
</blockquote>

## `lumina-node`
<blockquote>

## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.3.0...lumina-node-v0.3.1) - 2024-08-22

### Added
- Header pruning ([#351](https://github.com/eigerco/lumina/pull/351))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).