### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "celestia-grpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "celestia-grpc-macros",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "prost",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ members = ["cli", "grpc", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.8.0", path = "node" }
-lumina-node-wasm = { version = "0.7.0", path = "node-wasm" }
-celestia-proto = { version = "0.6.0", path = "proto" }
-celestia-grpc = { version = "0.1.0", path = "grpc" }
-celestia-rpc = { version = "0.8.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.9.0", path = "types", default-features = false }
+lumina-node = { version = "0.9.0", path = "node" }
+lumina-node-wasm = { version = "0.8.0", path = "node-wasm" }
+celestia-proto = { version = "0.7.0", path = "proto" }
+celestia-grpc = { version = "0.1.1", path = "grpc" }
+celestia-rpc = { version = "0.9.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.10.0", path = "types", default-features = false }
 tendermint = { version = "0.40.0", default-features = false }
 tendermint-proto = "0.40.0"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.2...lumina-cli-v0.6.0) - 2025-01-07
+
+### Added
+
+- Add remaining node types for wasm (#476)
+- *(cli)* Add `in-memory-store` and `pruning-delay` parameters (#490)
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.5.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.1...lumina-cli-v0.5.2) - 2024-12-02
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.1.0...celestia-grpc-v0.1.1) - 2025-01-07
+
+### Other
+
+- *(grpc)* Increase sleep before blob submission validation to reduce test flakyness (#481)
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-grpc-v0.1.0) - 2024-12-02
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.7.0...lumina-node-wasm-v0.8.0) - 2025-01-07
+
+### Added
+
+- Add remaining node types for wasm (#476)
+- *(node-wasm)* Add more configuration options in `NodeConfig` (#487)
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(node-wasm)* Update js build dependencies, commit package lock (#478)
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.6.1...lumina-node-wasm-v0.7.0) - 2024-12-02
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -1,7 +1,7 @@
 
 <a name="readmemd"></a>
 
-**lumina-node-wasm** • [**Docs**](#globalsmd)
+**lumina-node-wasm**
 
 ***
 
@@ -57,7 +57,7 @@ For comprehensive and fully typed interface documentation, see [lumina-node](htt
 
 <a name="classesblockrangemd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -66,16 +66,6 @@ For comprehensive and fully typed interface documentation, see [lumina-node](htt
 ## Class: BlockRange
 
 A range of blocks between `start` and `end` height, inclusive
-
-### Constructors
-
-#### new BlockRange()
-
-> **new BlockRange**(): [`BlockRange`](#classesblockrangemd)
-
-##### Returns
-
-[`BlockRange`](#classesblockrangemd)
 
 ### Properties
 
@@ -87,7 +77,7 @@ Last block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:44
+lumina\_node\_wasm.d.ts:66
 
 ***
 
@@ -99,7 +89,7 @@ First block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:48
+lumina\_node\_wasm.d.ts:62
 
 ### Methods
 
@@ -113,7 +103,7 @@ lumina\_node\_wasm.d.ts:48
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:40
+lumina\_node\_wasm.d.ts:58
 
 ***
 
@@ -129,7 +119,7 @@ lumina\_node\_wasm.d.ts:40
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:35
+lumina\_node\_wasm.d.ts:53
 
 ***
 
@@ -145,28 +135,18 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:39
+lumina\_node\_wasm.d.ts:57
 
 
 <a name="classesconnectioncounterssnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
 [lumina-node-wasm](#globalsmd) / ConnectionCountersSnapshot
 
 ## Class: ConnectionCountersSnapshot
-
-### Constructors
-
-#### new ConnectionCountersSnapshot()
-
-> **new ConnectionCountersSnapshot**(): [`ConnectionCountersSnapshot`](#classesconnectioncounterssnapshotmd)
-
-##### Returns
-
-[`ConnectionCountersSnapshot`](#classesconnectioncounterssnapshotmd)
 
 ### Properties
 
@@ -178,7 +158,7 @@ The total number of connections, both pending and established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:65
+lumina\_node\_wasm.d.ts:82
 
 ***
 
@@ -190,7 +170,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:69
+lumina\_node\_wasm.d.ts:98
 
 ***
 
@@ -202,7 +182,7 @@ The number of established incoming connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:73
+lumina\_node\_wasm.d.ts:102
 
 ***
 
@@ -214,7 +194,7 @@ The number of established outgoing connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:77
+lumina\_node\_wasm.d.ts:106
 
 ***
 
@@ -226,7 +206,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:81
+lumina\_node\_wasm.d.ts:86
 
 ***
 
@@ -238,7 +218,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:85
+lumina\_node\_wasm.d.ts:90
 
 ***
 
@@ -250,7 +230,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:89
+lumina\_node\_wasm.d.ts:94
 
 ### Methods
 
@@ -264,7 +244,7 @@ lumina\_node\_wasm.d.ts:89
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:61
+lumina\_node\_wasm.d.ts:78
 
 ***
 
@@ -280,7 +260,7 @@ lumina\_node\_wasm.d.ts:61
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:56
+lumina\_node\_wasm.d.ts:73
 
 ***
 
@@ -296,12 +276,551 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:60
+lumina\_node\_wasm.d.ts:77
+
+
+<a name="classesdataavailabilityheadermd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / DataAvailabilityHeader
+
+## Class: DataAvailabilityHeader
+
+Header with commitments of the data availability.
+
+It consists of the root hashes of the merkle trees created from each
+row and column of the [`ExtendedDataSquare`]. Those are used to prove
+the inclusion of the data in a block.
+
+The hash of this header is a hash of all rows and columns and thus a
+data commitment of the block.
+
+## Example
+
+```no_run
+## use celestia_types::{ExtendedHeader, Height, Share};
+## use celestia_types::nmt::{Namespace, NamespaceProof};
+## fn extended_header() -> ExtendedHeader {
+##     unimplemented!();
+## }
+## fn shares_with_proof(_: Height, _: &Namespace) -> (Vec<Share>, NamespaceProof) {
+##     unimplemented!();
+## }
+// fetch the block header and data for your namespace
+let namespace = Namespace::new_v0(&[1, 2, 3, 4]).unwrap();
+let eh = extended_header();
+let (shares, proof) = shares_with_proof(eh.height(), &namespace);
+
+// get the data commitment for a given row
+let dah = eh.dah;
+let root = dah.row_root(0).unwrap();
+
+// verify a proof of the inclusion of the shares
+assert!(proof.verify_complete_namespace(&root, &shares, *namespace).is_ok());
+```
+
+[`ExtendedDataSquare`]: crate::eds::ExtendedDataSquare
+
+### Methods
+
+#### columnRoot()
+
+> **columnRoot**(`column`): `any`
+
+Get the a root of the column with the given index.
+
+##### Parameters
+
+###### column
+
+`number`
+
+##### Returns
+
+`any`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:170
+
+***
+
+#### columnRoots()
+
+> **columnRoots**(): `any`[]
+
+Merkle roots of the [`ExtendedDataSquare`] columns.
+
+##### Returns
+
+`any`[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:162
+
+***
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:154
+
+***
+
+#### hash()
+
+> **hash**(): `any`
+
+Compute the combined hash of all rows and columns.
+
+This is the data commitment for the block.
+
+##### Returns
+
+`any`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:176
+
+***
+
+#### rowRoot()
+
+> **rowRoot**(`row`): `any`
+
+Get a root of the row with the given index.
+
+##### Parameters
+
+###### row
+
+`number`
+
+##### Returns
+
+`any`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:166
+
+***
+
+#### rowRoots()
+
+> **rowRoots**(): `any`[]
+
+Merkle roots of the [`ExtendedDataSquare`] rows.
+
+##### Returns
+
+`any`[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:158
+
+***
+
+#### squareWidth()
+
+> **squareWidth**(): `number`
+
+Get the size of the [`ExtendedDataSquare`] for which this header was built.
+
+##### Returns
+
+`number`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:180
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:149
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:153
+
+
+<a name="classesextendedheadermd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ExtendedHeader
+
+## Class: ExtendedHeader
+
+Block header together with the relevant Data Availability metadata.
+
+[`ExtendedHeader`]s are used to announce and describe the blocks
+in the Celestia network.
+
+Before being used, each header should be validated and verified with a header you trust.
+
+## Example
+
+```
+## use celestia_types::ExtendedHeader;
+## fn trusted_genesis_header() -> ExtendedHeader {
+##     let s = include_str!("../test_data/chain1/extended_header_block_1.json");
+##     serde_json::from_str(s).unwrap()
+## }
+## fn some_untrusted_header() -> ExtendedHeader {
+##     let s = include_str!("../test_data/chain1/extended_header_block_27.json");
+##     serde_json::from_str(s).unwrap()
+## }
+let genesis_header = trusted_genesis_header();
+
+// fetch new header
+let fetched_header = some_untrusted_header();
+
+fetched_header.validate().expect("Invalid block header");
+genesis_header.verify(&fetched_header).expect("Malicious header received");
+```
+
+### Properties
+
+#### commit
+
+> `readonly` **commit**: `any`
+
+Commit metadata and signatures from validators committing the block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:311
+
+***
+
+#### dah
+
+> **dah**: [`DataAvailabilityHeader`](#classesdataavailabilityheadermd)
+
+Header of the block data availability.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:303
+
+***
+
+#### header
+
+> `readonly` **header**: `any`
+
+Tendermint block header.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:307
+
+***
+
+#### validatorSet
+
+> `readonly` **validatorSet**: `any`
+
+Information about the set of validators commiting the block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:315
+
+### Methods
+
+#### clone()
+
+> **clone**(): [`ExtendedHeader`](#classesextendedheadermd)
+
+Clone a header producing a deep copy of it.
+
+##### Returns
+
+[`ExtendedHeader`](#classesextendedheadermd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:225
+
+***
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:221
+
+***
+
+#### hash()
+
+> **hash**(): `string`
+
+Get the block hash.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:237
+
+***
+
+#### height()
+
+> **height**(): `bigint`
+
+Get the block height.
+
+##### Returns
+
+`bigint`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:229
+
+***
+
+#### previousHeaderHash()
+
+> **previousHeaderHash**(): `string`
+
+Get the hash of the previous header.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:241
+
+***
+
+#### time()
+
+> **time**(): `number`
+
+Get the block time.
+
+##### Returns
+
+`number`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:233
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:216
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:220
+
+***
+
+#### validate()
+
+> **validate**(): `void`
+
+Decode protobuf encoded header and then validate it.
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:245
+
+***
+
+#### verify()
+
+> **verify**(`untrusted`): `void`
+
+Verify a chain of adjacent untrusted headers and make sure
+they are adjacent to `self`.
+
+## Errors
+
+If verification fails, this function will return an error with a reason of failure.
+This function will also return an error if untrusted headers and `self` don't form contiguous range
+
+##### Parameters
+
+###### untrusted
+
+[`ExtendedHeader`](#classesextendedheadermd)
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:255
+
+***
+
+#### verifyAdjacentRange()
+
+> **verifyAdjacentRange**(`untrusted`): `void`
+
+Verify a chain of adjacent untrusted headers and make sure
+they are adjacent to `self`.
+
+## Note
+
+Provided headers will be consumed by this method, meaning
+they will no longer be accessible. If this behavior is not desired,
+consider using `ExtendedHeader.clone()`.
+
+```js
+const genesis = hdr0;
+const headers = [hrd1, hdr2, hdr3];
+genesis.verifyAdjacentRange(headers.map(h => h.clone()));
+```
+
+## Errors
+
+If verification fails, this function will return an error with a reason of failure.
+This function will also return an error if untrusted headers and `self` don't form contiguous range
+
+##### Parameters
+
+###### untrusted
+
+[`ExtendedHeader`](#classesextendedheadermd)[]
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:299
+
+***
+
+#### verifyRange()
+
+> **verifyRange**(`untrusted`): `void`
+
+Verify a chain of adjacent untrusted headers.
+
+## Note
+
+Provided headers will be consumed by this method, meaning
+they will no longer be accessible. If this behavior is not desired,
+consider using `ExtendedHeader.clone()`.
+
+```js
+const genesis = hdr0;
+const headers = [hrd1, hdr2, hdr3];
+genesis.verifyRange(headers.map(h => h.clone()));
+```
+
+## Errors
+
+If verification fails, this function will return an error with a reason of failure.
+This function will also return an error if untrusted headers are not adjacent
+to each other.
+
+##### Parameters
+
+###### untrusted
+
+[`ExtendedHeader`](#classesextendedheadermd)[]
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:277
 
 
 <a name="classesnetworkinfosnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -310,16 +829,6 @@ lumina\_node\_wasm.d.ts:60
 ## Class: NetworkInfoSnapshot
 
 Information about the connections
-
-### Constructors
-
-#### new NetworkInfoSnapshot()
-
-> **new NetworkInfoSnapshot**(): [`NetworkInfoSnapshot`](#classesnetworkinfosnapshotmd)
-
-##### Returns
-
-[`NetworkInfoSnapshot`](#classesnetworkinfosnapshotmd)
 
 ### Properties
 
@@ -331,7 +840,7 @@ Gets counters for ongoing network connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:107
+lumina\_node\_wasm.d.ts:338
 
 ***
 
@@ -343,7 +852,7 @@ The number of connected peers, i.e. peers with whom at least one established con
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:111
+lumina\_node\_wasm.d.ts:334
 
 ### Methods
 
@@ -357,7 +866,7 @@ lumina\_node\_wasm.d.ts:111
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:103
+lumina\_node\_wasm.d.ts:330
 
 ***
 
@@ -373,7 +882,7 @@ lumina\_node\_wasm.d.ts:103
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:98
+lumina\_node\_wasm.d.ts:325
 
 ***
 
@@ -389,12 +898,12 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:102
+lumina\_node\_wasm.d.ts:329
 
 
 <a name="classesnodeclientmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -418,7 +927,9 @@ expected to have `MessagePort`-like interface for sending and receiving messages
 
 ##### Parameters
 
-• **port**: `any`
+###### port
+
+`any`
 
 ##### Returns
 
@@ -426,7 +937,7 @@ expected to have `MessagePort`-like interface for sending and receiving messages
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:126
+lumina\_node\_wasm.d.ts:352
 
 ### Methods
 
@@ -438,7 +949,9 @@ Establish a new connection to the existing worker over provided port
 
 ##### Parameters
 
-• **port**: `any`
+###### port
+
+`any`
 
 ##### Returns
 
@@ -446,7 +959,7 @@ Establish a new connection to the existing worker over provided port
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:132
+lumina\_node\_wasm.d.ts:356
 
 ***
 
@@ -462,7 +975,7 @@ Get all the peers that node is connected to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:182
+lumina\_node\_wasm.d.ts:393
 
 ***
 
@@ -478,7 +991,7 @@ Returns a [`BroadcastChannel`] for events generated by [`Node`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:298
+lumina\_node\_wasm.d.ts:473
 
 ***
 
@@ -492,13 +1005,13 @@ lumina\_node\_wasm.d.ts:298
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:120
+lumina\_node\_wasm.d.ts:347
 
 ***
 
 #### getHeaderByHash()
 
-> **getHeaderByHash**(`hash`): `Promise`\<`any`\>
+> **getHeaderByHash**(`hash`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get a synced header for the block with a given hash.
 
@@ -507,21 +1020,23 @@ https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
 
 ##### Parameters
 
-• **hash**: `string`
+###### hash
+
+`string`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:257
+lumina\_node\_wasm.d.ts:440
 
 ***
 
 #### getHeaderByHeight()
 
-> **getHeaderByHeight**(`height`): `Promise`\<`any`\>
+> **getHeaderByHeight**(`height`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get a synced header for the block with a given height.
 
@@ -530,21 +1045,23 @@ https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
 
 ##### Parameters
 
-• **height**: `bigint`
+###### height
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:266
+lumina\_node\_wasm.d.ts:447
 
 ***
 
 #### getHeaders()
 
-> **getHeaders**(`start_height`?, `end_height`?): `Promise`\<`any`[]\>
+> **getHeaders**(`start_height`?, `end_height`?): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 Get synced headers from the given heights range.
 
@@ -561,23 +1078,27 @@ https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
 
 ##### Parameters
 
-• **start\_height?**: `bigint`
+###### start\_height?
 
-• **end\_height?**: `bigint`
+`bigint`
+
+###### end\_height?
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`[]\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:284
+lumina\_node\_wasm.d.ts:462
 
 ***
 
 #### getLocalHeadHeader()
 
-> **getLocalHeadHeader**(): `Promise`\<`any`\>
+> **getLocalHeadHeader**(): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get the latest locally synced header.
 
@@ -586,17 +1107,17 @@ https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:248
+lumina\_node\_wasm.d.ts:433
 
 ***
 
 #### getNetworkHeadHeader()
 
-> **getNetworkHeadHeader**(): `Promise`\<`any`\>
+> **getNetworkHeadHeader**(): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get the latest header announced in the network.
 
@@ -605,17 +1126,17 @@ https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:240
+lumina\_node\_wasm.d.ts:426
 
 ***
 
 #### getSamplingMetadata()
 
-> **getSamplingMetadata**(`height`): `Promise`\<`any`\>
+> **getSamplingMetadata**(`height`): `Promise`\<[`SamplingMetadata`](#classessamplingmetadatamd)\>
 
 Get data sampling metadata of an already sampled height.
 
@@ -624,15 +1145,17 @@ https://docs.rs/lumina-node/latest/lumina_node/store/struct.SamplingMetadata.htm
 
 ##### Parameters
 
-• **height**: `bigint`
+###### height
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`SamplingMetadata`](#classessamplingmetadatamd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:293
+lumina\_node\_wasm.d.ts:469
 
 ***
 
@@ -648,7 +1171,7 @@ Check whether Lumina is currently running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:137
+lumina\_node\_wasm.d.ts:360
 
 ***
 
@@ -664,7 +1187,7 @@ Get all the multiaddresses on which the node listens.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:177
+lumina\_node\_wasm.d.ts:389
 
 ***
 
@@ -680,7 +1203,7 @@ Get node's local peer ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:152
+lumina\_node\_wasm.d.ts:369
 
 ***
 
@@ -696,7 +1219,7 @@ Get current network info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:172
+lumina\_node\_wasm.d.ts:385
 
 ***
 
@@ -712,99 +1235,95 @@ Get current [`PeerTracker`] info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:157
+lumina\_node\_wasm.d.ts:373
 
 ***
 
 #### requestHeaderByHash()
 
-> **requestHeaderByHash**(`hash`): `Promise`\<`any`\>
+> **requestHeaderByHash**(`hash`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Request a header for the block with a given hash from the network.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **hash**: `string`
+###### hash
+
+`string`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:206
+lumina\_node\_wasm.d.ts:405
 
 ***
 
 #### requestHeaderByHeight()
 
-> **requestHeaderByHeight**(`height`): `Promise`\<`any`\>
+> **requestHeaderByHeight**(`height`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Request a header for the block with a given height from the network.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **height**: `bigint`
+###### height
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:215
+lumina\_node\_wasm.d.ts:409
 
 ***
 
 #### requestHeadHeader()
 
-> **requestHeadHeader**(): `Promise`\<`any`\>
+> **requestHeadHeader**(): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Request the head header from the network.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:197
+lumina\_node\_wasm.d.ts:401
 
 ***
 
 #### requestVerifiedHeaders()
 
-> **requestVerifiedHeaders**(`from_header`, `amount`): `Promise`\<`any`[]\>
+> **requestVerifiedHeaders**(`from`, `amount`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 Request headers in range (from, from + amount] from the network.
 
 The headers will be verified with the `from` header.
 
-Returns an array of javascript objects with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **from\_header**: `any`
+###### from
 
-• **amount**: `bigint`
+[`ExtendedHeader`](#classesextendedheadermd)
+
+###### amount
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`[]\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:227
+lumina\_node\_wasm.d.ts:415
 
 ***
 
@@ -816,9 +1335,13 @@ Trust or untrust the peer with a given ID.
 
 ##### Parameters
 
-• **peer\_id**: `string`
+###### peer\_id
 
-• **is\_trusted**: `boolean`
+`string`
+
+###### is\_trusted
+
+`boolean`
 
 ##### Returns
 
@@ -826,7 +1349,7 @@ Trust or untrust the peer with a given ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:189
+lumina\_node\_wasm.d.ts:397
 
 ***
 
@@ -838,7 +1361,9 @@ Start a node with the provided config, if it's not running
 
 ##### Parameters
 
-• **config**: [`NodeConfig`](#classesnodeconfigmd)
+###### config
+
+[`NodeConfig`](#classesnodeconfigmd)
 
 ##### Returns
 
@@ -846,7 +1371,7 @@ Start a node with the provided config, if it's not running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:143
+lumina\_node\_wasm.d.ts:364
 
 ***
 
@@ -860,7 +1385,7 @@ lumina\_node\_wasm.d.ts:143
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:147
+lumina\_node\_wasm.d.ts:365
 
 ***
 
@@ -876,7 +1401,7 @@ Get current header syncing info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:232
+lumina\_node\_wasm.d.ts:419
 
 ***
 
@@ -892,7 +1417,7 @@ Wait until the node is connected to at least 1 peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:162
+lumina\_node\_wasm.d.ts:377
 
 ***
 
@@ -908,12 +1433,12 @@ Wait until the node is connected to at least 1 trusted peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:167
+lumina\_node\_wasm.d.ts:381
 
 
 <a name="classesnodeconfigmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -922,16 +1447,6 @@ lumina\_node\_wasm.d.ts:167
 ## Class: NodeConfig
 
 Config for the lumina wasm node.
-
-### Constructors
-
-#### new NodeConfig()
-
-> **new NodeConfig**(): [`NodeConfig`](#classesnodeconfigmd)
-
-##### Returns
-
-[`NodeConfig`](#classesnodeconfigmd)
 
 ### Properties
 
@@ -943,20 +1458,46 @@ A list of bootstrap peers to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:322
+lumina\_node\_wasm.d.ts:500
 
 ***
 
-#### custom\_syncing\_window\_secs?
+#### custom\_pruning\_delay\_secs?
 
-> `optional` **custom\_syncing\_window\_secs**: `number`
+> `optional` **custom\_pruning\_delay\_secs**: `number`
 
-Syncing window size, defines maximum age of headers considered for syncing and sampling.
-Headers older than syncing window by more than an hour are eligible for pruning.
+Pruning delay defines how much time the pruner should wait after sampling window in
+order to prune the block.
+
+If this is not set, then default value will apply:
+
+* If `use_persistent_memory == true`, default value is 1 hour.
+* If `use_persistent_memory == false`, default value is 60 seconds.
+
+The minimum value that can be set is 60 seconds.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:327
+lumina\_node\_wasm.d.ts:529
+
+***
+
+#### custom\_sampling\_window\_secs?
+
+> `optional` **custom\_sampling\_window\_secs**: `number`
+
+Sampling window defines maximum age of a block considered for syncing and sampling.
+
+If this is not set, then default value will apply:
+
+* If `use_persistent_memory == true`, default value is 30 days.
+* If `use_persistent_memory == false`, default value is 60 seconds.
+
+The minimum value that can be set is 60 seconds.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:517
 
 ***
 
@@ -968,7 +1509,21 @@ A network to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:331
+lumina\_node\_wasm.d.ts:496
+
+***
+
+#### use\_persistent\_memory
+
+> **use\_persistent\_memory**: `boolean`
+
+Whether to store data in persistent memory or not.
+
+**Default value:** true
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:506
 
 ### Methods
 
@@ -982,7 +1537,7 @@ lumina\_node\_wasm.d.ts:331
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:312
+lumina\_node\_wasm.d.ts:488
 
 ***
 
@@ -998,7 +1553,7 @@ lumina\_node\_wasm.d.ts:312
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:307
+lumina\_node\_wasm.d.ts:483
 
 ***
 
@@ -1014,7 +1569,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:311
+lumina\_node\_wasm.d.ts:487
 
 ***
 
@@ -1026,7 +1581,9 @@ Get the configuration with default bootnodes for provided network
 
 ##### Parameters
 
-• **network**: [`Network`](#enumerationsnetworkmd)
+###### network
+
+[`Network`](#enumerationsnetworkmd)
 
 ##### Returns
 
@@ -1034,12 +1591,12 @@ Get the configuration with default bootnodes for provided network
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:318
+lumina\_node\_wasm.d.ts:492
 
 
 <a name="classesnodeworkermd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1060,7 +1617,9 @@ them and sending a response back, as well as accepting new `NodeClient` connecti
 
 ##### Parameters
 
-• **port\_like\_object**: `any`
+###### port\_like\_object
+
+`any`
 
 ##### Returns
 
@@ -1068,7 +1627,7 @@ them and sending a response back, as well as accepting new `NodeClient` connecti
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:344
+lumina\_node\_wasm.d.ts:539
 
 ### Methods
 
@@ -1082,7 +1641,7 @@ lumina\_node\_wasm.d.ts:344
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:340
+lumina\_node\_wasm.d.ts:538
 
 ***
 
@@ -1096,12 +1655,12 @@ lumina\_node\_wasm.d.ts:340
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:348
+lumina\_node\_wasm.d.ts:540
 
 
 <a name="classespeertrackerinfosnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1110,16 +1669,6 @@ lumina\_node\_wasm.d.ts:348
 ## Class: PeerTrackerInfoSnapshot
 
 Statistics of the connected peers
-
-### Constructors
-
-#### new PeerTrackerInfoSnapshot()
-
-> **new PeerTrackerInfoSnapshot**(): [`PeerTrackerInfoSnapshot`](#classespeertrackerinfosnapshotmd)
-
-##### Returns
-
-[`PeerTrackerInfoSnapshot`](#classespeertrackerinfosnapshotmd)
 
 ### Properties
 
@@ -1131,7 +1680,7 @@ Number of the connected peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:366
+lumina\_node\_wasm.d.ts:559
 
 ***
 
@@ -1143,7 +1692,7 @@ Number of the connected trusted peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:370
+lumina\_node\_wasm.d.ts:563
 
 ### Methods
 
@@ -1157,7 +1706,7 @@ lumina\_node\_wasm.d.ts:370
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:362
+lumina\_node\_wasm.d.ts:555
 
 ***
 
@@ -1173,7 +1722,7 @@ lumina\_node\_wasm.d.ts:362
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:357
+lumina\_node\_wasm.d.ts:550
 
 ***
 
@@ -1189,12 +1738,65 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:361
+lumina\_node\_wasm.d.ts:554
+
+
+<a name="classessamplingmetadatamd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / SamplingMetadata
+
+## Class: SamplingMetadata
+
+Sampling metadata for a block.
+
+This struct persists DAS-ing information in a header store for future reference.
+
+### Properties
+
+#### cids
+
+> `readonly` **cids**: `Uint8Array`\<`ArrayBuffer`\>[]
+
+Return Array of cids
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:580
+
+***
+
+#### status
+
+> **status**: [`SamplingStatus`](#enumerationssamplingstatusmd)
+
+Indicates whether this node was able to successfuly sample the block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:576
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:572
 
 
 <a name="classessyncinginfosnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1203,16 +1805,6 @@ lumina\_node\_wasm.d.ts:361
 ## Class: SyncingInfoSnapshot
 
 Status of the synchronization.
-
-### Constructors
-
-#### new SyncingInfoSnapshot()
-
-> **new SyncingInfoSnapshot**(): [`SyncingInfoSnapshot`](#classessyncinginfosnapshotmd)
-
-##### Returns
-
-[`SyncingInfoSnapshot`](#classessyncinginfosnapshotmd)
 
 ### Properties
 
@@ -1224,7 +1816,7 @@ Ranges of headers that are already synchronised
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:388
+lumina\_node\_wasm.d.ts:599
 
 ***
 
@@ -1236,7 +1828,7 @@ Syncing target. The latest height seen in the network that was successfully veri
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:392
+lumina\_node\_wasm.d.ts:603
 
 ### Methods
 
@@ -1250,7 +1842,7 @@ lumina\_node\_wasm.d.ts:392
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:384
+lumina\_node\_wasm.d.ts:595
 
 ***
 
@@ -1266,7 +1858,7 @@ lumina\_node\_wasm.d.ts:384
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:379
+lumina\_node\_wasm.d.ts:590
 
 ***
 
@@ -1282,14 +1874,14 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:383
+lumina\_node\_wasm.d.ts:594
 
 # Enumerations
 
 
 <a name="enumerationsnetworkmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1347,12 +1939,61 @@ Private local network.
 
 lumina\_node\_wasm.d.ts:26
 
+
+<a name="enumerationssamplingstatusmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / SamplingStatus
+
+## Enumeration: SamplingStatus
+
+Sampling status for a block.
+
+### Enumeration Members
+
+#### Accepted
+
+> **Accepted**: `1`
+
+Sampling is done and block is accepted.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:39
+
+***
+
+#### Rejected
+
+> **Rejected**: `2`
+
+Sampling is done and block is rejected.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:43
+
+***
+
+#### Unknown
+
+> **Unknown**: `0`
+
+Sampling is not done.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:35
+
 # Functions
 
 
 <a name="functionssetup_loggingmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1375,7 +2016,7 @@ lumina\_node\_wasm.d.ts:6
 
 <a name="globalsmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1384,16 +2025,20 @@ lumina\_node\_wasm.d.ts:6
 ## Enumerations
 
 - [Network](#enumerationsnetworkmd)
+- [SamplingStatus](#enumerationssamplingstatusmd)
 
 ## Classes
 
 - [BlockRange](#classesblockrangemd)
 - [ConnectionCountersSnapshot](#classesconnectioncounterssnapshotmd)
+- [DataAvailabilityHeader](#classesdataavailabilityheadermd)
+- [ExtendedHeader](#classesextendedheadermd)
 - [NetworkInfoSnapshot](#classesnetworkinfosnapshotmd)
 - [NodeClient](#classesnodeclientmd)
 - [NodeConfig](#classesnodeconfigmd)
 - [NodeWorker](#classesnodeworkermd)
 - [PeerTrackerInfoSnapshot](#classespeertrackerinfosnapshotmd)
+- [SamplingMetadata](#classessamplingmetadatamd)
 - [SyncingInfoSnapshot](#classessyncinginfosnapshotmd)
 
 ## Functions

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.7.0"
+        "lumina-node-wasm": "0.8.0"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.8.0...lumina-node-v0.9.0) - 2025-01-07
+
+### Added
+
+- Add remaining node types for wasm (#476)
+- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
+- *(node)* Implement `EitherStore` combinator struct (#484)
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.7.0...lumina-node-v0.8.0) - 2024-12-02
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.6.0...celestia-proto-v0.7.0) - 2025-01-07
+
+### Other
+
+- [**breaking**] Add notes about Celestia's Tendermint modifications (#471)
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.5.0...celestia-proto-v0.6.0) - 2024-12-02
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.8.0...celestia-rpc-v0.9.0) - 2025-01-07
+
+### Added
+
+- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.7.1...celestia-rpc-v0.8.0) - 2024-12-02
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.9.0...celestia-types-v0.10.0) - 2025-01-07
+
+### Added
+
+- Add remaining node types for wasm (#476)
+- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
+
+### Fixed
+
+- *(types)* RowNamespaceData binary deserialization (#493)
+
 ## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.8.0...celestia-types-v0.9.0) - 2024-12-02
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `celestia-rpc`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `celestia-types`: 0.9.0 -> 0.10.0 (⚠️ API breaking changes)
* `celestia-proto`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `lumina-node`: 0.8.0 -> 0.9.0 (⚠️ API breaking changes)
* `celestia-grpc`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `lumina-node-wasm`: 0.7.0 -> 0.8.0

### ⚠️ `celestia-types` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_types::TxConfig, previously in file /tmp/.tmpAdb1bm/celestia-types/src/tx_config.rs:15
```

### ⚠️ `lumina-node` breaking changes

```
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Network no longer derives Copy, in /tmp/.tmplDFfBG/lumina/node/src/network.rs:13

--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum Network in /tmp/.tmplDFfBG/lumina/node/src/network.rs:13

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant Network:Custom in /tmp/.tmplDFfBG/lumina/node/src/network.rs:22
  variant NodeError:NodeBuilder in /tmp/.tmplDFfBG/lumina/node/src/node.rs:54
  variant NodeError:NodeBuilder in /tmp/.tmplDFfBG/lumina/node/src/node.rs:54

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Network::Private, previously in file /tmp/.tmpAdb1bm/lumina-node/src/network.rs:20

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/function_missing.ron

Failed in:
  function lumina_node::network::network_id, previously in file /tmp/.tmpAdb1bm/lumina-node/src/network.rs:42
  function lumina_node::test_utils::test_node_config, previously in file /tmp/.tmpAdb1bm/lumina-node/src/test_utils.rs:51
  function lumina_node::test_utils::listening_test_node_config, previously in file /tmp/.tmpAdb1bm/lumina-node/src/test_utils.rs:66
  function lumina_node::test_utils::test_node_config_with_keypair, previously in file /tmp/.tmpAdb1bm/lumina-node/src/test_utils.rs:74
  function lumina_node::network::canonical_network_bootnodes, previously in file /tmp/.tmpAdb1bm/lumina-node/src/network.rs:52

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  Node::new, previously in file /tmp/.tmpAdb1bm/lumina-node/src/node.rs:110
  Node::new_subscribed, previously in file /tmp/.tmpAdb1bm/lumina-node/src/node.rs:119
  Node::new, previously in file /tmp/.tmpAdb1bm/lumina-node/src/node.rs:110
  Node::new_subscribed, previously in file /tmp/.tmpAdb1bm/lumina-node/src/node.rs:119

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DEFAULT_SYNCING_WINDOW in file /tmp/.tmpAdb1bm/lumina-node/src/syncer.rs:39

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct lumina_node::network::UnknownNetworkError, previously in file /tmp/.tmpAdb1bm/lumina-node/src/network.rs:26
  struct lumina_node::node::NodeConfig, previously in file /tmp/.tmpAdb1bm/lumina-node/src/node.rs:63
  struct lumina_node::NodeConfig, previously in file /tmp/.tmpAdb1bm/lumina-node/src/node.rs:63
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.2...lumina-cli-v0.6.0) - 2025-01-07

### Added

- Add remaining node types for wasm (#476)
- *(cli)* Add `in-memory-store` and `pruning-delay` parameters (#490)
- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.8.0...celestia-rpc-v0.9.0) - 2025-01-07

### Added

- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
</blockquote>

## `celestia-types`
<blockquote>

## [0.10.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.9.0...celestia-types-v0.10.0) - 2025-01-07

### Added

- Add remaining node types for wasm (#476)
- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)

### Fixed

- *(types)* RowNamespaceData binary deserialization (#493)
</blockquote>

## `celestia-proto`
<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.6.0...celestia-proto-v0.7.0) - 2025-01-07

### Other

- [**breaking**] Add notes about Celestia's Tendermint modifications (#471)
</blockquote>

## `lumina-node`
<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.8.0...lumina-node-v0.9.0) - 2025-01-07

### Added

- Add remaining node types for wasm (#476)
- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
- *(node)* Implement `EitherStore` combinator struct (#484)
- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>

## `celestia-grpc`
<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.1.0...celestia-grpc-v0.1.1) - 2025-01-07

### Other

- *(grpc)* Increase sleep before blob submission validation to reduce test flakyness (#481)
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.7.0...lumina-node-wasm-v0.8.0) - 2025-01-07

### Added

- Add remaining node types for wasm (#476)
- *(node-wasm)* Add more configuration options in `NodeConfig` (#487)
- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(node-wasm)* Update js build dependencies, commit package lock (#478)
- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).