### PR TITLE
use protox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "beetswap"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +727,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "protox",
  "serde",
  "serde_json",
  "wasm-bindgen-test",
@@ -3192,6 +3199,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "logos"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.4",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,6 +3381,29 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "mime"
@@ -4064,12 +4127,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
+dependencies = [
+ "logos",
+ "miette",
+ "once_cell",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror",
 ]
 
 [[package]]
@@ -5491,6 +5594,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 [build-dependencies]
 anyhow = "1.0.86"
 prost-build = "0.12.6"
+protox = "0.6.1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.42"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -64,6 +64,24 @@ static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
 ];
 
 fn main() -> Result<()> {
+
+    println!("protox::compile_fds...");
+    let fds = protox::compile(&[
+        "vendor/celestia/da/data_availability_header.proto",
+        "vendor/celestia/blob/v1/tx.proto",
+        "vendor/header/pb/extended_header.proto",
+        "vendor/share/eds/byzantine/pb/share.proto",
+        "vendor/share/shwap/pb/shwap.proto",
+        "vendor/share/shwap/p2p/bitswap/pb/bitswap.proto",
+        "vendor/cosmos/base/v1beta1/coin.proto",
+        "vendor/cosmos/base/abci/v1beta1/abci.proto",
+        "vendor/cosmos/crypto/multisig/v1beta1/multisig.proto",
+        "vendor/cosmos/staking/v1beta1/query.proto",
+        "vendor/cosmos/tx/v1beta1/tx.proto",
+        "vendor/go-header/p2p/pb/header_request.proto",
+    ], &["vendor", "vendor/nmt"]).expect("protox faild to build");
+    println!("protox done");
+
     let mut config = prost_build::Config::new();
 
     for (type_path, attr) in CUSTOM_TYPE_ATTRIBUTES {
@@ -87,23 +105,7 @@ fn main() -> Result<()> {
         )
         // Comments in Google's protobuf are causing issues with cargo-test
         .disable_comments([".google"])
-        .compile_protos(
-            &[
-                "vendor/celestia/da/data_availability_header.proto",
-                "vendor/celestia/blob/v1/tx.proto",
-                "vendor/header/pb/extended_header.proto",
-                "vendor/share/eds/byzantine/pb/share.proto",
-                "vendor/share/shwap/pb/shwap.proto",
-                "vendor/share/shwap/p2p/bitswap/pb/bitswap.proto",
-                "vendor/cosmos/base/v1beta1/coin.proto",
-                "vendor/cosmos/base/abci/v1beta1/abci.proto",
-                "vendor/cosmos/crypto/multisig/v1beta1/multisig.proto",
-                "vendor/cosmos/staking/v1beta1/query.proto",
-                "vendor/cosmos/tx/v1beta1/tx.proto",
-                "vendor/go-header/p2p/pb/header_request.proto",
-            ],
-            &["vendor", "vendor/nmt"],
-        )?;
+        .compile_fds(fds).expect("prost failed");
 
     Ok(())
 }


### PR DESCRIPTION
Easy way to remove the `protoc` build dependency is to use [protox](https://github.com/andrewhickman/protox)