### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "celestia-grpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "celestia-grpc-macros",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "prost",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "bech32",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ members = ["cli", "grpc", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.8.0", path = "node" }
-lumina-node-wasm = { version = "0.7.0", path = "node-wasm" }
-celestia-proto = { version = "0.6.0", path = "proto" }
-celestia-grpc = { version = "0.1.0", path = "grpc" }
+lumina-node = { version = "0.9.0", path = "node" }
+lumina-node-wasm = { version = "0.8.0", path = "node-wasm" }
+celestia-proto = { version = "0.7.0", path = "proto" }
+celestia-grpc = { version = "0.1.1", path = "grpc" }
 celestia-rpc = { version = "0.8.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.9.0", path = "types", default-features = false }
+celestia-types = { version = "0.9.1", path = "types", default-features = false }
 tendermint = { version = "0.40.0", default-features = false }
 tendermint-proto = "0.40.0"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.2...lumina-cli-v0.6.0) - 2024-12-13
+
+### Added
+
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.5.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.1...lumina-cli-v0.5.2) - 2024-12-02
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.1.0...celestia-grpc-v0.1.1) - 2024-12-13
+
+### Other
+
+- *(grpc)* Increase sleep before blob submission validation to reduce test flakyness (#481)
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-grpc-v0.1.0) - 2024-12-02
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.7.0...lumina-node-wasm-v0.8.0) - 2024-12-13
+
+### Added
+
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.6.1...lumina-node-wasm-v0.7.0) - 2024-12-02
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.8.0...lumina-node-v0.9.0) - 2024-12-13
+
+### Added
+
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.7.0...lumina-node-v0.8.0) - 2024-12-02
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.6.0...celestia-proto-v0.7.0) - 2024-12-13
+
+### Other
+
+- [**breaking**] Add notes about Celestia's Tendermint modifications (#471)
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.5.0...celestia-proto-v0.6.0) - 2024-12-02
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.9.0...celestia-types-v0.9.1) - 2024-12-13
+
+### Other
+
+- updated the following local packages: celestia-proto
+
 ## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.8.0...celestia-types-v0.9.0) - 2024-12-02
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `celestia-proto`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `lumina-node`: 0.8.0 -> 0.9.0 (⚠️ API breaking changes)
* `celestia-grpc`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-node-wasm`: 0.7.0 -> 0.8.0
* `celestia-types`: 0.9.0 -> 0.9.1

### ⚠️ `lumina-node` breaking changes

```
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Network no longer derives Copy, in /tmp/.tmp7syhq1/lumina/node/src/network.rs:13

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_added.ron

Failed in:
  variant Network:Custom in /tmp/.tmp7syhq1/lumina/node/src/network.rs:22
  variant NodeError:NodeBuilder in /tmp/.tmp7syhq1/lumina/node/src/node.rs:54
  variant NodeError:NodeBuilder in /tmp/.tmp7syhq1/lumina/node/src/node.rs:54

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Network::Private, previously in file /tmp/.tmplMSrR9/lumina-node/src/network.rs:20

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function lumina_node::network::network_id, previously in file /tmp/.tmplMSrR9/lumina-node/src/network.rs:42
  function lumina_node::test_utils::listening_test_node_config, previously in file /tmp/.tmplMSrR9/lumina-node/src/test_utils.rs:66
  function lumina_node::test_utils::test_node_config_with_keypair, previously in file /tmp/.tmplMSrR9/lumina-node/src/test_utils.rs:74
  function lumina_node::network::canonical_network_bootnodes, previously in file /tmp/.tmplMSrR9/lumina-node/src/network.rs:52
  function lumina_node::test_utils::test_node_config, previously in file /tmp/.tmplMSrR9/lumina-node/src/test_utils.rs:51

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  Node::new, previously in file /tmp/.tmplMSrR9/lumina-node/src/node.rs:110
  Node::new_subscribed, previously in file /tmp/.tmplMSrR9/lumina-node/src/node.rs:119
  Node::new, previously in file /tmp/.tmplMSrR9/lumina-node/src/node.rs:110
  Node::new_subscribed, previously in file /tmp/.tmplMSrR9/lumina-node/src/node.rs:119

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DEFAULT_SYNCING_WINDOW in file /tmp/.tmplMSrR9/lumina-node/src/syncer.rs:39

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct lumina_node::network::UnknownNetworkError, previously in file /tmp/.tmplMSrR9/lumina-node/src/network.rs:26
  struct lumina_node::node::NodeConfig, previously in file /tmp/.tmplMSrR9/lumina-node/src/node.rs:63
  struct lumina_node::NodeConfig, previously in file /tmp/.tmplMSrR9/lumina-node/src/node.rs:63
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.2...lumina-cli-v0.6.0) - 2024-12-13

### Added

- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>

## `celestia-proto`
<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.6.0...celestia-proto-v0.7.0) - 2024-12-13

### Other

- [**breaking**] Add notes about Celestia's Tendermint modifications (#471)
</blockquote>

## `lumina-node`
<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.8.0...lumina-node-v0.9.0) - 2024-12-13

### Added

- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>

## `celestia-grpc`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.1.0...celestia-grpc-v0.1.1) - 2024-12-13

### Other

- *(grpc)* Increase sleep before blob submission validation to reduce test flakyness (#481)
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.7.0...lumina-node-wasm-v0.8.0) - 2024-12-13

### Added

- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>

## `celestia-types`
<blockquote>

## [0.9.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.9.0...celestia-types-v0.9.1) - 2024-12-13

### Other

- updated the following local packages: celestia-proto
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).