### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "celestia-proto"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "celestia-tendermint-proto",
  "prost",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "bech32",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.5.0", path = "node" }
-lumina-node-wasm = { version = "0.5.0", path = "node-wasm" }
-celestia-proto = { version = "0.4.0", path = "proto" }
-celestia-rpc = { version = "0.5.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.6.0", path = "types", default-features = false }
+lumina-node = { version = "0.5.1", path = "node" }
+lumina-node-wasm = { version = "0.5.1", path = "node-wasm" }
+celestia-proto = { version = "0.4.1", path = "proto" }
+celestia-rpc = { version = "0.5.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.6.1", path = "types", default-features = false }
 libp2p = "0.54.0"
 nmt-rs = "0.2.1"
 celestia-tendermint = { version = "0.32.2", default-features = false }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.4.0...lumina-cli-v0.4.1) - 2024-10-09
+
+### Added
+
+- setup local demo page with webpack ([#388](https://github.com/eigerco/lumina/pull/388))
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.3.1...lumina-cli-v0.4.0) - 2024-10-03
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.5.0...lumina-node-wasm-v0.5.1) - 2024-10-09
+
+### Added
+
+- setup local demo page with webpack ([#388](https://github.com/eigerco/lumina/pull/388))
+
 ## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.3.0...lumina-node-wasm-v0.5.0) - 2024-10-03
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.5.0...lumina-node-v0.5.1) - 2024-10-09
+
+### Other
+
+- updated the following local packages: celestia-rpc, celestia-types, celestia-types, celestia-types, celestia-proto
+
 ## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.4.0...lumina-node-v0.5.0) - 2024-10-03
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.4.0...celestia-proto-v0.4.1) - 2024-10-09
+
+### Other
+
+- *(types)* Use protox instead of requiring protoc when building ([#402](https://github.com/eigerco/lumina/pull/402))
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.3.1...celestia-proto-v0.4.0) - 2024-10-03
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.5.0...celestia-rpc-v0.5.1) - 2024-10-09
+
+### Fixed
+
+- fix!(rpc): use correct blob type in state submit pay for blob ([#418](https://github.com/eigerco/lumina/pull/418))
+
 ## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.4.1...celestia-rpc-v0.5.0) - 2024-10-03
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.6.0...celestia-types-v0.6.1) - 2024-10-09
+
+### Added
+
+- *(types)* derive PartialOrd and Ord for addresses ([#414](https://github.com/eigerco/lumina/pull/414))
+
+### Fixed
+
+- fix!(rpc): use correct blob type in state submit pay for blob ([#418](https://github.com/eigerco/lumina/pull/418))
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.5.0...celestia-types-v0.6.0) - 2024-10-03
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.4.0 -> 0.4.1
* `celestia-rpc`: 0.5.0 -> 0.5.1
* `celestia-types`: 0.6.0 -> 0.6.1
* `celestia-proto`: 0.4.0 -> 0.4.1
* `lumina-node-wasm`: 0.5.0 -> 0.5.1
* `lumina-node`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.4.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.4.0...lumina-cli-v0.4.1) - 2024-10-09

### Added

- setup local demo page with webpack ([#388](https://github.com/eigerco/lumina/pull/388))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.5.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.5.0...celestia-rpc-v0.5.1) - 2024-10-09

### Fixed

- fix!(rpc): use correct blob type in state submit pay for blob ([#418](https://github.com/eigerco/lumina/pull/418))
</blockquote>

## `celestia-types`
<blockquote>

## [0.6.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.6.0...celestia-types-v0.6.1) - 2024-10-09

### Added

- *(types)* derive PartialOrd and Ord for addresses ([#414](https://github.com/eigerco/lumina/pull/414))

### Fixed

- fix!(rpc): use correct blob type in state submit pay for blob ([#418](https://github.com/eigerco/lumina/pull/418))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.4.0...celestia-proto-v0.4.1) - 2024-10-09

### Other

- *(types)* Use protox instead of requiring protoc when building ([#402](https://github.com/eigerco/lumina/pull/402))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.5.0...lumina-node-wasm-v0.5.1) - 2024-10-09

### Added

- setup local demo page with webpack ([#388](https://github.com/eigerco/lumina/pull/388))
</blockquote>

## `lumina-node`
<blockquote>

## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.5.0...lumina-node-v0.5.1) - 2024-10-09

### Other

- updated the following local packages: celestia-rpc, celestia-types, celestia-types, celestia-types, celestia-proto
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).