### PR TITLE
fix(types): RowNamespaceData binary deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +831,7 @@ version = "0.9.0"
 dependencies = [
  "base64",
  "bech32",
+ "bincode",
  "bitvec",
  "blockstore",
  "bytes",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -45,6 +45,7 @@ time = { version = "0.3.36", default-features = false }
 ed25519-consensus = "2.1.0"
 rand = "0.8.5"
 serde_json = "1.0.117"
+bincode = "1.3.3"
 
 # doc-tests
 indoc = "2.0.5"

--- a/types/src/row_namespace_data.rs
+++ b/types/src/row_namespace_data.rs
@@ -458,4 +458,72 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn namespace_data_roundtrip() {
+        let proof = nmt_rs::nmt_proof::NamespaceProof::<
+            crate::nmt::NamespacedSha2Hasher,
+            { crate::nmt::NS_SIZE },
+        >::AbsenceProof {
+            proof: crate::nmt::Proof {
+                siblings: vec![
+                    nmt_rs::NamespacedHash::new(
+                        nmt_rs::NamespaceId([
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 4,
+                        ]),
+                        nmt_rs::NamespaceId([
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 4,
+                        ]),
+                        [
+                            180, 43, 29, 197, 134, 127, 103, 202, 217, 240, 11, 18, 15, 47, 140,
+                            136, 58, 134, 117, 174, 162, 95, 216, 114, 31, 71, 90, 238, 49, 228,
+                            95, 89,
+                        ],
+                    ),
+                    nmt_rs::NamespacedHash::new(
+                        nmt_rs::NamespaceId::MAX_ID,
+                        nmt_rs::NamespaceId::MAX_ID,
+                        [
+                            126, 112, 141, 49, 103, 177, 23, 186, 153, 245, 110, 62, 165, 4, 39,
+                            125, 171, 55, 116, 176, 36, 153, 101, 171, 25, 253, 200, 61, 226, 43,
+                            81, 52,
+                        ],
+                    ),
+                ],
+                range: 1..2,
+            },
+            ignore_max_ns: true,
+            leaf: Some(nmt_rs::NamespacedHash::new(
+                nmt_rs::NamespaceId([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 115, 111, 118, 45,
+                    116, 101, 115, 116, 45, 112,
+                ]),
+                nmt_rs::NamespaceId([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 115, 111, 118, 45,
+                    116, 101, 115, 116, 45, 112,
+                ]),
+                [
+                    132, 118, 183, 139, 217, 27, 43, 49, 209, 15, 142, 136, 209, 205, 230, 67, 247,
+                    102, 202, 206, 118, 16, 124, 41, 208, 225, 148, 103, 192, 184, 59, 155,
+                ],
+            )),
+        };
+
+        let row = RowNamespaceData {
+            proof: proof.into(),
+            shares: vec![],
+        };
+
+        // JSON works,
+        let row_j = serde_json::to_value(&row).unwrap();
+        let d_from_json: RowNamespaceData = serde_json::from_value(row_j).unwrap();
+        assert_eq!(d_from_json, row);
+
+        // And what about bincode?
+        let s_row = bincode::serialize(&row).unwrap();
+        let d_row: RowNamespaceData = bincode::deserialize(&s_row).unwrap();
+        assert_eq!(row, d_row);
+    }
 }


### PR DESCRIPTION
I've encountered following error when have been deserializing `NamespaceData`. After some investigation I've noticed that problem stems from `RowNamespaceData`

```
called `Result::unwrap()` on an `Err` value: InvalidBoolEncoding(2)
```

Reproducible test is added as part of this PR. You can comment out actual changes and see how it fails.


I would suggest check all types that have `serde(into` to be checked against binary serialization and have symmetrical `from` or `try_from`. Those types are:


* `ExtendedDataSquare`
* `Row`
* `Sample`
