### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "bech32",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.4.0", path = "node" }
-lumina-node-wasm = { version = "0.3.0", path = "node-wasm" }
+lumina-node = { version = "0.4.1", path = "node" }
+lumina-node-wasm = { version = "0.3.1", path = "node-wasm" }
 celestia-proto = { version = "0.3.1", path = "proto" }
-celestia-rpc = { version = "0.4.1", path = "rpc", default-features = false }
-celestia-types = { version = "0.5.0", path = "types", default-features = false }
+celestia-rpc = { version = "0.4.2", path = "rpc", default-features = false }
+celestia-types = { version = "0.5.1", path = "types", default-features = false }
 libp2p = "0.54.0"
 nmt-rs = "0.2.1"
 celestia-tendermint = { version = "0.32.2", default-features = false }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.3.1...lumina-cli-v0.3.2) - 2024-09-25
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.3.0...lumina-cli-v0.3.1) - 2024-09-24
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.3.0...lumina-node-wasm-v0.3.1) - 2024-09-25
+
+### Other
+
+- *(node-wasm)* clarify edge case when polling worker on startup ([#390](https://github.com/eigerco/lumina/pull/390))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.2.0...lumina-node-wasm-v0.3.0) - 2024-09-24
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.3.0"
+        "lumina-node-wasm": "0.3.1"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.4.0...lumina-node-v0.4.1) - 2024-09-25
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-types, celestia-types
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.3.1...lumina-node-v0.4.0) - 2024-09-24
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.4.1...celestia-rpc-v0.4.2) - 2024-09-25
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.4.0...celestia-rpc-v0.4.1) - 2024-09-24
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.5.0...celestia-types-v0.5.1) - 2024-09-25
+
+### Added
+
+- *(types)* align for building for riscv32 ([#393](https://github.com/eigerco/lumina/pull/393))
+
 ## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.4.0...celestia-types-v0.5.0) - 2024-09-24
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `celestia-types`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `lumina-node-wasm`: 0.3.0 -> 0.3.1
* `lumina-cli`: 0.3.1 -> 0.3.2
* `celestia-rpc`: 0.4.1 -> 0.4.2
* `lumina-node`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`
<blockquote>

## [0.5.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.5.0...celestia-types-v0.5.1) - 2024-09-25

### Added

- *(types)* align for building for riscv32 ([#393](https://github.com/eigerco/lumina/pull/393))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.3.0...lumina-node-wasm-v0.3.1) - 2024-09-25

### Other

- *(node-wasm)* clarify edge case when polling worker on startup ([#390](https://github.com/eigerco/lumina/pull/390))
</blockquote>

## `lumina-cli`
<blockquote>

## [0.3.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.3.1...lumina-cli-v0.3.2) - 2024-09-25

### Other

- updated the following local packages: celestia-types
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.4.2](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.4.1...celestia-rpc-v0.4.2) - 2024-09-25

### Other

- updated the following local packages: celestia-types
</blockquote>

## `lumina-node`
<blockquote>

## [0.4.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.4.0...lumina-node-v0.4.1) - 2024-09-25

### Other

- updated the following local packages: celestia-types, celestia-types, celestia-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).