### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "celestia-grpc-macros",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64",
  "bech32",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.9.0", path = "node" }
-lumina-node-wasm = { version = "0.8.0", path = "node-wasm" }
+lumina-node = { version = "0.9.1", path = "node" }
+lumina-node-wasm = { version = "0.8.1", path = "node-wasm" }
 celestia-proto = { version = "0.7.0", path = "proto" }
-celestia-grpc = { version = "0.2.0", path = "grpc" }
-celestia-rpc = { version = "0.9.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.10.0", path = "types", default-features = false }
+celestia-grpc = { version = "0.2.1", path = "grpc" }
+celestia-rpc = { version = "0.9.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.10.1", path = "types", default-features = false }
 tendermint = { version = "0.40.0", default-features = false }
 tendermint-proto = "0.40.0"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.0...lumina-cli-v0.6.1) - 2025-02-24
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.5.2...lumina-cli-v0.6.0) - 2025-01-28
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.0...celestia-grpc-v0.2.1) - 2025-02-24
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.1.0...celestia-grpc-v0.2.0) - 2025-01-28
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-uniffi-v0.1.0) - 2025-02-24
+
+### Added
+
+- *(node-uniffi)* [**breaking**] Use in-memory stores if base path is not set (#530)
+- adding uniffi bindings to support android and ios (#473)
+
+### Fixed
+
+- *(node-uniffi)* [**breaking**] Serialize correctly ExtendedHeader to json (#531)
+
+### Other
+
+- *(ci)* add releasing for node-uniffi (#545)

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.0...lumina-node-wasm-v0.8.1) - 2025-02-24
+
+### Other
+
+- *(ci)* fix outdated lockfiles when releasing to npm (#544)
+- remove outdated shwap note and link to changelog for js (#536)
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.7.0...lumina-node-wasm-v0.8.0) - 2025-01-28
 
 Summary:

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -10,11 +10,15 @@
 A compatibility layer for the [`Lumina`](https://github.com/eigerco/lumina) node to
 work within a browser environment and be operable with javascript.
 
+# Changelog
+
+You can find about the latest changes [here](https://github.com/eigerco/lumina/blob/main/node-wasm/CHANGELOG.md).
+
 # Example
 Starting lumina inside a dedicated worker
 
 ```javascript
-import { spawnNode, NodeConfig, Network } from "lumina-node";
+import { spawnNode, Network, NodeConfig } from "lumina-node";
 
 const node = await spawnNode();
 const mainnetConfig = NodeConfig.default(Network.Mainnet);
@@ -27,12 +31,12 @@ await node.requestHeadHeader();
 
 ## Manual setup
 
-Note that `spawnNode` implicitly calls wasm initialisation code. If you want to set things up manually, make sure to call the default export before using any of the wasm functionality.
+`spawnNode` sets up a `DedicatedWorker` instance and runs `NodeWorker` there. If you want to set things up manually
+you need to connect client and worker using objects that have `MessagePort` interface.
 
 ```javascript
-import init, { NodeConfig, Network } from "lumina-node";
+import { Network, NodeClient, NodeConfig, NodeWorker } from "lumina-node";
 
-await init();
 const config = NodeConfig.default(Network.Mainnet);
 
 // client and worker accept any object with MessagePort like interface e.g. Worker
@@ -50,7 +54,10 @@ await client.requestHeadHeader();
 
 ## Rust API
 
-For comprehensive and fully typed interface documentation, see [lumina-node](https://docs.rs/lumina-node/latest/lumina_node/) and [celestia-types](https://docs.rs/celestia-types/latest/celestia_types/) documentation on docs.rs. You can see there the exact structure of more complex types, such as [`ExtendedHeader`](https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html). JavaScript API's goal is to provide similar interface to Rust when possible, e.g. `NodeClient` mirrors [`Node`](https://docs.rs/lumina-node/latest/lumina_node/node/struct.Node.html).
+For comprehensive and fully typed interface documentation, see [lumina-node](https://docs.rs/lumina-node/latest/lumina_node/)
+and [celestia-types](https://docs.rs/celestia-types/latest/celestia_types/) documentation on docs.rs.
+You can see there the exact structure of more complex types, such as [`ExtendedHeader`](https://docs.rs/celestia-types/latest/celestia_types/struct.ExtendedHeader.html).
+JavaScript API's goal is to provide similar interface to Rust when possible, e.g. `NodeClient` mirrors [`Node`](https://docs.rs/lumina-node/latest/lumina_node/node/struct.Node.html).
 
 # Classes
 
@@ -3460,7 +3467,7 @@ Auth module parameters
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:78
+lumina\_node\_wasm.d.ts:88
 
 ***
 
@@ -3470,7 +3477,7 @@ lumina\_node\_wasm.d.ts:78
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:81
+lumina\_node\_wasm.d.ts:91
 
 ***
 
@@ -3480,7 +3487,7 @@ lumina\_node\_wasm.d.ts:81
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:82
+lumina\_node\_wasm.d.ts:92
 
 ***
 
@@ -3490,7 +3497,7 @@ lumina\_node\_wasm.d.ts:82
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:79
+lumina\_node\_wasm.d.ts:89
 
 ***
 
@@ -3500,7 +3507,7 @@ lumina\_node\_wasm.d.ts:79
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:80
+lumina\_node\_wasm.d.ts:90
 
 
 <a name="interfacesbaseaccountmd"></a>
@@ -3523,7 +3530,7 @@ Common data of all account types
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:70
+lumina\_node\_wasm.d.ts:80
 
 ***
 
@@ -3533,7 +3540,7 @@ lumina\_node\_wasm.d.ts:70
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:68
+lumina\_node\_wasm.d.ts:78
 
 ***
 
@@ -3543,7 +3550,7 @@ lumina\_node\_wasm.d.ts:68
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:69
+lumina\_node\_wasm.d.ts:79
 
 ***
 
@@ -3553,7 +3560,7 @@ lumina\_node\_wasm.d.ts:69
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:71
+lumina\_node\_wasm.d.ts:81
 
 
 <a name="interfacescoinmd"></a>
@@ -3576,7 +3583,7 @@ Coin
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:92
+lumina\_node\_wasm.d.ts:61
 
 ***
 
@@ -3586,7 +3593,7 @@ lumina\_node\_wasm.d.ts:92
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:91
+lumina\_node\_wasm.d.ts:60
 
 
 <a name="interfacesprotoanymd"></a>
@@ -3609,7 +3616,7 @@ Protobuf Any type
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:136
+lumina\_node\_wasm.d.ts:118
 
 ***
 
@@ -3619,7 +3626,7 @@ lumina\_node\_wasm.d.ts:136
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:137
+lumina\_node\_wasm.d.ts:119
 
 
 <a name="interfacespublickeymd"></a>
@@ -3642,7 +3649,7 @@ Public key
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:60
+lumina\_node\_wasm.d.ts:70
 
 ***
 
@@ -3652,7 +3659,7 @@ lumina\_node\_wasm.d.ts:60
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:61
+lumina\_node\_wasm.d.ts:71
 
 
 <a name="interfacessigndocmd"></a>
@@ -3675,7 +3682,7 @@ A payload to be signed
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:122
+lumina\_node\_wasm.d.ts:104
 
 ***
 
@@ -3685,7 +3692,7 @@ lumina\_node\_wasm.d.ts:122
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:120
+lumina\_node\_wasm.d.ts:102
 
 ***
 
@@ -3695,7 +3702,7 @@ lumina\_node\_wasm.d.ts:120
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:119
+lumina\_node\_wasm.d.ts:101
 
 ***
 
@@ -3705,7 +3712,7 @@ lumina\_node\_wasm.d.ts:119
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:121
+lumina\_node\_wasm.d.ts:103
 
 
 <a name="interfacestxconfigmd"></a>
@@ -3728,7 +3735,7 @@ Transaction config.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:109
+lumina\_node\_wasm.d.ts:136
 
 ***
 
@@ -3738,7 +3745,7 @@ lumina\_node\_wasm.d.ts:109
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:110
+lumina\_node\_wasm.d.ts:137
 
 
 <a name="interfacestxinfomd"></a>
@@ -3761,7 +3768,7 @@ Transaction info
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:101
+lumina\_node\_wasm.d.ts:128
 
 ***
 
@@ -3771,7 +3778,7 @@ lumina\_node\_wasm.d.ts:101
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:102
+lumina\_node\_wasm.d.ts:129
 
 # Type Aliases
 
@@ -3813,4 +3820,4 @@ A function that produces a signature of a payload
 
 ### Defined in
 
-lumina\_node\_wasm.d.ts:128
+lumina\_node\_wasm.d.ts:110

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.9.0...lumina-node-v0.9.1) - 2025-02-24
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-types, celestia-types
+
 ## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.8.0...lumina-node-v0.9.0) - 2025-01-28
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.9.0...celestia-rpc-v0.9.1) - 2025-02-24
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.8.0...celestia-rpc-v0.9.0) - 2025-01-28
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.10.0...celestia-types-v0.10.1) - 2025-02-24
+
+### Added
+
+- *(types)* Make fields of `ShareProof` public (#538)
+
 ## [0.10.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.9.0...celestia-types-v0.10.0) - 2025-01-28
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION



## 🤖 New release

* `celestia-types`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `lumina-node-wasm`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `lumina-node-uniffi`: 0.1.0
* `lumina-cli`: 0.6.0 -> 0.6.1
* `celestia-rpc`: 0.9.0 -> 0.9.1
* `lumina-node`: 0.9.0 -> 0.9.1
* `celestia-grpc`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`

<blockquote>

## [0.10.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.10.0...celestia-types-v0.10.1) - 2025-02-24

### Added

- *(types)* Make fields of `ShareProof` public (#538)
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.8.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.0...lumina-node-wasm-v0.8.1) - 2025-02-24

### Other

- *(ci)* fix outdated lockfiles when releasing to npm (#544)
- remove outdated shwap note and link to changelog for js (#536)
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-uniffi-v0.1.0) - 2025-02-24

### Added

- *(node-uniffi)* [**breaking**] Use in-memory stores if base path is not set (#530)
- adding uniffi bindings to support android and ios (#473)

### Fixed

- *(node-uniffi)* [**breaking**] Serialize correctly ExtendedHeader to json (#531)

### Other

- *(ci)* add releasing for node-uniffi (#545)
</blockquote>

## `lumina-cli`

<blockquote>

## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.0...lumina-cli-v0.6.1) - 2025-02-24

### Other

- updated the following local packages: celestia-types
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.9.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.9.0...celestia-rpc-v0.9.1) - 2025-02-24

### Other

- updated the following local packages: celestia-types
</blockquote>

## `lumina-node`

<blockquote>

## [0.9.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.9.0...lumina-node-v0.9.1) - 2025-02-24

### Other

- updated the following local packages: celestia-types, celestia-types, celestia-types
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.2.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.0...celestia-grpc-v0.2.1) - 2025-02-24

### Other

- updated the following local packages: celestia-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).