### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "celestia-grpc-macros",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "prost",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.8.0", path = "node" }
-lumina-node-wasm = { version = "0.7.0", path = "node-wasm" }
-celestia-proto = { version = "0.6.0", path = "proto" }
-celestia-grpc = { version = "0.1.0", path = "grpc" }
-celestia-rpc = { version = "0.8.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.9.0", path = "types", default-features = false }
+lumina-node = { version = "0.9.0", path = "node" }
+lumina-node-wasm = { version = "0.8.0", path = "node-wasm" }
+celestia-proto = { version = "0.7.0", path = "proto" }
+celestia-grpc = { version = "0.2.0", path = "grpc" }
+celestia-rpc = { version = "0.9.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.10.0", path = "types", default-features = false }
 tendermint = { version = "0.40.0", default-features = false }
 tendermint-proto = "0.40.0"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.2...lumina-cli-v0.6.0) - 2025-01-21
+
+### Added
+
+- Add remaining node types for wasm (#476)
+- *(cli)* Add `in-memory-store` and `pruning-delay` parameters (#490)
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Fixed
+
+- *(cli)* align with dah javascript breaking changes (#501)
+
+### Other
+
+- *(ci)* migrate toolchain action, parallelize (#503)
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.5.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.1...lumina-cli-v0.5.2) - 2024-12-02
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.1.0...celestia-grpc-v0.2.0) - 2025-01-21
+
+### Added
+
+- *(grpc)* [**breaking**] add wasm support and transaction client (#474)
+
+### Other
+
+- *(ci)* migrate toolchain action, parallelize (#503)
+- *(grpc)* Increase sleep before blob submission validation to reduce test flakyness (#481)
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-grpc-v0.1.0) - 2024-12-02
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"
@@ -19,7 +19,7 @@ categories = [
 ]
 
 [dependencies]
-celestia-grpc-macros = { version = "0.1.0", path = "grpc-macros" }
+celestia-grpc-macros = { version = "0.2.0", path = "grpc-macros" }
 celestia-proto = { workspace = true, features = ["tonic"] }
 celestia-types.workspace = true
 prost.workspace = true

--- a/grpc/grpc-macros/CHANGELOG.md
+++ b/grpc/grpc-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.1.0...celestia-grpc-macros-v0.2.0) - 2025-01-21
+
+### Added
+
+- *(grpc)* [**breaking**] add wasm support and transaction client (#474)
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-grpc-macros-v0.1.0) - 2024-12-02
 
 ### Added

--- a/grpc/grpc-macros/Cargo.toml
+++ b/grpc/grpc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc-macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Helper crate for grpc_method macro for creating gRPC client, used by celestia-grpc"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.7.0...lumina-node-wasm-v0.8.0) - 2025-01-21
+
+### Added
+
+- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
+- Add remaining node types for wasm (#476)
+- *(node-wasm)* Add more configuration options in `NodeConfig` (#487)
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(ci)* migrate toolchain action, parallelize (#503)
+- *(node-wasm)* Update js build dependencies, commit package lock (#478)
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.6.1...lumina-node-wasm-v0.7.0) - 2024-12-02
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -1,7 +1,7 @@
 
 <a name="readmemd"></a>
 
-**lumina-node-wasm** • [**Docs**](#globalsmd)
+**lumina-node-wasm**
 
 ***
 
@@ -55,9 +55,261 @@ For comprehensive and fully typed interface documentation, see [lumina-node](htt
 # Classes
 
 
+<a name="classesappversionmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / AppVersion
+
+## Class: AppVersion
+
+Version of the App
+
+### Properties
+
+#### V1
+
+> `readonly` `static` **V1**: [`AppVersion`](#classesappversionmd)
+
+App v1
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:58
+
+***
+
+#### V2
+
+> `readonly` `static` **V2**: [`AppVersion`](#classesappversionmd)
+
+App v2
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:62
+
+***
+
+#### V3
+
+> `readonly` `static` **V3**: [`AppVersion`](#classesappversionmd)
+
+App v3
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:66
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:50
+
+***
+
+#### latest()
+
+> `static` **latest**(): [`AppVersion`](#classesappversionmd)
+
+Latest App version variant.
+
+##### Returns
+
+[`AppVersion`](#classesappversionmd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:54
+
+
+<a name="classesblobmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Blob
+
+## Class: Blob
+
+Arbitrary data that can be stored in the network within certain [`Namespace`].
+
+### Constructors
+
+#### new Blob()
+
+> **new Blob**(`namespace`, `data`, `app_version`): [`Blob`](#classesblobmd)
+
+Create a new blob with the given data within the [`Namespace`].
+
+##### Parameters
+
+###### namespace
+
+[`Namespace`](#classesnamespacemd)
+
+###### data
+
+`Uint8Array`\<`ArrayBuffer`\>
+
+###### app\_version
+
+[`AppVersion`](#classesappversionmd)
+
+##### Returns
+
+[`Blob`](#classesblobmd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:84
+
+### Properties
+
+#### commitment
+
+> **commitment**: [`Commitment`](#classescommitmentmd)
+
+A [`Commitment`] computed from the [`Blob`]s data.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:102
+
+***
+
+#### data
+
+> **data**: `Uint8Array`\<`ArrayBuffer`\>
+
+Data stored within the [`Blob`].
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:92
+
+***
+
+#### namespace
+
+> **namespace**: [`Namespace`](#classesnamespacemd)
+
+A [`Namespace`] the [`Blob`] belongs to.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:88
+
+***
+
+#### share\_version
+
+> **share\_version**: `number`
+
+Version indicating the format in which [`Share`]s should be created from this [`Blob`].
+
+[`Share`]: crate::share::Share
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:98
+
+### Accessors
+
+#### index
+
+##### Get Signature
+
+> **get** **index**(): `bigint`
+
+Index of the blob's first share in the EDS. Only set for blobs retrieved from chain.
+
+###### Returns
+
+`bigint`
+
+##### Set Signature
+
+> **set** **index**(`value`): `void`
+
+Index of the blob's first share in the EDS. Only set for blobs retrieved from chain.
+
+###### Parameters
+
+####### value
+
+`bigint`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:106
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:80
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:75
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:79
+
+
 <a name="classesblockrangemd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -66,16 +318,6 @@ For comprehensive and fully typed interface documentation, see [lumina-node](htt
 ## Class: BlockRange
 
 A range of blocks between `start` and `end` height, inclusive
-
-### Constructors
-
-#### new BlockRange()
-
-> **new BlockRange**(): [`BlockRange`](#classesblockrangemd)
-
-##### Returns
-
-[`BlockRange`](#classesblockrangemd)
 
 ### Properties
 
@@ -87,7 +329,7 @@ Last block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:44
+lumina\_node\_wasm.d.ts:133
 
 ***
 
@@ -99,7 +341,7 @@ First block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:48
+lumina\_node\_wasm.d.ts:129
 
 ### Methods
 
@@ -113,7 +355,7 @@ lumina\_node\_wasm.d.ts:48
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:40
+lumina\_node\_wasm.d.ts:125
 
 ***
 
@@ -129,7 +371,7 @@ lumina\_node\_wasm.d.ts:40
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:35
+lumina\_node\_wasm.d.ts:120
 
 ***
 
@@ -145,28 +387,127 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:39
+lumina\_node\_wasm.d.ts:124
+
+
+<a name="classescommitmentmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Commitment
+
+## Class: Commitment
+
+A merkle hash used to identify the [`Blob`]s data.
+
+In Celestia network, the transaction which pays for the blob's inclusion
+is separated from the data itself. The reason for that is to allow verifying
+the blockchain's state without the need to pull the actual data which got stored.
+To achieve that, the [`MsgPayForBlobs`] transaction only includes the [`Commitment`]s
+of the blobs it is paying for, not the data itself.
+
+The algorithm of computing the [`Commitment`] of the [`Blob`]'s [`Share`]s is
+designed in a way to allow easy and cheap proving of the [`Share`]s inclusion in the
+block. It is computed as a [`merkle hash`] of all the [`Nmt`] subtree roots created from
+the blob shares included in the [`ExtendedDataSquare`] rows. Assuming the `s1` and `s2`
+are the only shares of some blob posted to the celestia, they'll result in a single subtree
+root as shown below:
+
+```text
+NMT:           row root
+               /     \
+             o   subtree root
+            / \      / \
+          _________________
+EDS row: | s | s | s1 | s2 |
+```
+
+Using subtree roots as a base for [`Commitment`] computation allows for much smaller
+inclusion proofs than when the [`Share`]s would be used directly, but it imposes some
+constraints on how the [`Blob`]s can be placed in the [`ExtendedDataSquare`]. You can
+read more about that in the [`share commitment rules`].
+
+[`Blob`]: crate::Blob
+[`Share`]: crate::share::Share
+[`MsgPayForBlobs`]: celestia_proto::celestia::blob::v1::MsgPayForBlobs
+[`merkle hash`]: tendermint::merkle::simple_hash_from_byte_vectors
+[`Nmt`]: crate::nmt::Nmt
+[`ExtendedDataSquare`]: crate::ExtendedDataSquare
+[`share commitment rules`]: https://github.com/celestiaorg/celestia-app/blob/main/specs/src/specs/data_square_layout.md#blob-share-commitment-rules
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:183
+
+***
+
+#### hash()
+
+> **hash**(): `Uint8Array`\<`ArrayBuffer`\>
+
+Hash of the commitment
+
+##### Returns
+
+`Uint8Array`\<`ArrayBuffer`\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:187
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:178
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:182
 
 
 <a name="classesconnectioncounterssnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
 [lumina-node-wasm](#globalsmd) / ConnectionCountersSnapshot
 
 ## Class: ConnectionCountersSnapshot
-
-### Constructors
-
-#### new ConnectionCountersSnapshot()
-
-> **new ConnectionCountersSnapshot**(): [`ConnectionCountersSnapshot`](#classesconnectioncounterssnapshotmd)
-
-##### Returns
-
-[`ConnectionCountersSnapshot`](#classesconnectioncounterssnapshotmd)
 
 ### Properties
 
@@ -178,7 +519,7 @@ The total number of connections, both pending and established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:65
+lumina\_node\_wasm.d.ts:203
 
 ***
 
@@ -190,7 +531,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:69
+lumina\_node\_wasm.d.ts:219
 
 ***
 
@@ -202,7 +543,7 @@ The number of established incoming connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:73
+lumina\_node\_wasm.d.ts:223
 
 ***
 
@@ -214,7 +555,7 @@ The number of established outgoing connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:77
+lumina\_node\_wasm.d.ts:227
 
 ***
 
@@ -226,7 +567,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:81
+lumina\_node\_wasm.d.ts:207
 
 ***
 
@@ -238,7 +579,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:85
+lumina\_node\_wasm.d.ts:211
 
 ***
 
@@ -250,7 +591,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:89
+lumina\_node\_wasm.d.ts:215
 
 ### Methods
 
@@ -264,7 +605,7 @@ lumina\_node\_wasm.d.ts:89
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:61
+lumina\_node\_wasm.d.ts:199
 
 ***
 
@@ -280,7 +621,7 @@ lumina\_node\_wasm.d.ts:61
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:56
+lumina\_node\_wasm.d.ts:194
 
 ***
 
@@ -296,12 +637,831 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:60
+lumina\_node\_wasm.d.ts:198
+
+
+<a name="classesdataavailabilityheadermd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / DataAvailabilityHeader
+
+## Class: DataAvailabilityHeader
+
+Header with commitments of the data availability.
+
+It consists of the root hashes of the merkle trees created from each
+row and column of the [`ExtendedDataSquare`]. Those are used to prove
+the inclusion of the data in a block.
+
+The hash of this header is a hash of all rows and columns and thus a
+data commitment of the block.
+
+## Example
+
+```no_run
+## use celestia_types::{ExtendedHeader, Height, Share};
+## use celestia_types::nmt::{Namespace, NamespaceProof};
+## fn extended_header() -> ExtendedHeader {
+##     unimplemented!();
+## }
+## fn shares_with_proof(_: Height, _: &Namespace) -> (Vec<Share>, NamespaceProof) {
+##     unimplemented!();
+## }
+// fetch the block header and data for your namespace
+let namespace = Namespace::new_v0(&[1, 2, 3, 4]).unwrap();
+let eh = extended_header();
+let (shares, proof) = shares_with_proof(eh.height(), &namespace);
+
+// get the data commitment for a given row
+let dah = eh.dah;
+let root = dah.row_root(0).unwrap();
+
+// verify a proof of the inclusion of the shares
+assert!(proof.verify_complete_namespace(&root, &shares, *namespace).is_ok());
+```
+
+[`ExtendedDataSquare`]: crate::eds::ExtendedDataSquare
+
+### Methods
+
+#### columnRoot()
+
+> **columnRoot**(`column`): `any`
+
+Get the a root of the column with the given index.
+
+##### Parameters
+
+###### column
+
+`number`
+
+##### Returns
+
+`any`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:291
+
+***
+
+#### columnRoots()
+
+> **columnRoots**(): `any`[]
+
+Merkle roots of the [`ExtendedDataSquare`] columns.
+
+##### Returns
+
+`any`[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:283
+
+***
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:275
+
+***
+
+#### hash()
+
+> **hash**(): `any`
+
+Compute the combined hash of all rows and columns.
+
+This is the data commitment for the block.
+
+##### Returns
+
+`any`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:297
+
+***
+
+#### rowRoot()
+
+> **rowRoot**(`row`): `any`
+
+Get a root of the row with the given index.
+
+##### Parameters
+
+###### row
+
+`number`
+
+##### Returns
+
+`any`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:287
+
+***
+
+#### rowRoots()
+
+> **rowRoots**(): `any`[]
+
+Merkle roots of the [`ExtendedDataSquare`] rows.
+
+##### Returns
+
+`any`[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:279
+
+***
+
+#### squareWidth()
+
+> **squareWidth**(): `number`
+
+Get the size of the [`ExtendedDataSquare`] for which this header was built.
+
+##### Returns
+
+`number`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:301
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:270
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:274
+
+
+<a name="classesextendedheadermd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ExtendedHeader
+
+## Class: ExtendedHeader
+
+Block header together with the relevant Data Availability metadata.
+
+[`ExtendedHeader`]s are used to announce and describe the blocks
+in the Celestia network.
+
+Before being used, each header should be validated and verified with a header you trust.
+
+## Example
+
+```
+## use celestia_types::ExtendedHeader;
+## fn trusted_genesis_header() -> ExtendedHeader {
+##     let s = include_str!("../test_data/chain1/extended_header_block_1.json");
+##     serde_json::from_str(s).unwrap()
+## }
+## fn some_untrusted_header() -> ExtendedHeader {
+##     let s = include_str!("../test_data/chain1/extended_header_block_27.json");
+##     serde_json::from_str(s).unwrap()
+## }
+let genesis_header = trusted_genesis_header();
+
+// fetch new header
+let fetched_header = some_untrusted_header();
+
+fetched_header.validate().expect("Invalid block header");
+genesis_header.verify(&fetched_header).expect("Malicious header received");
+```
+
+### Properties
+
+#### commit
+
+> `readonly` **commit**: `any`
+
+Commit metadata and signatures from validators committing the block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:432
+
+***
+
+#### dah
+
+> **dah**: [`DataAvailabilityHeader`](#classesdataavailabilityheadermd)
+
+Header of the block data availability.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:424
+
+***
+
+#### header
+
+> `readonly` **header**: `any`
+
+Tendermint block header.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:428
+
+***
+
+#### validatorSet
+
+> `readonly` **validatorSet**: `any`
+
+Information about the set of validators commiting the block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:436
+
+### Methods
+
+#### clone()
+
+> **clone**(): [`ExtendedHeader`](#classesextendedheadermd)
+
+Clone a header producing a deep copy of it.
+
+##### Returns
+
+[`ExtendedHeader`](#classesextendedheadermd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:346
+
+***
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:342
+
+***
+
+#### hash()
+
+> **hash**(): `string`
+
+Get the block hash.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:358
+
+***
+
+#### height()
+
+> **height**(): `bigint`
+
+Get the block height.
+
+##### Returns
+
+`bigint`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:350
+
+***
+
+#### previousHeaderHash()
+
+> **previousHeaderHash**(): `string`
+
+Get the hash of the previous header.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:362
+
+***
+
+#### time()
+
+> **time**(): `number`
+
+Get the block time.
+
+##### Returns
+
+`number`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:354
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:337
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:341
+
+***
+
+#### validate()
+
+> **validate**(): `void`
+
+Decode protobuf encoded header and then validate it.
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:366
+
+***
+
+#### verify()
+
+> **verify**(`untrusted`): `void`
+
+Verify a chain of adjacent untrusted headers and make sure
+they are adjacent to `self`.
+
+## Errors
+
+If verification fails, this function will return an error with a reason of failure.
+This function will also return an error if untrusted headers and `self` don't form contiguous range
+
+##### Parameters
+
+###### untrusted
+
+[`ExtendedHeader`](#classesextendedheadermd)
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:376
+
+***
+
+#### verifyAdjacentRange()
+
+> **verifyAdjacentRange**(`untrusted`): `void`
+
+Verify a chain of adjacent untrusted headers and make sure
+they are adjacent to `self`.
+
+## Note
+
+Provided headers will be consumed by this method, meaning
+they will no longer be accessible. If this behavior is not desired,
+consider using `ExtendedHeader.clone()`.
+
+```js
+const genesis = hdr0;
+const headers = [hrd1, hdr2, hdr3];
+genesis.verifyAdjacentRange(headers.map(h => h.clone()));
+```
+
+## Errors
+
+If verification fails, this function will return an error with a reason of failure.
+This function will also return an error if untrusted headers and `self` don't form contiguous range
+
+##### Parameters
+
+###### untrusted
+
+[`ExtendedHeader`](#classesextendedheadermd)[]
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:420
+
+***
+
+#### verifyRange()
+
+> **verifyRange**(`untrusted`): `void`
+
+Verify a chain of adjacent untrusted headers.
+
+## Note
+
+Provided headers will be consumed by this method, meaning
+they will no longer be accessible. If this behavior is not desired,
+consider using `ExtendedHeader.clone()`.
+
+```js
+const genesis = hdr0;
+const headers = [hrd1, hdr2, hdr3];
+genesis.verifyRange(headers.map(h => h.clone()));
+```
+
+## Errors
+
+If verification fails, this function will return an error with a reason of failure.
+This function will also return an error if untrusted headers are not adjacent
+to each other.
+
+##### Parameters
+
+###### untrusted
+
+[`ExtendedHeader`](#classesextendedheadermd)[]
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:398
+
+
+<a name="classesnamespacemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Namespace
+
+## Class: Namespace
+
+Namespace of the data published to the celestia network.
+
+The [`Namespace`] is a single byte defining the version
+followed by 28 bytes specifying concrete ID of the namespace.
+
+Currently there are two versions of namespaces:
+
+ - version `0` - the one allowing for the custom namespace ids. It requires an id to start
+   with 18 `0x00` bytes followed by a user specified suffix (except reserved ones, see below).
+ - version `255` - for secondary reserved namespaces. It requires an id to start with 27
+   `0xff` bytes followed by a single byte indicating the id.
+
+Some namespaces are reserved for the block creation purposes and cannot be used
+when submitting the blobs to celestia. Those fall into one of the two categories:
+
+ - primary reserved namespaces - those use version `0` and have id lower or equal to `0xff`
+   so they are always placed in blocks before user-submitted data.
+ - secondary reserved namespaces - those use version `0xff` so they are always placed after
+   user-submitted data.
+
+### Properties
+
+#### id
+
+> `readonly` **id**: `Uint8Array`\<`ArrayBuffer`\>
+
+Returns the trailing 28 bytes indicating the id of the [`Namespace`].
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:545
+
+***
+
+#### version
+
+> `readonly` **version**: `number`
+
+Returns the first byte indicating the version of the [`Namespace`].
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:541
+
+***
+
+#### MAX\_PRIMARY\_RESERVED
+
+> `readonly` `static` **MAX\_PRIMARY\_RESERVED**: [`Namespace`](#classesnamespacemd)
+
+Maximal primary reserved [`Namespace`].
+
+Used to indicate the end of the primary reserved group.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:516
+
+***
+
+#### MIN\_SECONDARY\_RESERVED
+
+> `readonly` `static` **MIN\_SECONDARY\_RESERVED**: [`Namespace`](#classesnamespacemd)
+
+Minimal secondary reserved [`Namespace`].
+
+Used to indicate the beginning of the secondary reserved group.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:522
+
+***
+
+#### NS\_SIZE
+
+> `readonly` `static` **NS\_SIZE**: `number`
+
+Namespace size in bytes.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:495
+
+***
+
+#### PARITY\_SHARE
+
+> `readonly` `static` **PARITY\_SHARE**: [`Namespace`](#classesnamespacemd)
+
+The [`Namespace`] for `parity shares`.
+
+It is the namespace with which all the `parity shares` from
+`ExtendedDataSquare` are inserted to the `Nmt` when computing
+merkle roots.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:537
+
+***
+
+#### PAY\_FOR\_BLOB
+
+> `readonly` `static` **PAY\_FOR\_BLOB**: [`Namespace`](#classesnamespacemd)
+
+Primary reserved [`Namespace`] for the compact Shares with MsgPayForBlobs transactions.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:503
+
+***
+
+#### PRIMARY\_RESERVED\_PADDING
+
+> `readonly` `static` **PRIMARY\_RESERVED\_PADDING**: [`Namespace`](#classesnamespacemd)
+
+Primary reserved [`Namespace`] for the `Share`s used for padding.
+
+`Share`s with this namespace are inserted after other shares from primary reserved namespace
+so that user-defined namespaces are correctly aligned in `ExtendedDataSquare`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:510
+
+***
+
+#### TAIL\_PADDING
+
+> `readonly` `static` **TAIL\_PADDING**: [`Namespace`](#classesnamespacemd)
+
+Secondary reserved [`Namespace`] used for padding after the blobs.
+
+It is used to fill up the `original data square` after all user-submitted
+blobs before the parity data is generated for the `ExtendedDataSquare`.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:529
+
+***
+
+#### TRANSACTION
+
+> `readonly` `static` **TRANSACTION**: [`Namespace`](#classesnamespacemd)
+
+Primary reserved [`Namespace`] for the compact `Share`s with `cosmos SDK` transactions.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:499
+
+### Methods
+
+#### asBytes()
+
+> **asBytes**(): `Uint8Array`\<`ArrayBuffer`\>
+
+Converts the [`Namespace`] to a byte slice.
+
+##### Returns
+
+`Uint8Array`\<`ArrayBuffer`\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:491
+
+***
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:469
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:464
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:468
+
+***
+
+#### fromRaw()
+
+> `static` **fromRaw**(`raw`): [`Namespace`](#classesnamespacemd)
+
+Create a new [`Namespace`] from the raw bytes.
+
+## Errors
+
+This function will return an error if the slice length is different than
+[`NS_SIZE`] or if the namespace is invalid. If you are constructing the
+version `0` namespace, check [`newV0`].
+
+##### Parameters
+
+###### raw
+
+`Uint8Array`\<`ArrayBuffer`\>
+
+##### Returns
+
+[`Namespace`](#classesnamespacemd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:487
+
+***
+
+#### newV0()
+
+> `static` **newV0**(`id`): [`Namespace`](#classesnamespacemd)
+
+Create a new [`Namespace`] version `0` with given id.
+
+Check [`Namespace::new_v0`] for more details.
+
+[`Namespace::new_v0`]: https://docs.rs/celestia-types/latest/celestia_types/nmt/struct.Namespace.html#method.new_v0
+##### Parameters
+
+###### id
+
+`Uint8Array`\<`ArrayBuffer`\>
+
+##### Returns
+
+[`Namespace`](#classesnamespacemd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:477
 
 
 <a name="classesnetworkinfosnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -310,16 +1470,6 @@ lumina\_node\_wasm.d.ts:60
 ## Class: NetworkInfoSnapshot
 
 Information about the connections
-
-### Constructors
-
-#### new NetworkInfoSnapshot()
-
-> **new NetworkInfoSnapshot**(): [`NetworkInfoSnapshot`](#classesnetworkinfosnapshotmd)
-
-##### Returns
-
-[`NetworkInfoSnapshot`](#classesnetworkinfosnapshotmd)
 
 ### Properties
 
@@ -331,7 +1481,7 @@ Gets counters for ongoing network connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:107
+lumina\_node\_wasm.d.ts:568
 
 ***
 
@@ -343,7 +1493,7 @@ The number of connected peers, i.e. peers with whom at least one established con
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:111
+lumina\_node\_wasm.d.ts:564
 
 ### Methods
 
@@ -357,7 +1507,7 @@ lumina\_node\_wasm.d.ts:111
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:103
+lumina\_node\_wasm.d.ts:560
 
 ***
 
@@ -373,7 +1523,7 @@ lumina\_node\_wasm.d.ts:103
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:98
+lumina\_node\_wasm.d.ts:555
 
 ***
 
@@ -389,12 +1539,12 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:102
+lumina\_node\_wasm.d.ts:559
 
 
 <a name="classesnodeclientmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -418,7 +1568,9 @@ expected to have `MessagePort`-like interface for sending and receiving messages
 
 ##### Parameters
 
-• **port**: `any`
+###### port
+
+`any`
 
 ##### Returns
 
@@ -426,7 +1578,7 @@ expected to have `MessagePort`-like interface for sending and receiving messages
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:126
+lumina\_node\_wasm.d.ts:582
 
 ### Methods
 
@@ -438,7 +1590,9 @@ Establish a new connection to the existing worker over provided port
 
 ##### Parameters
 
-• **port**: `any`
+###### port
+
+`any`
 
 ##### Returns
 
@@ -446,7 +1600,7 @@ Establish a new connection to the existing worker over provided port
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:132
+lumina\_node\_wasm.d.ts:586
 
 ***
 
@@ -462,7 +1616,7 @@ Get all the peers that node is connected to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:182
+lumina\_node\_wasm.d.ts:623
 
 ***
 
@@ -478,7 +1632,7 @@ Returns a [`BroadcastChannel`] for events generated by [`Node`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:298
+lumina\_node\_wasm.d.ts:690
 
 ***
 
@@ -492,59 +1646,57 @@ lumina\_node\_wasm.d.ts:298
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:120
+lumina\_node\_wasm.d.ts:577
 
 ***
 
 #### getHeaderByHash()
 
-> **getHeaderByHash**(`hash`): `Promise`\<`any`\>
+> **getHeaderByHash**(`hash`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get a synced header for the block with a given hash.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **hash**: `string`
+###### hash
+
+`string`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:257
+lumina\_node\_wasm.d.ts:666
 
 ***
 
 #### getHeaderByHeight()
 
-> **getHeaderByHeight**(`height`): `Promise`\<`any`\>
+> **getHeaderByHeight**(`height`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get a synced header for the block with a given height.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **height**: `bigint`
+###### height
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:266
+lumina\_node\_wasm.d.ts:670
 
 ***
 
 #### getHeaders()
 
-> **getHeaders**(`start_height`?, `end_height`?): `Promise`\<`any`[]\>
+> **getHeaders**(`start_height`?, `end_height`?): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 Get synced headers from the given heights range.
 
@@ -556,83 +1708,77 @@ store.
 
 If range contains a height of a header that is not found in the store.
 
-Returns an array of javascript objects with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **start\_height?**: `bigint`
+###### start\_height?
 
-• **end\_height?**: `bigint`
+`bigint`
+
+###### end\_height?
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`[]\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:284
+lumina\_node\_wasm.d.ts:682
 
 ***
 
 #### getLocalHeadHeader()
 
-> **getLocalHeadHeader**(): `Promise`\<`any`\>
+> **getLocalHeadHeader**(): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get the latest locally synced header.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:248
+lumina\_node\_wasm.d.ts:662
 
 ***
 
 #### getNetworkHeadHeader()
 
-> **getNetworkHeadHeader**(): `Promise`\<`any`\>
+> **getNetworkHeadHeader**(): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Get the latest header announced in the network.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:240
+lumina\_node\_wasm.d.ts:658
 
 ***
 
 #### getSamplingMetadata()
 
-> **getSamplingMetadata**(`height`): `Promise`\<`any`\>
+> **getSamplingMetadata**(`height`): `Promise`\<[`SamplingMetadata`](#classessamplingmetadatamd)\>
 
 Get data sampling metadata of an already sampled height.
 
-Returns a javascript object with given structure:
-https://docs.rs/lumina-node/latest/lumina_node/store/struct.SamplingMetadata.html
-
 ##### Parameters
 
-• **height**: `bigint`
+###### height
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`SamplingMetadata`](#classessamplingmetadatamd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:293
+lumina\_node\_wasm.d.ts:686
 
 ***
 
@@ -648,7 +1794,7 @@ Check whether Lumina is currently running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:137
+lumina\_node\_wasm.d.ts:590
 
 ***
 
@@ -664,7 +1810,7 @@ Get all the multiaddresses on which the node listens.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:177
+lumina\_node\_wasm.d.ts:619
 
 ***
 
@@ -680,7 +1826,7 @@ Get node's local peer ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:152
+lumina\_node\_wasm.d.ts:599
 
 ***
 
@@ -696,7 +1842,7 @@ Get current network info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:172
+lumina\_node\_wasm.d.ts:615
 
 ***
 
@@ -712,99 +1858,126 @@ Get current [`PeerTracker`] info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:157
+lumina\_node\_wasm.d.ts:603
+
+***
+
+#### requestAllBlobs()
+
+> **requestAllBlobs**(`header`, `namespace`, `timeout_secs`?): `Promise`\<[`Blob`](#classesblobmd)[]\>
+
+Request all blobs with provided namespace in the block corresponding to this header
+using bitswap protocol.
+
+##### Parameters
+
+###### header
+
+[`ExtendedHeader`](#classesextendedheadermd)
+
+###### namespace
+
+[`Namespace`](#classesnamespacemd)
+
+###### timeout\_secs?
+
+`number`
+
+##### Returns
+
+`Promise`\<[`Blob`](#classesblobmd)[]\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:650
 
 ***
 
 #### requestHeaderByHash()
 
-> **requestHeaderByHash**(`hash`): `Promise`\<`any`\>
+> **requestHeaderByHash**(`hash`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Request a header for the block with a given hash from the network.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **hash**: `string`
+###### hash
+
+`string`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:206
+lumina\_node\_wasm.d.ts:635
 
 ***
 
 #### requestHeaderByHeight()
 
-> **requestHeaderByHeight**(`height`): `Promise`\<`any`\>
+> **requestHeaderByHeight**(`height`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Request a header for the block with a given height from the network.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **height**: `bigint`
+###### height
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:215
+lumina\_node\_wasm.d.ts:639
 
 ***
 
 #### requestHeadHeader()
 
-> **requestHeadHeader**(): `Promise`\<`any`\>
+> **requestHeadHeader**(): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 Request the head header from the network.
 
-Returns a javascript object with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Returns
 
-`Promise`\<`any`\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:197
+lumina\_node\_wasm.d.ts:631
 
 ***
 
 #### requestVerifiedHeaders()
 
-> **requestVerifiedHeaders**(`from_header`, `amount`): `Promise`\<`any`[]\>
+> **requestVerifiedHeaders**(`from`, `amount`): `Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 Request headers in range (from, from + amount] from the network.
 
 The headers will be verified with the `from` header.
 
-Returns an array of javascript objects with given structure:
-https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html
-
 ##### Parameters
 
-• **from\_header**: `any`
+###### from
 
-• **amount**: `bigint`
+[`ExtendedHeader`](#classesextendedheadermd)
+
+###### amount
+
+`bigint`
 
 ##### Returns
 
-`Promise`\<`any`[]\>
+`Promise`\<[`ExtendedHeader`](#classesextendedheadermd)[]\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:227
+lumina\_node\_wasm.d.ts:645
 
 ***
 
@@ -816,9 +1989,13 @@ Trust or untrust the peer with a given ID.
 
 ##### Parameters
 
-• **peer\_id**: `string`
+###### peer\_id
 
-• **is\_trusted**: `boolean`
+`string`
+
+###### is\_trusted
+
+`boolean`
 
 ##### Returns
 
@@ -826,7 +2003,7 @@ Trust or untrust the peer with a given ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:189
+lumina\_node\_wasm.d.ts:627
 
 ***
 
@@ -838,7 +2015,9 @@ Start a node with the provided config, if it's not running
 
 ##### Parameters
 
-• **config**: [`NodeConfig`](#classesnodeconfigmd)
+###### config
+
+[`NodeConfig`](#classesnodeconfigmd)
 
 ##### Returns
 
@@ -846,7 +2025,7 @@ Start a node with the provided config, if it's not running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:143
+lumina\_node\_wasm.d.ts:594
 
 ***
 
@@ -860,7 +2039,7 @@ lumina\_node\_wasm.d.ts:143
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:147
+lumina\_node\_wasm.d.ts:595
 
 ***
 
@@ -876,7 +2055,7 @@ Get current header syncing info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:232
+lumina\_node\_wasm.d.ts:654
 
 ***
 
@@ -892,7 +2071,7 @@ Wait until the node is connected to at least 1 peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:162
+lumina\_node\_wasm.d.ts:607
 
 ***
 
@@ -908,12 +2087,12 @@ Wait until the node is connected to at least 1 trusted peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:167
+lumina\_node\_wasm.d.ts:611
 
 
 <a name="classesnodeconfigmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -922,16 +2101,6 @@ lumina\_node\_wasm.d.ts:167
 ## Class: NodeConfig
 
 Config for the lumina wasm node.
-
-### Constructors
-
-#### new NodeConfig()
-
-> **new NodeConfig**(): [`NodeConfig`](#classesnodeconfigmd)
-
-##### Returns
-
-[`NodeConfig`](#classesnodeconfigmd)
 
 ### Properties
 
@@ -943,20 +2112,7 @@ A list of bootstrap peers to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:322
-
-***
-
-#### custom\_syncing\_window\_secs?
-
-> `optional` **custom\_syncing\_window\_secs**: `number`
-
-Syncing window size, defines maximum age of headers considered for syncing and sampling.
-Headers older than syncing window by more than an hour are eligible for pruning.
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:327
+lumina\_node\_wasm.d.ts:717
 
 ***
 
@@ -968,7 +2124,119 @@ A network to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:331
+lumina\_node\_wasm.d.ts:713
+
+***
+
+#### use\_persistent\_memory
+
+> **use\_persistent\_memory**: `boolean`
+
+Whether to store data in persistent memory or not.
+
+**Default value:** true
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:723
+
+### Accessors
+
+#### custom\_pruning\_delay\_secs
+
+##### Get Signature
+
+> **get** **custom\_pruning\_delay\_secs**(): `number`
+
+Pruning delay defines how much time the pruner should wait after sampling window in
+order to prune the block.
+
+If this is not set, then default value will apply:
+
+* If `use_persistent_memory == true`, default value is 1 hour.
+* If `use_persistent_memory == false`, default value is 60 seconds.
+
+The minimum value that can be set is 60 seconds.
+
+###### Returns
+
+`number`
+
+##### Set Signature
+
+> **set** **custom\_pruning\_delay\_secs**(`value`): `void`
+
+Pruning delay defines how much time the pruner should wait after sampling window in
+order to prune the block.
+
+If this is not set, then default value will apply:
+
+* If `use_persistent_memory == true`, default value is 1 hour.
+* If `use_persistent_memory == false`, default value is 60 seconds.
+
+The minimum value that can be set is 60 seconds.
+
+###### Parameters
+
+####### value
+
+`number`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:757
+
+***
+
+#### custom\_sampling\_window\_secs
+
+##### Get Signature
+
+> **get** **custom\_sampling\_window\_secs**(): `number`
+
+Sampling window defines maximum age of a block considered for syncing and sampling.
+
+If this is not set, then default value will apply:
+
+* If `use_persistent_memory == true`, default value is 30 days.
+* If `use_persistent_memory == false`, default value is 60 seconds.
+
+The minimum value that can be set is 60 seconds.
+
+###### Returns
+
+`number`
+
+##### Set Signature
+
+> **set** **custom\_sampling\_window\_secs**(`value`): `void`
+
+Sampling window defines maximum age of a block considered for syncing and sampling.
+
+If this is not set, then default value will apply:
+
+* If `use_persistent_memory == true`, default value is 30 days.
+* If `use_persistent_memory == false`, default value is 60 seconds.
+
+The minimum value that can be set is 60 seconds.
+
+###### Parameters
+
+####### value
+
+`number`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:734
 
 ### Methods
 
@@ -982,7 +2250,7 @@ lumina\_node\_wasm.d.ts:331
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:312
+lumina\_node\_wasm.d.ts:705
 
 ***
 
@@ -998,7 +2266,7 @@ lumina\_node\_wasm.d.ts:312
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:307
+lumina\_node\_wasm.d.ts:700
 
 ***
 
@@ -1014,7 +2282,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:311
+lumina\_node\_wasm.d.ts:704
 
 ***
 
@@ -1026,7 +2294,9 @@ Get the configuration with default bootnodes for provided network
 
 ##### Parameters
 
-• **network**: [`Network`](#enumerationsnetworkmd)
+###### network
+
+[`Network`](#enumerationsnetworkmd)
 
 ##### Returns
 
@@ -1034,12 +2304,12 @@ Get the configuration with default bootnodes for provided network
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:318
+lumina\_node\_wasm.d.ts:709
 
 
 <a name="classesnodeworkermd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1060,7 +2330,9 @@ them and sending a response back, as well as accepting new `NodeClient` connecti
 
 ##### Parameters
 
-• **port\_like\_object**: `any`
+###### port\_like\_object
+
+`any`
 
 ##### Returns
 
@@ -1068,7 +2340,7 @@ them and sending a response back, as well as accepting new `NodeClient` connecti
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:344
+lumina\_node\_wasm.d.ts:779
 
 ### Methods
 
@@ -1082,7 +2354,7 @@ lumina\_node\_wasm.d.ts:344
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:340
+lumina\_node\_wasm.d.ts:778
 
 ***
 
@@ -1096,12 +2368,12 @@ lumina\_node\_wasm.d.ts:340
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:348
+lumina\_node\_wasm.d.ts:780
 
 
 <a name="classespeertrackerinfosnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1110,16 +2382,6 @@ lumina\_node\_wasm.d.ts:348
 ## Class: PeerTrackerInfoSnapshot
 
 Statistics of the connected peers
-
-### Constructors
-
-#### new PeerTrackerInfoSnapshot()
-
-> **new PeerTrackerInfoSnapshot**(): [`PeerTrackerInfoSnapshot`](#classespeertrackerinfosnapshotmd)
-
-##### Returns
-
-[`PeerTrackerInfoSnapshot`](#classespeertrackerinfosnapshotmd)
 
 ### Properties
 
@@ -1131,7 +2393,7 @@ Number of the connected peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:366
+lumina\_node\_wasm.d.ts:799
 
 ***
 
@@ -1143,7 +2405,7 @@ Number of the connected trusted peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:370
+lumina\_node\_wasm.d.ts:803
 
 ### Methods
 
@@ -1157,7 +2419,7 @@ lumina\_node\_wasm.d.ts:370
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:362
+lumina\_node\_wasm.d.ts:795
 
 ***
 
@@ -1173,7 +2435,7 @@ lumina\_node\_wasm.d.ts:362
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:357
+lumina\_node\_wasm.d.ts:790
 
 ***
 
@@ -1189,12 +2451,65 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:361
+lumina\_node\_wasm.d.ts:794
+
+
+<a name="classessamplingmetadatamd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / SamplingMetadata
+
+## Class: SamplingMetadata
+
+Sampling metadata for a block.
+
+This struct persists DAS-ing information in a header store for future reference.
+
+### Properties
+
+#### cids
+
+> `readonly` **cids**: `Uint8Array`\<`ArrayBuffer`\>[]
+
+Return Array of cids
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:820
+
+***
+
+#### status
+
+> **status**: [`SamplingStatus`](#enumerationssamplingstatusmd)
+
+Indicates whether this node was able to successfuly sample the block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:816
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:812
 
 
 <a name="classessyncinginfosnapshotmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1203,16 +2518,6 @@ lumina\_node\_wasm.d.ts:361
 ## Class: SyncingInfoSnapshot
 
 Status of the synchronization.
-
-### Constructors
-
-#### new SyncingInfoSnapshot()
-
-> **new SyncingInfoSnapshot**(): [`SyncingInfoSnapshot`](#classessyncinginfosnapshotmd)
-
-##### Returns
-
-[`SyncingInfoSnapshot`](#classessyncinginfosnapshotmd)
 
 ### Properties
 
@@ -1224,7 +2529,7 @@ Ranges of headers that are already synchronised
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:388
+lumina\_node\_wasm.d.ts:839
 
 ***
 
@@ -1236,7 +2541,7 @@ Syncing target. The latest height seen in the network that was successfully veri
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:392
+lumina\_node\_wasm.d.ts:843
 
 ### Methods
 
@@ -1250,7 +2555,7 @@ lumina\_node\_wasm.d.ts:392
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:384
+lumina\_node\_wasm.d.ts:835
 
 ***
 
@@ -1266,7 +2571,7 @@ lumina\_node\_wasm.d.ts:384
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:379
+lumina\_node\_wasm.d.ts:830
 
 ***
 
@@ -1282,14 +2587,14 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:383
+lumina\_node\_wasm.d.ts:834
 
 # Enumerations
 
 
 <a name="enumerationsnetworkmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1347,12 +2652,61 @@ Private local network.
 
 lumina\_node\_wasm.d.ts:26
 
+
+<a name="enumerationssamplingstatusmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / SamplingStatus
+
+## Enumeration: SamplingStatus
+
+Sampling status for a block.
+
+### Enumeration Members
+
+#### Accepted
+
+> **Accepted**: `1`
+
+Sampling is done and block is accepted.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:39
+
+***
+
+#### Rejected
+
+> **Rejected**: `2`
+
+Sampling is done and block is rejected.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:43
+
+***
+
+#### Unknown
+
+> **Unknown**: `0`
+
+Sampling is not done.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:35
+
 # Functions
 
 
 <a name="functionssetup_loggingmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1375,7 +2729,7 @@ lumina\_node\_wasm.d.ts:6
 
 <a name="globalsmd"></a>
 
-[**lumina-node-wasm**](#readmemd) • **Docs**
+[**lumina-node-wasm**](#readmemd)
 
 ***
 
@@ -1384,16 +2738,24 @@ lumina\_node\_wasm.d.ts:6
 ## Enumerations
 
 - [Network](#enumerationsnetworkmd)
+- [SamplingStatus](#enumerationssamplingstatusmd)
 
 ## Classes
 
+- [AppVersion](#classesappversionmd)
+- [Blob](#classesblobmd)
 - [BlockRange](#classesblockrangemd)
+- [Commitment](#classescommitmentmd)
 - [ConnectionCountersSnapshot](#classesconnectioncounterssnapshotmd)
+- [DataAvailabilityHeader](#classesdataavailabilityheadermd)
+- [ExtendedHeader](#classesextendedheadermd)
+- [Namespace](#classesnamespacemd)
 - [NetworkInfoSnapshot](#classesnetworkinfosnapshotmd)
 - [NodeClient](#classesnodeclientmd)
 - [NodeConfig](#classesnodeconfigmd)
 - [NodeWorker](#classesnodeworkermd)
 - [PeerTrackerInfoSnapshot](#classespeertrackerinfosnapshotmd)
+- [SamplingMetadata](#classessamplingmetadatamd)
 - [SyncingInfoSnapshot](#classessyncinginfosnapshotmd)
 
 ## Functions

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.7.0"
+        "lumina-node-wasm": "0.8.0"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.8.0...lumina-node-v0.9.0) - 2025-01-21
+
+### Added
+
+- adding uniffi bindings to support android and ios (#473)
+- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
+- Add remaining node types for wasm (#476)
+- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
+- *(node)* Implement `EitherStore` combinator struct (#484)
+- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)
+
+### Other
+
+- *(node)* update bootstrap peers (#520)
+- Update wasm-bindgen, remove cfg_attr wasm-bindgen workaround (#507)
+- *(ci)* migrate toolchain action, parallelize (#503)
+- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.7.0...lumina-node-v0.8.0) - 2024-12-02
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.6.0...celestia-proto-v0.7.0) - 2025-01-21
+
+### Added
+
+- *(grpc)* [**breaking**] add wasm support and transaction client (#474)
+
+### Other
+
+- *(ci)* migrate toolchain action, parallelize (#503)
+- [**breaking**] Add notes about Celestia's Tendermint modifications (#471)
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.5.0...celestia-proto-v0.6.0) - 2024-12-02
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.8.0...celestia-rpc-v0.9.0) - 2025-01-21
+
+### Added
+
+- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
+- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
+
+### Other
+
+- *(ci)* migrate toolchain action, parallelize (#503)
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.7.1...celestia-rpc-v0.8.0) - 2024-12-02
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.9.0...celestia-types-v0.10.0) - 2025-01-21
+
+### Added
+
+- *(grpc)* [**breaking**] add wasm support and transaction client (#474)
+- *(types)* add serde feature for nmt-rs (#480)
+- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
+- Add remaining node types for wasm (#476)
+- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
+
+### Fixed
+
+- *(types)* RowNamespaceData binary deserialization (#493)
+
+### Other
+
+- Update wasm-bindgen, remove cfg_attr wasm-bindgen workaround (#507)
+- *(ci)* migrate toolchain action, parallelize (#503)
+
 ## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.8.0...celestia-types-v0.9.0) - 2024-12-02
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `celestia-rpc`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `celestia-types`: 0.9.0 -> 0.10.0 (⚠️ API breaking changes)
* `celestia-proto`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `lumina-node`: 0.8.0 -> 0.9.0 (⚠️ API breaking changes)
* `celestia-grpc`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)
* `celestia-grpc-macros`: 0.1.0 -> 0.2.0
* `lumina-node-wasm`: 0.7.0 -> 0.8.0

### ⚠️ `celestia-types` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_types::TxConfig, previously in file /tmp/.tmp2U1o2y/celestia-types/src/tx_config.rs:15

--- failure tuple_struct_to_plain_struct: tuple struct changed to plain struct ---

Description:
A publicly-visible, exhaustive tuple struct with pub fields changed to normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/tuple_struct_to_plain_struct.ron
Failed in:
  struct Commitment in /tmp/.tmp9bf8yG/lumina/types/src/blob/commitment.rs:60
  struct Commitment in /tmp/.tmp9bf8yG/lumina/types/src/blob/commitment.rs:60
```

### ⚠️ `lumina-node` breaking changes

```
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Network no longer derives Copy, in /tmp/.tmp9bf8yG/lumina/node/src/network.rs:14

--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum Network in /tmp/.tmp9bf8yG/lumina/node/src/network.rs:14

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant Network:Custom in /tmp/.tmp9bf8yG/lumina/node/src/network.rs:23
  variant NodeError:NodeBuilder in /tmp/.tmp9bf8yG/lumina/node/src/node.rs:54
  variant NodeError:NodeBuilder in /tmp/.tmp9bf8yG/lumina/node/src/node.rs:54

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Network::Private, previously in file /tmp/.tmp2U1o2y/lumina-node/src/network.rs:20

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/function_missing.ron

Failed in:
  function lumina_node::test_utils::test_node_config, previously in file /tmp/.tmp2U1o2y/lumina-node/src/test_utils.rs:51
  function lumina_node::test_utils::test_node_config_with_keypair, previously in file /tmp/.tmp2U1o2y/lumina-node/src/test_utils.rs:74
  function lumina_node::network::canonical_network_bootnodes, previously in file /tmp/.tmp2U1o2y/lumina-node/src/network.rs:52
  function lumina_node::network::network_id, previously in file /tmp/.tmp2U1o2y/lumina-node/src/network.rs:42
  function lumina_node::test_utils::listening_test_node_config, previously in file /tmp/.tmp2U1o2y/lumina-node/src/test_utils.rs:66

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  Node::new, previously in file /tmp/.tmp2U1o2y/lumina-node/src/node.rs:110
  Node::new_subscribed, previously in file /tmp/.tmp2U1o2y/lumina-node/src/node.rs:119
  Node::new, previously in file /tmp/.tmp2U1o2y/lumina-node/src/node.rs:110
  Node::new_subscribed, previously in file /tmp/.tmp2U1o2y/lumina-node/src/node.rs:119

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DEFAULT_SYNCING_WINDOW in file /tmp/.tmp2U1o2y/lumina-node/src/syncer.rs:39

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct lumina_node::network::UnknownNetworkError, previously in file /tmp/.tmp2U1o2y/lumina-node/src/network.rs:26
  struct lumina_node::node::NodeConfig, previously in file /tmp/.tmp2U1o2y/lumina-node/src/node.rs:63
  struct lumina_node::NodeConfig, previously in file /tmp/.tmp2U1o2y/lumina-node/src/node.rs:63
```

### ⚠️ `celestia-grpc` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_missing.ron

Failed in:
  enum celestia_grpc::types::auth::Account, previously in file /tmp/.tmp2U1o2y/celestia-grpc/src/types/auth.rs:19

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:TransportError in /tmp/.tmp9bf8yG/lumina/grpc/src/error.rs:20
  variant Error:TxBroadcastFailed in /tmp/.tmp9bf8yG/lumina/grpc/src/error.rs:48
  variant Error:TxExecutionFailed in /tmp/.tmp9bf8yG/lumina/grpc/src/error.rs:52
  variant Error:TxEvicted in /tmp/.tmp9bf8yG/lumina/grpc/src/error.rs:56
  variant Error:TxNotFound in /tmp/.tmp9bf8yG/lumina/grpc/src/error.rs:60
  variant Error:PublicKeyMismatch in /tmp/.tmp9bf8yG/lumina/grpc/src/error.rs:64

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/feature_missing.ron

Failed in:
  feature tonic in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/function_missing.ron

Failed in:
  function celestia_grpc::types::tx::sign_tx, previously in file /tmp/.tmp2U1o2y/celestia-grpc/src/types/tx.rs:84

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  GrpcClient::broadcast_blob_tx, previously in file /tmp/.tmp2U1o2y/celestia-grpc/src/client.rs:83

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/method_parameter_count_changed.ron

Failed in:
  celestia_grpc::GrpcClient::new now takes 1 parameters instead of 2, in /tmp/.tmp9bf8yG/lumina/grpc/src/grpc.rs:68

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/module_missing.ron

Failed in:
  mod celestia_grpc::types::auth, previously in file /tmp/.tmp2U1o2y/celestia-grpc/src/types/auth.rs:1
  mod celestia_grpc::types::tx, previously in file /tmp/.tmp2U1o2y/celestia-grpc/src/types/tx.rs:1
  mod celestia_grpc::types, previously in file /tmp/.tmp2U1o2y/celestia-grpc/src/types.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_grpc::types::tx::GetTxResponse, previously in file /tmp/.tmp2U1o2y/celestia-grpc/src/types/tx.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.2...lumina-cli-v0.6.0) - 2025-01-21

### Added

- Add remaining node types for wasm (#476)
- *(cli)* Add `in-memory-store` and `pruning-delay` parameters (#490)
- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Fixed

- *(cli)* align with dah javascript breaking changes (#501)

### Other

- *(ci)* migrate toolchain action, parallelize (#503)
- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.8.0...celestia-rpc-v0.9.0) - 2025-01-21

### Added

- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)

### Other

- *(ci)* migrate toolchain action, parallelize (#503)
</blockquote>

## `celestia-types`
<blockquote>

## [0.10.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.9.0...celestia-types-v0.10.0) - 2025-01-21

### Added

- *(grpc)* [**breaking**] add wasm support and transaction client (#474)
- *(types)* add serde feature for nmt-rs (#480)
- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
- Add remaining node types for wasm (#476)
- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)

### Fixed

- *(types)* RowNamespaceData binary deserialization (#493)

### Other

- Update wasm-bindgen, remove cfg_attr wasm-bindgen workaround (#507)
- *(ci)* migrate toolchain action, parallelize (#503)
</blockquote>

## `celestia-proto`
<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.6.0...celestia-proto-v0.7.0) - 2025-01-21

### Added

- *(grpc)* [**breaking**] add wasm support and transaction client (#474)

### Other

- *(ci)* migrate toolchain action, parallelize (#503)
- [**breaking**] Add notes about Celestia's Tendermint modifications (#471)
</blockquote>

## `lumina-node`
<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.8.0...lumina-node-v0.9.0) - 2025-01-21

### Added

- adding uniffi bindings to support android and ios (#473)
- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
- Add remaining node types for wasm (#476)
- *(types,rpc)* [**breaking**] move TxConfig to celestia-rpc (#485)
- *(node)* Implement `EitherStore` combinator struct (#484)
- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(node)* update bootstrap peers (#520)
- Update wasm-bindgen, remove cfg_attr wasm-bindgen workaround (#507)
- *(ci)* migrate toolchain action, parallelize (#503)
- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>

## `celestia-grpc`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.1.0...celestia-grpc-v0.2.0) - 2025-01-21

### Added

- *(grpc)* [**breaking**] add wasm support and transaction client (#474)

### Other

- *(ci)* migrate toolchain action, parallelize (#503)
- *(grpc)* Increase sleep before blob submission validation to reduce test flakyness (#481)
</blockquote>

## `celestia-grpc-macros`
<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.1.0...celestia-grpc-macros-v0.2.0) - 2025-01-21

### Added

- *(grpc)* [**breaking**] add wasm support and transaction client (#474)
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.7.0...lumina-node-wasm-v0.8.0) - 2025-01-21

### Added

- *(node-wasm, types)* [**breaking**] Add method to get blobs for wasm (#468)
- Add remaining node types for wasm (#476)
- *(node-wasm)* Add more configuration options in `NodeConfig` (#487)
- *(node)* [**breaking**] Implement `NodeBuilder` and remove `NodeConfig` (#472)

### Other

- *(ci)* migrate toolchain action, parallelize (#503)
- *(node-wasm)* Update js build dependencies, commit package lock (#478)
- *(node,node-wasm)* [**breaking**] Rename `syncing_window` to `sampling_window` (#477)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).