### PR TITLE
chore(ci): fix outdated lockfiles when releasing to npm

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
-          set -eu
+          set -xeuo pipefail
 
           pr_branch_name="${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}"
 
@@ -58,19 +58,23 @@ jobs:
             echo "Version up to date"
             exit
           fi
-          # Update the types definition for lumina-node
+
+          wasm-pack build ..
+
+          # Update lockfile with new node-wasm version
+          npm install --save ../pkg
           npm clean-install
+
+          # Update the types definition for lumina-node
           npm run tsc
           # Update the readme for lumina-node
-          wasm-pack build ..
           npm run update-readme
-          # Update the version of lumina-node-wasm dependency
-          npm pkg set "dependencies[lumina-node-wasm]=$node_wasm_version"
 
           # push a commit to release-plz's pr
           # prepare graphql query
           branch_sha="$(git rev-parse "$pr_branch_name")"
           package_json="$(base64 --wrap 0 package.json)"
+          package_lock_json="$(base64 --wrap 0 package-lock.json)"
           readme="$(base64 --wrap 0 README.md)"
           types_definitions="$(base64 --wrap 0 index.d.ts)"
           query='{"query": "mutation {
@@ -88,6 +92,10 @@ jobs:
                   {
                     path: \"node-wasm/js/package.json\",
                     contents: \"'"$package_json"'\"
+                  },
+                  {
+                    path: \"node-wasm/js/package-lock.json\",
+                    contents: \"'"$package_lock_json"'\"
                   },
                   {
                     path: \"node-wasm/js/README.md\",
@@ -140,6 +148,8 @@ jobs:
         env:
           NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
         run: |
+          set -xeuo pipefail
+
           published_version=$(npm show lumina-node-wasm version)
           local_version="$(cargo pkgid --manifest-path=node-wasm/Cargo.toml | cut -d@ -f 2)"
 
@@ -154,4 +164,6 @@ jobs:
 
           # publish lumina-node
           cd node-wasm/js
+          # replace dependency on node-wasm from path based to version in npm
+          npm pkg set "dependencies[lumina-node-wasm]=$local_version"
           npm publish --access public

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "lumina-node",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "lumina-node-wasm": "0.7.0"
+                "lumina-node-wasm": "file:../pkg"
             },
             "devDependencies": {
                 "concat-md": "^0.5.1",
@@ -17,6 +17,11 @@
                 "typedoc-plugin-markdown": "^4.3.2",
                 "typescript": "^5.6.3"
             }
+        },
+        "../pkg": {
+            "name": "lumina-node-wasm",
+            "version": "0.8.0",
+            "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.26.2",
@@ -1759,9 +1764,8 @@
             }
         },
         "node_modules/lumina-node-wasm": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/lumina-node-wasm/-/lumina-node-wasm-0.7.0.tgz",
-            "integrity": "sha512-uFFggtEDcn1gNLaSRaCS5By1RY08P/txT+gUvrMVAqkrsdiv5XTpJOTOY4gGxDMUPRpOLjyO8t6L/AetJnx5AA=="
+            "resolved": "../pkg",
+            "link": true
         },
         "node_modules/lunr": {
             "version": "2.3.9",

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.8.0"
+        "lumina-node-wasm": "file:../pkg"
     },
     "keywords": [
         "blockchain",


### PR DESCRIPTION
Currently we update package.json with new version of node-wasm and commit that from release-plz PR. However we can't keep lock file up to date this way, because at this time, the new version is not yet in npm.

To fix that, we depend on node-wasm based on the path and update the lockfile in release-plz PR. The actual version-based dependency is only set temporarily when we are releasing to npm.