### PR TITLE
ci: Fix lumina-node version bump

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -53,6 +53,9 @@ jobs:
           node_wasm_version="$(cargo pkgid --manifest-path=node-wasm/Cargo.toml | cut -d@ -f 2)"
           cd node-wasm/js
 
+          # Update the version of lumina-node-wasm dependency
+          npm install "lumina-node-wasm@$node_wasm_version"
+
           # Update lumina-node version
           if ! npm version $node_wasm_version >/dev/null; then
             echo "Version up to date"
@@ -64,8 +67,6 @@ jobs:
           # Update the readme for lumina-node
           wasm-pack build ..
           npm run update-readme
-          # Update the version of lumina-node-wasm dependency
-          npm pkg set "dependencies[lumina-node-wasm]=$node_wasm_version"
 
           # push a commit to release-plz's pr
           # prepare graphql query


### PR DESCRIPTION
As far as I understand, version bump step happens after lumina-node-wasm has been published, so `npm install` should work here. I think existing code used `npm pkg set`because everything used to be done in release-plz flow..