### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "celestia-proto"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.4.0", path = "node" }
-lumina-node-wasm = { version = "0.3.0", path = "node-wasm" }
-celestia-proto = { version = "0.3.1", path = "proto" }
-celestia-rpc = { version = "0.4.1", path = "rpc", default-features = false }
-celestia-types = { version = "0.5.0", path = "types", default-features = false }
+lumina-node = { version = "0.5.0", path = "node" }
+lumina-node-wasm = { version = "0.4.0", path = "node-wasm" }
+celestia-proto = { version = "0.4.0", path = "proto" }
+celestia-rpc = { version = "0.5.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.6.0", path = "types", default-features = false }
 libp2p = "0.54.0"
 nmt-rs = "0.2.1"
 celestia-tendermint = { version = "0.32.2", default-features = false }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.3.1...lumina-cli-v0.4.0) - 2024-10-03
+
+### Added
+
+- *(node,node-wasm)* [**breaking**] Integrate graceful shutdown in WASM ([#396](https://github.com/eigerco/lumina/pull/396))
+
 ## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.3.0...lumina-cli-v0.3.1) - 2024-09-24
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.3.0...lumina-node-wasm-v0.4.0) - 2024-10-03
+
+### Added
+
+- *(node,node-wasm)* [**breaking**] Integrate graceful shutdown in WASM ([#396](https://github.com/eigerco/lumina/pull/396))
+
+### Other
+
+- *(node-wasm)* Switch to bundler target for wasm-pack for manifest v3 ([#398](https://github.com/eigerco/lumina/pull/398))
+- *(node-wasm)* clarify edge case when polling worker on startup ([#390](https://github.com/eigerco/lumina/pull/390))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.2.0...lumina-node-wasm-v0.3.0) - 2024-09-24
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.3.0"
+        "lumina-node-wasm": "0.4.0"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.4.0...lumina-node-v0.5.0) - 2024-10-03
+
+### Added
+
+- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
+- *(node,node-wasm)* [**breaking**] Integrate graceful shutdown in WASM ([#396](https://github.com/eigerco/lumina/pull/396))
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.3.1...lumina-node-v0.4.0) - 2024-09-24
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.3.1...celestia-proto-v0.4.0) - 2024-10-03
+
+### Added
+
+- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
+
 ## [0.3.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.3.0...celestia-proto-v0.3.1) - 2024-09-24
 
 ### Other

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.4.1...celestia-rpc-v0.5.0) - 2024-10-03
+
+### Added
+
+- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
+
 ## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.4.0...celestia-rpc-v0.4.1) - 2024-09-24
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.5.0...celestia-types-v0.6.0) - 2024-10-03
+
+### Added
+
+- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
+- *(types)* align for building for riscv32 ([#393](https://github.com/eigerco/lumina/pull/393))
+
 ## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.4.0...celestia-types-v0.5.0) - 2024-09-24
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `celestia-rpc`: 0.4.1 -> 0.5.0 (✓ API compatible changes)
* `celestia-types`: 0.5.0 -> 0.6.0 (⚠️ API breaking changes)
* `celestia-proto`: 0.3.1 -> 0.4.0 (⚠️ API breaking changes)
* `lumina-node`: 0.4.0 -> 0.5.0 (⚠️ API breaking changes)
* `lumina-node-wasm`: 0.3.0 -> 0.4.0

### ⚠️ `celestia-types` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/inherent_method_missing.ron

Failed in:
  ExtendedDataSquare::get_namespaced_data, previously in file /tmp/.tmpNXeECZ/celestia-types/src/rsmt2d.rs:398

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/method_parameter_count_changed.ron

Failed in:
  celestia_types::sample::Sample::new now takes 4 parameters instead of 5, in /tmp/.tmpfcVWYm/lumina/types/src/sample.rs:96
  celestia_types::sample::Sample::verify now takes 3 parameters instead of 2, in /tmp/.tmpfcVWYm/lumina/types/src/sample.rs:126
  celestia_types::row::Row::new now takes 2 parameters instead of 3, in /tmp/.tmpfcVWYm/lumina/types/src/row.rs:62
  celestia_types::row::Row::verify now takes 3 parameters instead of 2, in /tmp/.tmpfcVWYm/lumina/types/src/row.rs:69

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/module_missing.ron

Failed in:
  mod celestia_types::namespaced_data, previously in file /tmp/.tmpNXeECZ/celestia-types/src/namespaced_data.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  NAMESPACED_DATA_ID_MULTIHASH_CODE in file /tmp/.tmpNXeECZ/celestia-types/src/namespaced_data.rs:24
  NAMESPACED_DATA_ID_CODEC in file /tmp/.tmpNXeECZ/celestia-types/src/namespaced_data.rs:26

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_types::namespaced_data::NamespacedData, previously in file /tmp/.tmpNXeECZ/celestia-types/src/namespaced_data.rs:45
  struct celestia_types::RawShare, previously in file /tmp/.tmpNXeECZ/celestia-types/src/share.rs:194
  struct celestia_types::NamespacedShares, previously in file /tmp/.tmpNXeECZ/celestia-types/src/share.rs:28
  struct celestia_types::NamespacedRow, previously in file /tmp/.tmpNXeECZ/celestia-types/src/share.rs:36
  struct celestia_types::namespaced_data::NamespacedDataId, previously in file /tmp/.tmpNXeECZ/celestia-types/src/namespaced_data.rs:34

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field id of struct Sample, previously in file /tmp/.tmpNXeECZ/celestia-types/src/sample.rs:46
  field id of struct Row, previously in file /tmp/.tmpNXeECZ/celestia-types/src/row.rs:43
```

### ⚠️ `celestia-proto` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_missing.ron

Failed in:
  enum celestia_proto::share::p2p::shrex::nd::StatusCode, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shrex.nd.rs:29
  enum celestia_proto::share::p2p::shwap::ProofType, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shwap.rs:40

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/module_missing.ron

Failed in:
  mod celestia_proto::share::p2p::shrex::nd, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/mod.rs:84
  mod celestia_proto::share::p2p::shrex, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/mod.rs:83
  mod celestia_proto::share::p2p::shwap, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/mod.rs:88
  mod celestia_proto::share::p2p, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/mod.rs:82

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_proto::share::p2p::shrex::nd::GetSharesByNamespaceStatusResponse, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shrex.nd.rs:12
  struct celestia_proto::share::p2p::shwap::Row, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shwap.rs:6
  struct celestia_proto::share::p2p::shwap::Data, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shwap.rs:30
  struct celestia_proto::share::p2p::shrex::nd::GetSharesByNamespaceRequest, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shrex.nd.rs:4
  struct celestia_proto::share::p2p::shwap::Sample, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shwap.rs:16
  struct celestia_proto::share::p2p::shrex::nd::NamespaceRowResponse, previously in file /tmp/.tmpNXeECZ/celestia-proto/target/semver-checks/local-celestia_proto-0_3_1/target/semver-checks/target/debug/build/celestia-proto-ec54eac5bd4df25a/out/share.p2p.shrex.nd.rs:20
```

### ⚠️ `lumina-node` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant P2pError:Shwap in /tmp/.tmpfcVWYm/lumina/node/src/p2p.rs:149

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/inherent_method_missing.ron

Failed in:
  Node::request_namespaced_data, previously in file /tmp/.tmpNXeECZ/lumina-node/src/node.rs:357
  Node::request_namespaced_data, previously in file /tmp/.tmpNXeECZ/lumina-node/src/node.rs:357
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.3.1...lumina-cli-v0.4.0) - 2024-10-03

### Added

- *(node,node-wasm)* [**breaking**] Integrate graceful shutdown in WASM ([#396](https://github.com/eigerco/lumina/pull/396))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.4.1...celestia-rpc-v0.5.0) - 2024-10-03

### Added

- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
</blockquote>

## `celestia-types`
<blockquote>

## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.5.0...celestia-types-v0.6.0) - 2024-10-03

### Added

- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
- *(types)* align for building for riscv32 ([#393](https://github.com/eigerco/lumina/pull/393))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.3.1...celestia-proto-v0.4.0) - 2024-10-03

### Added

- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
</blockquote>

## `lumina-node`
<blockquote>

## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.4.0...lumina-node-v0.5.0) - 2024-10-03

### Added

- [**breaking**] shwap protocol updates ([#369](https://github.com/eigerco/lumina/pull/369))
- *(node,node-wasm)* [**breaking**] Integrate graceful shutdown in WASM ([#396](https://github.com/eigerco/lumina/pull/396))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.3.0...lumina-node-wasm-v0.4.0) - 2024-10-03

### Added

- *(node,node-wasm)* [**breaking**] Integrate graceful shutdown in WASM ([#396](https://github.com/eigerco/lumina/pull/396))

### Other

- *(node-wasm)* Switch to bundler target for wasm-pack for manifest v3 ([#398](https://github.com/eigerco/lumina/pull/398))
- *(node-wasm)* clarify edge case when polling worker on startup ([#390](https://github.com/eigerco/lumina/pull/390))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).