### PR TITLE
feat(node): adding agent version

### DIFF
--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -614,8 +614,7 @@ where
 
         let identify = identify::Behaviour::new(
             identify::Config::new(String::new(), args.local_keypair.public())
-                // TODO: add version number
-                .with_agent_version(String::from("lumina")),
+                .with_agent_version(format!("lumina/{}", env!("CARGO_PKG_VERSION"))),
         );
 
         let header_sub_topic = gossipsub_ident_topic(&args.network_id, "/header-sub/v0.0.1");

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -612,9 +612,10 @@ where
         let autonat = autonat::Behaviour::new(local_peer_id, autonat::Config::default());
         let ping = ping::Behaviour::new(ping::Config::default());
 
+        let agent_version = format!("lumina/{}/{}", args.network_id, env!("CARGO_PKG_VERSION"));
         let identify = identify::Behaviour::new(
             identify::Config::new(String::new(), args.local_keypair.public())
-                .with_agent_version(format!("lumina/{}", env!("CARGO_PKG_VERSION"))),
+                .with_agent_version(agent_version),
         );
 
         let header_sub_topic = gossipsub_ident_topic(&args.network_id, "/header-sub/v0.0.1");

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -612,10 +612,11 @@ where
         let autonat = autonat::Behaviour::new(local_peer_id, autonat::Config::default());
         let ping = ping::Behaviour::new(ping::Config::default());
 
-        let identify = identify::Behaviour::new(identify::Config::new(
-            String::new(),
-            args.local_keypair.public(),
-        ));
+        let identify = identify::Behaviour::new(
+            identify::Config::new(String::new(), args.local_keypair.public())
+                // TODO: add version number
+                .with_agent_version(String::from("lumina")),
+        );
 
         let header_sub_topic = gossipsub_ident_topic(&args.network_id, "/header-sub/v0.0.1");
         let bad_encoding_fraud_sub_topic =


### PR DESCRIPTION
At [ProbeLab](https://probelab.io/) we are measuring the Celestia network and producing [weekly reports](https://probelab.io/celestia/dht/2024-36/). We would like to include numbers on light nodes, however we noticed that Lumina nodes don't advertise an agent version through the libp2p identify protocol. So we cannot distinguish Lumina nodes, and we would like to include them in our statistics.

I added just the basic user agent, feel free to complete the PR and add more information, such as version number, build etc. For inspiration [`celestia-node`](https://github.com/celestiaorg/celestia-node) uses the following user agent format `celestia-node/celestia/light/v0.16.0/6744f64`.

