### PR TITLE
feat(types): Make fields of `ShareProof` public

### DIFF
--- a/types/src/share/proof.rs
+++ b/types/src/share/proof.rs
@@ -18,10 +18,10 @@ use crate::{nmt::Namespace, Error, Result};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "RawShareProof", into = "RawShareProof")]
 pub struct ShareProof {
-    data: Vec<[u8; SHARE_SIZE]>,
-    namespace_id: Namespace,
-    share_proofs: Vec<NamespaceProof>,
-    row_proof: RowProof,
+    pub data: Vec<[u8; SHARE_SIZE]>,
+    pub namespace_id: Namespace,
+    pub share_proofs: Vec<NamespaceProof>,
+    pub row_proof: RowProof,
 }
 
 impl ShareProof {

--- a/types/src/share/proof.rs
+++ b/types/src/share/proof.rs
@@ -18,9 +18,13 @@ use crate::{nmt::Namespace, Error, Result};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "RawShareProof", into = "RawShareProof")]
 pub struct ShareProof {
+    /// The shares, as a Vec of byte arrays
     pub data: Vec<[u8; SHARE_SIZE]>,
+    /// The namespace of the shares
     pub namespace_id: Namespace,
+    /// Vec of the NMT multiproofs for the rows spanned by the range
     pub share_proofs: Vec<NamespaceProof>,
+    /// Proofs for row roots into data root
     pub row_proof: RowProof,
 }
 


### PR DESCRIPTION
I need to construct a ShareProof from its parts. There is no constructor besides the unfriendly protobuf types.