### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "celestia-proto"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "celestia-tendermint-proto",
  "prost",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.5.1", path = "node" }
-lumina-node-wasm = { version = "0.5.2", path = "node-wasm" }
-celestia-proto = { version = "0.4.1", path = "proto" }
-celestia-rpc = { version = "0.6.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.6.1", path = "types", default-features = false }
+lumina-node = { version = "0.6.0", path = "node" }
+lumina-node-wasm = { version = "0.6.0", path = "node-wasm" }
+celestia-proto = { version = "0.5.0", path = "proto" }
+celestia-rpc = { version = "0.7.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.7.0", path = "types", default-features = false }
 celestia-tendermint = { version = "0.32.2", default-features = false }
 celestia-tendermint-proto = "0.32.2"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.4.1...lumina-cli-v0.5.0) - 2024-10-25
+
+### Added
+
+- *(node,node-wasm)* [**breaking**] Allow customising syncing window size ([#442](https://github.com/eigerco/lumina/pull/442))
+
 ## [0.4.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.4.0...lumina-cli-v0.4.1) - 2024-10-11
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.5.2...lumina-node-wasm-v0.6.0) - 2024-10-25
+
+### Added
+
+- *(node,node-wasm)* [**breaking**] Allow customising syncing window size ([#442](https://github.com/eigerco/lumina/pull/442))
+
 ## [0.5.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.5.1...lumina-node-wasm-v0.5.2) - 2024-10-21
 
 ### Fixed

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -947,6 +947,19 @@ lumina\_node\_wasm.d.ts:322
 
 ***
 
+#### custom\_syncing\_window\_secs?
+
+> `optional` **custom\_syncing\_window\_secs**: `number`
+
+Syncing window size, defines maximum age of headers considered for syncing and sampling.
+Headers older than syncing window by more than an hour are eligible for pruning.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:327
+
+***
+
 #### network
 
 > **network**: [`Network`](#enumerationsnetworkmd)
@@ -955,7 +968,7 @@ A network to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:326
+lumina\_node\_wasm.d.ts:331
 
 ### Methods
 
@@ -1050,7 +1063,7 @@ lumina\_node\_wasm.d.ts:318
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:335
+lumina\_node\_wasm.d.ts:340
 
 ### Methods
 
@@ -1064,7 +1077,7 @@ lumina\_node\_wasm.d.ts:335
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:331
+lumina\_node\_wasm.d.ts:336
 
 ***
 
@@ -1078,7 +1091,7 @@ lumina\_node\_wasm.d.ts:331
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:339
+lumina\_node\_wasm.d.ts:344
 
 
 <a name="classespeertrackerinfosnapshotmd"></a>
@@ -1113,7 +1126,7 @@ Number of the connected peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:357
+lumina\_node\_wasm.d.ts:362
 
 ***
 
@@ -1125,7 +1138,7 @@ Number of the connected trusted peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:361
+lumina\_node\_wasm.d.ts:366
 
 ### Methods
 
@@ -1139,7 +1152,7 @@ lumina\_node\_wasm.d.ts:361
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:353
+lumina\_node\_wasm.d.ts:358
 
 ***
 
@@ -1155,7 +1168,7 @@ lumina\_node\_wasm.d.ts:353
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:348
+lumina\_node\_wasm.d.ts:353
 
 ***
 
@@ -1171,7 +1184,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:352
+lumina\_node\_wasm.d.ts:357
 
 
 <a name="classessyncinginfosnapshotmd"></a>
@@ -1206,7 +1219,7 @@ Ranges of headers that are already synchronised
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:379
+lumina\_node\_wasm.d.ts:384
 
 ***
 
@@ -1218,7 +1231,7 @@ Syncing target. The latest height seen in the network that was successfully veri
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:383
+lumina\_node\_wasm.d.ts:388
 
 ### Methods
 
@@ -1232,7 +1245,7 @@ lumina\_node\_wasm.d.ts:383
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:375
+lumina\_node\_wasm.d.ts:380
 
 ***
 
@@ -1248,7 +1261,7 @@ lumina\_node\_wasm.d.ts:375
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:370
+lumina\_node\_wasm.d.ts:375
 
 ***
 
@@ -1264,7 +1277,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:374
+lumina\_node\_wasm.d.ts:379
 
 # Enumerations
 

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.5.2"
+        "lumina-node-wasm": "0.6.0"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.5.1...lumina-node-v0.6.0) - 2024-10-25
+
+### Added
+
+- *(types)* [**breaking**] add blob reconstruction from shares ([#450](https://github.com/eigerco/lumina/pull/450))
+- *(node,node-wasm)* [**breaking**] Allow customising syncing window size ([#442](https://github.com/eigerco/lumina/pull/442))
+- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))
+
 ## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.5.0...lumina-node-v0.5.1) - 2024-10-11
 
 ### Other

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.4.1...celestia-proto-v0.5.0) - 2024-10-25
+
+### Added
+
+- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))
+
 ## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.4.0...celestia-proto-v0.4.1) - 2024-10-11
 
 ### Fixed

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.6.0...celestia-rpc-v0.7.0) - 2024-10-25
+
+### Added
+
+- *(types)* [**breaking**] add blob reconstruction from shares ([#450](https://github.com/eigerco/lumina/pull/450))
+- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.5.0...celestia-rpc-v0.6.0) - 2024-10-11
 
 ### Fixed

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.6.1...celestia-types-v0.7.0) - 2024-10-25
+
+### Added
+
+- *(types)* [**breaking**] add blob reconstruction from shares ([#450](https://github.com/eigerco/lumina/pull/450))
+- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))
+
+### Fixed
+
+- *(types)* axis type for eds new error reporting ([#447](https://github.com/eigerco/lumina/pull/447))
+
+### Other
+
+- *(types)* [**breaking**] Rename `rsmt2d` module to `eds` ([#449](https://github.com/eigerco/lumina/pull/449))
+
 ## [0.6.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.6.0...celestia-types-v0.6.1) - 2024-10-11
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.4.1 -> 0.5.0 (✓ API compatible changes)
* `celestia-rpc`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `celestia-types`: 0.6.1 -> 0.7.0 (⚠️ API breaking changes)
* `celestia-proto`: 0.4.1 -> 0.5.0 (✓ API compatible changes)
* `lumina-node`: 0.5.1 -> 0.6.0 (⚠️ API breaking changes)
* `lumina-node-wasm`: 0.5.2 -> 0.6.0

### ⚠️ `celestia-types` breaking changes

```
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field Share.is_parity in /tmp/.tmpbEjTqZ/lumina/types/src/share.rs:43

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:MissingShares in /tmp/.tmpbEjTqZ/lumina/types/src/error.rs:63
  variant Error:ExpectedShareWithSequenceStart in /tmp/.tmpbEjTqZ/lumina/types/src/error.rs:189
  variant Error:UnexpectedReservedNamespace in /tmp/.tmpbEjTqZ/lumina/types/src/error.rs:193
  variant Error:UnexpectedSequenceStart in /tmp/.tmpbEjTqZ/lumina/types/src/error.rs:197
  variant Error:BlobSharesMetadataMismatch in /tmp/.tmpbEjTqZ/lumina/types/src/error.rs:201

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field data of struct Share, previously in file /tmp/.tmpXpcG9e/celestia-types/src/share.rs:42

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field Share.data in file /tmp/.tmpbEjTqZ/lumina/types/src/share.rs:40
```

### ⚠️ `lumina-node` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NodeConfig.custom_syncing_window in /tmp/.tmpbEjTqZ/lumina/node/src/node.rs:80
  field NodeConfig.custom_syncing_window in /tmp/.tmpbEjTqZ/lumina/node/src/node.rs:80
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.4.1...lumina-cli-v0.5.0) - 2024-10-25

### Added

- *(node,node-wasm)* [**breaking**] Allow customising syncing window size ([#442](https://github.com/eigerco/lumina/pull/442))
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.6.0...celestia-rpc-v0.7.0) - 2024-10-25

### Added

- *(types)* [**breaking**] add blob reconstruction from shares ([#450](https://github.com/eigerco/lumina/pull/450))
- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))
</blockquote>

## `celestia-types`
<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.6.1...celestia-types-v0.7.0) - 2024-10-25

### Added

- *(types)* [**breaking**] add blob reconstruction from shares ([#450](https://github.com/eigerco/lumina/pull/450))
- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))

### Fixed

- *(types)* axis type for eds new error reporting ([#447](https://github.com/eigerco/lumina/pull/447))

### Other

- *(types)* [**breaking**] Rename `rsmt2d` module to `eds` ([#449](https://github.com/eigerco/lumina/pull/449))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.4.1...celestia-proto-v0.5.0) - 2024-10-25

### Added

- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))
</blockquote>

## `lumina-node`
<blockquote>

## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.5.1...lumina-node-v0.6.0) - 2024-10-25

### Added

- *(types)* [**breaking**] add blob reconstruction from shares ([#450](https://github.com/eigerco/lumina/pull/450))
- *(node,node-wasm)* [**breaking**] Allow customising syncing window size ([#442](https://github.com/eigerco/lumina/pull/442))
- *(types,rpc,node)* [**breaking**] refactor Share to work for parity and data ([#443](https://github.com/eigerco/lumina/pull/443))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.5.2...lumina-node-wasm-v0.6.0) - 2024-10-25

### Added

- *(node,node-wasm)* [**breaking**] Allow customising syncing window size ([#442](https://github.com/eigerco/lumina/pull/442))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).