### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.6.0", path = "node" }
-lumina-node-wasm = { version = "0.6.0", path = "node-wasm" }
+lumina-node = { version = "0.7.0", path = "node" }
+lumina-node-wasm = { version = "0.6.1", path = "node-wasm" }
 celestia-proto = { version = "0.5.0", path = "proto" }
-celestia-rpc = { version = "0.7.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.7.0", path = "types", default-features = false }
+celestia-rpc = { version = "0.7.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.8.0", path = "types", default-features = false }
 celestia-tendermint = { version = "0.32.2", default-features = false }
 celestia-tendermint-proto = "0.32.2"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.0...lumina-cli-v0.5.1) - 2024-10-31
+
+### Other
+
+- updated the following local packages: celestia-types, lumina-node
+
 ## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.4.1...lumina-cli-v0.5.0) - 2024-10-25
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.6.0...lumina-node-wasm-v0.6.1) - 2024-10-31
+
+### Other
+
+- updated the following local packages: celestia-types, lumina-node
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.5.2...lumina-node-wasm-v0.6.0) - 2024-10-25
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.6.0"
+        "lumina-node-wasm": "0.6.1"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.6.0...lumina-node-v0.7.0) - 2024-10-31
+
+### Added
+
+- feat!(node): add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.5.1...lumina-node-v0.6.0) - 2024-10-25
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.7.0...celestia-rpc-v0.7.1) - 2024-10-31
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.6.0...celestia-rpc-v0.7.0) - 2024-10-25
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.7.0...celestia-types-v0.8.0) - 2024-10-31
+
+### Added
+
+- feat!(node): add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.6.1...celestia-types-v0.7.0) - 2024-10-25
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `celestia-types`: 0.7.0 -> 0.8.0 (⚠️ API breaking changes)
* `lumina-node`: 0.6.0 -> 0.7.0 (⚠️ API breaking changes)
* `lumina-cli`: 0.5.0 -> 0.5.1
* `celestia-rpc`: 0.7.0 -> 0.7.1
* `lumina-node-wasm`: 0.6.0 -> 0.6.1

### ⚠️ `celestia-types` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:UnsupportedAppVersion in /tmp/.tmpf2kHWe/lumina/types/src/error.rs:19
```

### ⚠️ `lumina-node` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant P2pError:CelestiaTypes in /tmp/.tmpf2kHWe/lumina/node/src/p2p.rs:150

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/method_parameter_count_changed.ron

Failed in:
  lumina_node::Node::request_row now takes 4 parameters instead of 3, in /tmp/.tmpf2kHWe/lumina/node/src/node.rs:341
  lumina_node::Node::request_sample now takes 5 parameters instead of 4, in /tmp/.tmpf2kHWe/lumina/node/src/node.rs:356
  lumina_node::Node::request_row_namespace_data now takes 5 parameters instead of 4, in /tmp/.tmpf2kHWe/lumina/node/src/node.rs:375
  lumina_node::node::Node::request_row now takes 4 parameters instead of 3, in /tmp/.tmpf2kHWe/lumina/node/src/node.rs:341
  lumina_node::node::Node::request_sample now takes 5 parameters instead of 4, in /tmp/.tmpf2kHWe/lumina/node/src/node.rs:356
  lumina_node::node::Node::request_row_namespace_data now takes 5 parameters instead of 4, in /tmp/.tmpf2kHWe/lumina/node/src/node.rs:375
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`
<blockquote>

## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.7.0...celestia-types-v0.8.0) - 2024-10-31

### Added

- feat!(node): add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))
</blockquote>

## `lumina-node`
<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.6.0...lumina-node-v0.7.0) - 2024-10-31

### Added

- feat!(node): add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))
</blockquote>

## `lumina-cli`
<blockquote>

## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.0...lumina-cli-v0.5.1) - 2024-10-31

### Other

- updated the following local packages: celestia-types, lumina-node
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.7.0...celestia-rpc-v0.7.1) - 2024-10-31

### Other

- updated the following local packages: celestia-types
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.6.0...lumina-node-wasm-v0.6.1) - 2024-10-31

### Other

- updated the following local packages: celestia-types, lumina-node
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).