### PR TITLE
Adding symmetrical serialization to `eds`, `row` and `sample`

### DIFF
--- a/types/src/eds.rs
+++ b/types/src/eds.rs
@@ -131,7 +131,7 @@ impl Display for AxisType {
 /// [`Share`]: crate::share::Share
 /// [`DataAvailabilityHeader`]: crate::DataAvailabilityHeader
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(into = "RawExtendedDataSquare")]
+#[serde(into = "RawExtendedDataSquare", try_from = "RawExtendedDataSquare")]
 pub struct ExtendedDataSquare {
     /// The raw data of the EDS.
     data_square: Vec<Share>,
@@ -465,6 +465,14 @@ impl From<ExtendedDataSquare> for RawExtendedDataSquare {
                 .collect(),
             codec: eds.codec,
         }
+    }
+}
+
+impl TryFrom<RawExtendedDataSquare> for ExtendedDataSquare {
+    type Error = Error;
+
+    fn try_from(raw: RawExtendedDataSquare) -> std::result::Result<Self, Self::Error> {
+        ExtendedDataSquare::from_raw(raw, AppVersion::V2)
     }
 }
 

--- a/types/src/row.rs
+++ b/types/src/row.rs
@@ -50,7 +50,7 @@ pub struct RowId {
 
 /// Row together with the data
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(into = "RawRow")]
+#[serde(into = "RawRow", try_from = "RawRow")]
 pub struct Row {
     /// Shares contained in the row
     pub shares: Vec<Share>,
@@ -164,6 +164,18 @@ impl From<Row> for RawRow {
             shares_half,
             half_side: RawHalfSide::Left.into(),
         }
+    }
+}
+
+impl TryFrom<RawRow> for Row {
+    type Error = Error;
+
+    fn try_from(raw: RawRow) -> std::result::Result<Self, Self::Error> {
+        let mut shares = Vec::with_capacity(raw.shares_half.len());
+        for shr in raw.shares_half {
+            shares.push(Share::try_from(shr)?);
+        }
+        Ok(Row { shares })
     }
 }
 

--- a/types/src/sample.rs
+++ b/types/src/sample.rs
@@ -40,7 +40,7 @@ pub struct SampleId {
 
 /// Represents Sample, with proof of its inclusion
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(into = "RawSample")]
+#[serde(into = "RawSample", try_from = "RawSample")]
 pub struct Sample {
     /// Indication whether proving was done row or column-wise
     pub proof_type: AxisType,
@@ -207,6 +207,20 @@ impl From<Sample> for RawSample {
             proof: Some(sample.proof.into()),
             proof_type: sample.proof_type as i32,
         }
+    }
+}
+
+impl TryFrom<RawSample> for Sample {
+    type Error = Error;
+
+    fn try_from(raw: RawSample) -> std::result::Result<Self, Self::Error> {
+        let share = raw.share.ok_or(Error::MissingShares)?.try_into()?;
+        let proof = raw.proof.ok_or(Error::MissingProof)?.try_into()?;
+        Ok(Sample {
+            proof_type: AxisType::try_from(raw.proof_type)?,
+            share,
+            proof,
+        })
     }
 }
 


### PR DESCRIPTION
Follow up of https://github.com/eigerco/lumina/pull/493