### PR TITLE
feat(types): add serde feature for nmt-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tendermint = { version = "0.40.0", default-features = false }
 tendermint-proto = "0.40.0"
 
 libp2p = "0.54.0"
-nmt-rs = "0.2.1"
+nmt-rs = {version = "0.2.1", features=["serde"]}
 prost = "0.13.3"
 prost-build = "0.13.3"
 prost-types = "0.13.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tendermint = { version = "0.40.0", default-features = false }
 tendermint-proto = "0.40.0"
 
 libp2p = "0.54.0"
-nmt-rs = {version = "0.2.1", features=["serde"]}
+nmt-rs = "0.2.1"
 prost = "0.13.3"
 prost-build = "0.13.3"
 prost-types = "0.13.3"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["encoding", "cryptography::cryptocurrencies"]
 [dependencies]
 blockstore.workspace = true
 celestia-proto.workspace = true
-nmt-rs.workspace = true
+nmt-rs = { workspace = true, features = ["serde"] }
 prost.workspace = true
 tendermint = { workspace = true, features = ["std", "rust-crypto", "secp256k1"] }
 tendermint-proto.workspace = true


### PR DESCRIPTION
Adding the `serde` feature to the `nmt-rs` dep allows me to use the serde methods of nmt-rs when `celestia-types` is imported as a library