### PR TITLE
Fix typo Update namespaced_hash.rs

### DIFF
--- a/types/src/nmt/namespaced_hash.rs
+++ b/types/src/nmt/namespaced_hash.rs
@@ -11,7 +11,7 @@ pub const HASH_SIZE: usize = 32;
 /// Byte representation of the [`NamespacedHash`].
 pub type RawNamespacedHash = [u8; NAMESPACED_HASH_SIZE];
 
-/// An extention trait for the [`NamespacedHash`] to perform additional actions.
+/// An extension trait for the [`NamespacedHash`] to perform additional actions.
 pub trait NamespacedHashExt {
     /// Get the hash of the root of an empty [`Nmt`].
     ///


### PR DESCRIPTION
# Pull Request Title
**Fix typo Update namespaced_hash.rs**

## Description
This PR fixes a typo in the `namespaced_hash.rs` file. The word "extention" has been corrected to "extension."

### Changes:
- Corrected the typo: "extention" → "extension" in the `namespaced_hash.rs` file.

## Related Issues
- #1234 (replace with relevant issue number, if applicable)

## How to Test
- Review the `namespaced_hash.rs` file to ensure the typo has been corrected.

## Checklist:
- [x] The code has been tested.
- [x] The documentation has been updated (if necessary).
- [x] I have followed the contributing guidelines.

## Notes:
- This is a minor fix and does not affect the functionality of the project.
