### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.6.0", path = "node" }
-lumina-node-wasm = { version = "0.6.0", path = "node-wasm" }
+lumina-node = { version = "0.7.0", path = "node" }
+lumina-node-wasm = { version = "0.6.1", path = "node-wasm" }
 celestia-proto = { version = "0.5.0", path = "proto" }
-celestia-rpc = { version = "0.7.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.7.0", path = "types", default-features = false }
+celestia-rpc = { version = "0.7.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.8.0", path = "types", default-features = false }
 celestia-tendermint = { version = "0.32.2", default-features = false }
 celestia-tendermint-proto = "0.32.2"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.0...lumina-cli-v0.5.1) - 2024-11-07
+
+### Other
+
+- updated the following local packages: celestia-types, lumina-node
+
 ## [0.5.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.4.1...lumina-cli-v0.5.0) - 2024-10-25
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.6.0...lumina-node-wasm-v0.6.1) - 2024-11-07
+
+### Other
+
+- update lumina-node npm package
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.5.2...lumina-node-wasm-v0.6.0) - 2024-10-25
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.6.0"
+        "lumina-node-wasm": "0.6.1"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.6.0...lumina-node-v0.7.0) - 2024-11-07
+
+### Added
+
+- *(node)* [**breaking**] add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))
+
+### Fixed
+
+- *(node)* redial peers if we go below limits ([#460](https://github.com/eigerco/lumina/pull/460))
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.5.1...lumina-node-v0.6.0) - 2024-10-25
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.7.0...celestia-rpc-v0.7.1) - 2024-11-07
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.6.0...celestia-rpc-v0.7.0) - 2024-10-25
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.7.0...celestia-types-v0.8.0) - 2024-11-07
+
+### Added
+
+- *(node)* [**breaking**] add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.6.1...celestia-types-v0.7.0) - 2024-10-25
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `celestia-types`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `lumina-node`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `lumina-cli`: 0.5.0 -> 0.5.1
* `celestia-rpc`: 0.7.0 -> 0.7.1
* `lumina-node-wasm`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`
<blockquote>

## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.7.0...celestia-types-v0.7.1) - 2024-11-07

### Added

- feat!(node): add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))
</blockquote>

## `lumina-node`
<blockquote>

## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.6.0...lumina-node-v0.6.1) - 2024-11-07

### Added

- feat!(node): add a method to get all blobs using shwap ([#452](https://github.com/eigerco/lumina/pull/452))

### Fixed

- *(node)* redial peers if we go below limits ([#460](https://github.com/eigerco/lumina/pull/460))
</blockquote>

## `lumina-cli`
<blockquote>

## [0.5.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.0...lumina-cli-v0.5.1) - 2024-11-07

### Other

- updated the following local packages: celestia-types, lumina-node
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.7.0...celestia-rpc-v0.7.1) - 2024-11-07

### Other

- updated the following local packages: celestia-types
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.6.0...lumina-node-wasm-v0.6.1) - 2024-11-07

### Other

- updated the following local packages: celestia-types, lumina-node
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).