### PR TITLE
test(rpc): Use `AuthLevel::Skip` and provide `new_test_client_with_url`

### DIFF
--- a/rpc/tests/auth_token.rs
+++ b/rpc/tests/auth_token.rs
@@ -17,8 +17,8 @@ async fn blob_submit_using_bridge_node() {
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
 
-    // AuthLevel::Skip
-    let unauthorized_client = new_test_client_with_url(AuthLevel::Skip, CELESTIA_BRIDGE_RPC_URL).await;
+    let unauthorized_client =
+        new_test_client_with_url(AuthLevel::Skip, CELESTIA_BRIDGE_RPC_URL).await;
     assert!(unauthorized_client.is_err());
 
     for auth_level in [AuthLevel::Read, AuthLevel::Write, AuthLevel::Admin] {

--- a/rpc/tests/auth_token.rs
+++ b/rpc/tests/auth_token.rs
@@ -6,7 +6,7 @@ use celestia_types::Blob;
 
 pub mod utils;
 
-use crate::utils::client::{blob_submit, new_test_client, AuthLevel};
+use crate::utils::client::{blob_submit, new_test_client_with_url, AuthLevel};
 use crate::utils::{random_bytes, random_ns};
 
 // Use node-1 (bridge node) as the RPC URL
@@ -14,7 +14,7 @@ const CELESTIA_BRIDGE_RPC_URL: &str = "ws://localhost:36658";
 
 #[tokio::test]
 async fn blob_submit_and_get_using_bridge_node() {
-    let client = new_test_client(AuthLevel::Write, Some(CELESTIA_BRIDGE_RPC_URL))
+    let client = new_test_client_with_url(AuthLevel::Write, CELESTIA_BRIDGE_RPC_URL)
         .await
         .unwrap();
     let namespace = random_ns();

--- a/rpc/tests/auth_token.rs
+++ b/rpc/tests/auth_token.rs
@@ -1,0 +1,63 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use celestia_rpc::prelude::*;
+use celestia_types::consts::appconsts::AppVersion;
+use celestia_types::Blob;
+
+pub mod utils;
+
+use crate::utils::client::{blob_submit, new_test_client, AuthLevel};
+use crate::utils::{random_bytes, random_ns};
+
+// Use node-1 (bridge node) as the RPC URL
+const CELESTIA_BRIDGE_RPC_URL: &str = "ws://localhost:36658";
+
+#[tokio::test]
+async fn blob_submit_and_get_using_bridge_node() {
+    let client = new_test_client(AuthLevel::Write, Some(CELESTIA_BRIDGE_RPC_URL))
+        .await
+        .unwrap();
+    let namespace = random_ns();
+    let data = random_bytes(5);
+    let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
+
+    let submitted_height = blob_submit(&client, &[blob.clone()]).await.unwrap();
+
+    let dah = client
+        .header_get_by_height(submitted_height)
+        .await
+        .unwrap()
+        .dah;
+    let root_hash = dah.row_root(0).unwrap();
+
+    let received_blob = client
+        .blob_get(submitted_height, namespace, blob.commitment)
+        .await
+        .unwrap();
+
+    received_blob.validate(AppVersion::V2).unwrap();
+    assert_blob_equal_to_sent(&received_blob, &blob);
+
+    let proofs = client
+        .blob_get_proof(submitted_height, namespace, blob.commitment)
+        .await
+        .unwrap();
+
+    assert_eq!(proofs.len(), 1);
+
+    let leaves = blob.to_shares().unwrap();
+
+    proofs[0]
+        .verify_complete_namespace(&root_hash, &leaves, namespace.into())
+        .unwrap();
+}
+
+/// Blobs received from chain have index field set, so to
+/// compare if they are equal to the ones we sent, we need
+/// to overwrite the index field with received one.
+#[track_caller]
+fn assert_blob_equal_to_sent(received: &Blob, sent: &Blob) {
+    let mut sent = sent.clone();
+    sent.index = received.index;
+    assert_eq!(&sent, received);
+}

--- a/rpc/tests/auth_token.rs
+++ b/rpc/tests/auth_token.rs
@@ -1,6 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use celestia_rpc::prelude::*;
 use celestia_types::consts::appconsts::AppVersion;
 use celestia_types::Blob;
 
@@ -13,51 +12,27 @@ use crate::utils::{random_bytes, random_ns};
 const CELESTIA_BRIDGE_RPC_URL: &str = "ws://localhost:36658";
 
 #[tokio::test]
-async fn blob_submit_and_get_using_bridge_node() {
-    let client = new_test_client_with_url(AuthLevel::Write, CELESTIA_BRIDGE_RPC_URL)
-        .await
-        .unwrap();
+async fn blob_submit_using_bridge_node() {
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
 
-    let submitted_height = blob_submit(&client, &[blob.clone()]).await.unwrap();
+    // AuthLevel::Skip
+    let unauthorized_client = new_test_client_with_url(AuthLevel::Skip, CELESTIA_BRIDGE_RPC_URL).await;
+    assert!(unauthorized_client.is_err());
 
-    let dah = client
-        .header_get_by_height(submitted_height)
-        .await
-        .unwrap()
-        .dah;
-    let root_hash = dah.row_root(0).unwrap();
+    for auth_level in [AuthLevel::Read, AuthLevel::Write, AuthLevel::Admin] {
+        let client = new_test_client_with_url(auth_level, CELESTIA_BRIDGE_RPC_URL)
+            .await
+            .unwrap();
 
-    let received_blob = client
-        .blob_get(submitted_height, namespace, blob.commitment)
-        .await
-        .unwrap();
-
-    received_blob.validate(AppVersion::V2).unwrap();
-    assert_blob_equal_to_sent(&received_blob, &blob);
-
-    let proofs = client
-        .blob_get_proof(submitted_height, namespace, blob.commitment)
-        .await
-        .unwrap();
-
-    assert_eq!(proofs.len(), 1);
-
-    let leaves = blob.to_shares().unwrap();
-
-    proofs[0]
-        .verify_complete_namespace(&root_hash, &leaves, namespace.into())
-        .unwrap();
-}
-
-/// Blobs received from chain have index field set, so to
-/// compare if they are equal to the ones we sent, we need
-/// to overwrite the index field with received one.
-#[track_caller]
-fn assert_blob_equal_to_sent(received: &Blob, sent: &Blob) {
-    let mut sent = sent.clone();
-    sent.index = received.index;
-    assert_eq!(&sent, received);
+        match auth_level {
+            AuthLevel::Read => {
+                blob_submit(&client, &[blob.clone()]).await.unwrap_err();
+            }
+            _ => {
+                blob_submit(&client, &[blob.clone()]).await.unwrap();
+            }
+        }
+    }
 }

--- a/rpc/tests/blob.rs
+++ b/rpc/tests/blob.rs
@@ -16,7 +16,7 @@ use crate::utils::{random_bytes, random_bytes_array, random_ns};
 
 #[tokio::test]
 async fn blob_submit_and_get() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -54,7 +54,7 @@ async fn blob_submit_and_get() {
 
 #[tokio::test]
 async fn blob_submit_and_get_all() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespaces = &[random_ns(), random_ns()];
 
     let blobs = &[
@@ -89,7 +89,7 @@ async fn blob_submit_and_get_all() {
 
 #[tokio::test]
 async fn blob_submit_and_get_large() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024 * 1024);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -120,7 +120,7 @@ async fn blob_submit_and_get_large() {
 
 #[tokio::test]
 async fn blob_subscribe() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
 
     let mut incoming_blobs = client.blob_subscribe(namespace).await.unwrap();
@@ -160,7 +160,7 @@ async fn blob_subscribe() {
 
 #[tokio::test]
 async fn blob_submit_too_large() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5 * 1024 * 1024);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -170,7 +170,7 @@ async fn blob_submit_too_large() {
 
 #[tokio::test]
 async fn blob_get_get_proof_wrong_ns() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -190,7 +190,7 @@ async fn blob_get_get_proof_wrong_ns() {
 
 #[tokio::test]
 async fn blob_get_get_proof_wrong_commitment() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -211,7 +211,7 @@ async fn blob_get_get_proof_wrong_commitment() {
 
 #[tokio::test]
 async fn blob_get_all_with_no_blobs() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let blobs = client.blob_get_all(3, &[random_ns()]).await.unwrap();
 

--- a/rpc/tests/blob.rs
+++ b/rpc/tests/blob.rs
@@ -16,7 +16,7 @@ use crate::utils::{random_bytes, random_bytes_array, random_ns};
 
 #[tokio::test]
 async fn blob_submit_and_get() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -54,7 +54,7 @@ async fn blob_submit_and_get() {
 
 #[tokio::test]
 async fn blob_submit_and_get_all() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespaces = &[random_ns(), random_ns()];
 
     let blobs = &[
@@ -89,7 +89,7 @@ async fn blob_submit_and_get_all() {
 
 #[tokio::test]
 async fn blob_submit_and_get_large() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024 * 1024);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -120,7 +120,7 @@ async fn blob_submit_and_get_large() {
 
 #[tokio::test]
 async fn blob_subscribe() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
 
     let mut incoming_blobs = client.blob_subscribe(namespace).await.unwrap();
@@ -160,7 +160,7 @@ async fn blob_subscribe() {
 
 #[tokio::test]
 async fn blob_submit_too_large() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5 * 1024 * 1024);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -170,7 +170,7 @@ async fn blob_submit_too_large() {
 
 #[tokio::test]
 async fn blob_get_get_proof_wrong_ns() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -190,7 +190,7 @@ async fn blob_get_get_proof_wrong_ns() {
 
 #[tokio::test]
 async fn blob_get_get_proof_wrong_commitment() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();
@@ -211,7 +211,7 @@ async fn blob_get_get_proof_wrong_commitment() {
 
 #[tokio::test]
 async fn blob_get_all_with_no_blobs() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let blobs = client.blob_get_all(3, &[random_ns()]).await.unwrap();
 

--- a/rpc/tests/das.rs
+++ b/rpc/tests/das.rs
@@ -9,7 +9,7 @@ use crate::utils::client::{new_test_client, AuthLevel};
 
 #[tokio::test]
 async fn das_sampling_stats() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let stats1 = client.das_sampling_stats().await.unwrap();
     assert!(matches!(stats1, SamplingStats { .. }));
@@ -25,7 +25,7 @@ async fn das_sampling_stats() {
 
 #[tokio::test]
 async fn das_wait_catch_up() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     client.das_wait_catch_up().await.unwrap();
 

--- a/rpc/tests/das.rs
+++ b/rpc/tests/das.rs
@@ -9,7 +9,7 @@ use crate::utils::client::{new_test_client, AuthLevel};
 
 #[tokio::test]
 async fn das_sampling_stats() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let stats1 = client.das_sampling_stats().await.unwrap();
     assert!(matches!(stats1, SamplingStats { .. }));
@@ -25,7 +25,7 @@ async fn das_sampling_stats() {
 
 #[tokio::test]
 async fn das_wait_catch_up() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     client.das_wait_catch_up().await.unwrap();
 

--- a/rpc/tests/header.rs
+++ b/rpc/tests/header.rs
@@ -8,7 +8,7 @@ use crate::utils::client::{new_test_client, AuthLevel};
 
 #[tokio::test]
 async fn local_head() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let local_head = client.header_local_head().await.unwrap();
 
@@ -26,7 +26,7 @@ async fn local_head() {
 
 #[tokio::test]
 async fn get_by_height() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
     let second_header = client.header_get_by_height(2).await.unwrap();
@@ -37,14 +37,14 @@ async fn get_by_height() {
 
 #[tokio::test]
 async fn get_by_height_non_existent() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     client.header_get_by_height(999_999_999).await.unwrap_err();
 }
 
 #[tokio::test]
 async fn get_by_hash() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
     let genesis_header2 = client
@@ -57,7 +57,7 @@ async fn get_by_hash() {
 
 #[tokio::test]
 async fn get_range_by_height() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
     let second_header = client.header_get_by_height(2).await.unwrap();
@@ -73,7 +73,7 @@ async fn get_range_by_height() {
 
 #[tokio::test]
 async fn network_head() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let network_head = client.header_network_head().await.unwrap();
 
@@ -90,7 +90,7 @@ async fn network_head() {
 
 #[tokio::test]
 async fn subscribe() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
 
@@ -104,7 +104,7 @@ async fn subscribe() {
 
 #[tokio::test]
 async fn sync_state() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let state1 = client.header_sync_state().await.unwrap();
 

--- a/rpc/tests/header.rs
+++ b/rpc/tests/header.rs
@@ -8,7 +8,7 @@ use crate::utils::client::{new_test_client, AuthLevel};
 
 #[tokio::test]
 async fn local_head() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let local_head = client.header_local_head().await.unwrap();
 
@@ -26,7 +26,7 @@ async fn local_head() {
 
 #[tokio::test]
 async fn get_by_height() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
     let second_header = client.header_get_by_height(2).await.unwrap();
@@ -37,14 +37,14 @@ async fn get_by_height() {
 
 #[tokio::test]
 async fn get_by_height_non_existent() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     client.header_get_by_height(999_999_999).await.unwrap_err();
 }
 
 #[tokio::test]
 async fn get_by_hash() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
     let genesis_header2 = client
@@ -57,7 +57,7 @@ async fn get_by_hash() {
 
 #[tokio::test]
 async fn get_range_by_height() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
     let second_header = client.header_get_by_height(2).await.unwrap();
@@ -73,7 +73,7 @@ async fn get_range_by_height() {
 
 #[tokio::test]
 async fn network_head() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let network_head = client.header_network_head().await.unwrap();
 
@@ -90,7 +90,7 @@ async fn network_head() {
 
 #[tokio::test]
 async fn subscribe() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let genesis_header = client.header_get_by_height(1).await.unwrap();
 
@@ -104,7 +104,7 @@ async fn subscribe() {
 
 #[tokio::test]
 async fn sync_state() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let state1 = client.header_sync_state().await.unwrap();
 

--- a/rpc/tests/p2p.rs
+++ b/rpc/tests/p2p.rs
@@ -9,7 +9,7 @@ pub mod utils;
 
 #[tokio::test]
 async fn info_test() {
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     client.p2p_info().await.expect("Failed to get node info");
 }
 
@@ -19,7 +19,7 @@ async fn add_remove_peer_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let initial_peers = client
         .p2p_peers()
@@ -75,7 +75,7 @@ async fn protect_unprotect_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     client
         .p2p_connect(&addr_info)
@@ -125,7 +125,7 @@ async fn peer_block_unblock_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let blocked_peers = client
         .p2p_list_blocked_peers()
@@ -162,7 +162,7 @@ async fn peer_block_unblock_test() {
 async fn bandwidth_stats_test() {
     // just check whether we can get the data without error, node could have been running any
     // amount of time, so any value should be valid.
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     client
         .p2p_bandwidth_stats()
         .await
@@ -174,7 +174,7 @@ async fn bandwidth_for_peer_test() {
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = p2p::PeerId(PeerId::from(local_key.public()));
 
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let stats = client
         .p2p_bandwidth_for_peer(&local_peer_id)
         .await
@@ -189,7 +189,7 @@ async fn bandwidth_for_peer_test() {
 
 #[tokio::test]
 async fn bandwidth_for_protocol_test() {
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     // query for nonsense protocol name so that we get all zeros in response
     // until we have better way of inducing traffic
@@ -206,7 +206,7 @@ async fn bandwidth_for_protocol_test() {
 #[tokio::test]
 async fn nat_status_test() {
     // just query for status and make sure no errors happen, since any value is potentially correct
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let _ = client
         .p2p_nat_status()
         .await
@@ -218,7 +218,7 @@ async fn peer_info_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     client
         .p2p_connect(&addr_info)
@@ -242,7 +242,7 @@ async fn peer_info_test() {
 
 #[tokio::test]
 async fn pub_sub_peers_test() {
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let peers = client
         .p2p_pub_sub_peers("topic")
         .await
@@ -254,7 +254,7 @@ async fn pub_sub_peers_test() {
 #[tokio::test]
 async fn resource_state_test() {
     // cannot really test values here, just make sure it deserializes correctly
-    let client = new_test_client(AuthLevel::Admin).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     client
         .p2p_resource_state()
         .await

--- a/rpc/tests/p2p.rs
+++ b/rpc/tests/p2p.rs
@@ -9,7 +9,7 @@ pub mod utils;
 
 #[tokio::test]
 async fn info_test() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     client.p2p_info().await.expect("Failed to get node info");
 }
 
@@ -19,7 +19,7 @@ async fn add_remove_peer_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let initial_peers = client
         .p2p_peers()
@@ -75,7 +75,7 @@ async fn protect_unprotect_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     client
         .p2p_connect(&addr_info)
@@ -125,7 +125,7 @@ async fn peer_block_unblock_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let blocked_peers = client
         .p2p_list_blocked_peers()
@@ -162,7 +162,7 @@ async fn peer_block_unblock_test() {
 async fn bandwidth_stats_test() {
     // just check whether we can get the data without error, node could have been running any
     // amount of time, so any value should be valid.
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     client
         .p2p_bandwidth_stats()
         .await
@@ -174,7 +174,7 @@ async fn bandwidth_for_peer_test() {
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = p2p::PeerId(PeerId::from(local_key.public()));
 
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let stats = client
         .p2p_bandwidth_for_peer(&local_peer_id)
         .await
@@ -189,7 +189,7 @@ async fn bandwidth_for_peer_test() {
 
 #[tokio::test]
 async fn bandwidth_for_protocol_test() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     // query for nonsense protocol name so that we get all zeros in response
     // until we have better way of inducing traffic
@@ -206,7 +206,7 @@ async fn bandwidth_for_protocol_test() {
 #[tokio::test]
 async fn nat_status_test() {
     // just query for status and make sure no errors happen, since any value is potentially correct
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let _ = client
         .p2p_nat_status()
         .await
@@ -218,7 +218,7 @@ async fn peer_info_test() {
     let addr_info = utils::tiny_node::start_tiny_node()
         .await
         .expect("failed to spin up second node");
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     client
         .p2p_connect(&addr_info)
@@ -242,7 +242,7 @@ async fn peer_info_test() {
 
 #[tokio::test]
 async fn pub_sub_peers_test() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let peers = client
         .p2p_pub_sub_peers("topic")
         .await
@@ -254,7 +254,7 @@ async fn pub_sub_peers_test() {
 #[tokio::test]
 async fn resource_state_test() {
     // cannot really test values here, just make sure it deserializes correctly
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     client
         .p2p_resource_state()
         .await

--- a/rpc/tests/share.rs
+++ b/rpc/tests/share.rs
@@ -12,7 +12,7 @@ use crate::utils::{random_bytes, random_ns, random_ns_range};
 
 #[tokio::test]
 async fn get_share() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let header = client.header_network_head().await.unwrap();
     let square_width = header.dah.square_width() as u64;
 
@@ -28,7 +28,7 @@ async fn get_share() {
 
 #[tokio::test]
 async fn get_shares_by_namespace() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let blobs: Vec<_> = (0..4)
         .map(|_| {
@@ -57,7 +57,7 @@ async fn get_shares_by_namespace() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_forbidden() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let header = client.header_network_head().await.unwrap();
 
     // those namespaces are forbidden in celestia-node's implementation
@@ -71,7 +71,7 @@ async fn get_shares_by_namespace_forbidden() {
 
 #[tokio::test]
 async fn get_shares_range() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -106,7 +106,7 @@ async fn get_shares_range() {
 
 #[tokio::test]
 async fn get_shares_range_not_existing() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let header = client.header_network_head().await.unwrap();
     let shares_in_block = header.dah.square_width().pow(2);
 
@@ -122,7 +122,7 @@ async fn get_shares_range_not_existing() {
 
 #[tokio::test]
 async fn get_shares_range_ignores_parity() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let namespace = random_ns();
     let data = random_bytes(100);
@@ -141,7 +141,7 @@ async fn get_shares_range_ignores_parity() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_wrong_ns() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -182,7 +182,7 @@ async fn get_shares_by_namespace_wrong_ns() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_wrong_ns_out_of_range() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -208,7 +208,7 @@ async fn get_shares_by_namespace_wrong_ns_out_of_range() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_wrong_roots() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -227,7 +227,7 @@ async fn get_shares_by_namespace_wrong_roots() {
 
 #[tokio::test]
 async fn get_eds() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = vec![1, 2, 3, 4];
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();

--- a/rpc/tests/share.rs
+++ b/rpc/tests/share.rs
@@ -12,7 +12,7 @@ use crate::utils::{random_bytes, random_ns, random_ns_range};
 
 #[tokio::test]
 async fn get_share() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let header = client.header_network_head().await.unwrap();
     let square_width = header.dah.square_width() as u64;
 
@@ -28,7 +28,7 @@ async fn get_share() {
 
 #[tokio::test]
 async fn get_shares_by_namespace() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let blobs: Vec<_> = (0..4)
         .map(|_| {
@@ -57,7 +57,7 @@ async fn get_shares_by_namespace() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_forbidden() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let header = client.header_network_head().await.unwrap();
 
     // those namespaces are forbidden in celestia-node's implementation
@@ -71,7 +71,7 @@ async fn get_shares_by_namespace_forbidden() {
 
 #[tokio::test]
 async fn get_shares_range() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -106,7 +106,7 @@ async fn get_shares_range() {
 
 #[tokio::test]
 async fn get_shares_range_not_existing() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let header = client.header_network_head().await.unwrap();
     let shares_in_block = header.dah.square_width().pow(2);
 
@@ -122,7 +122,7 @@ async fn get_shares_range_not_existing() {
 
 #[tokio::test]
 async fn get_shares_range_ignores_parity() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let namespace = random_ns();
     let data = random_bytes(100);
@@ -141,7 +141,7 @@ async fn get_shares_range_ignores_parity() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_wrong_ns() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -182,7 +182,7 @@ async fn get_shares_by_namespace_wrong_ns() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_wrong_ns_out_of_range() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -208,7 +208,7 @@ async fn get_shares_by_namespace_wrong_ns_out_of_range() {
 
 #[tokio::test]
 async fn get_shares_by_namespace_wrong_roots() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
@@ -227,7 +227,7 @@ async fn get_shares_by_namespace_wrong_roots() {
 
 #[tokio::test]
 async fn get_eds() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = vec![1, 2, 3, 4];
     let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();

--- a/rpc/tests/state.rs
+++ b/rpc/tests/state.rs
@@ -11,20 +11,20 @@ use crate::utils::client::{new_test_client, AuthLevel};
 
 #[tokio::test]
 async fn account_address() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let _addr = client.state_account_address().await.unwrap();
 }
 
 #[tokio::test]
 async fn balance() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let balance = client.state_balance().await.unwrap();
     assert_eq!(balance.denom, "utia");
 }
 
 #[tokio::test]
 async fn balance_for_address() {
-    let client = new_test_client(AuthLevel::Read).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
 
     let my_addr = client.state_account_address().await.unwrap();
     let my_balance = client.state_balance().await.unwrap();
@@ -35,7 +35,7 @@ async fn balance_for_address() {
 
 #[tokio::test]
 async fn submit_pay_for_blob() {
-    let client = new_test_client(AuthLevel::Write).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();

--- a/rpc/tests/state.rs
+++ b/rpc/tests/state.rs
@@ -11,20 +11,20 @@ use crate::utils::client::{new_test_client, AuthLevel};
 
 #[tokio::test]
 async fn account_address() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let _addr = client.state_account_address().await.unwrap();
 }
 
 #[tokio::test]
 async fn balance() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let balance = client.state_balance().await.unwrap();
     assert_eq!(balance.denom, "utia");
 }
 
 #[tokio::test]
 async fn balance_for_address() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
 
     let my_addr = client.state_account_address().await.unwrap();
     let my_balance = client.state_balance().await.unwrap();
@@ -35,7 +35,7 @@ async fn balance_for_address() {
 
 #[tokio::test]
 async fn submit_pay_for_blob() {
-    let client = new_test_client(AuthLevel::Skip, None).await.unwrap();
+    let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(5);
     let blob = Blob::new(namespace, data, AppVersion::V2).unwrap();

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -58,8 +58,7 @@ pub async fn new_test_client_with_url(
 }
 
 pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
-    let url = env_or("CELESTIA_RPC_URL", CELESTIA_RPC_URL);
-    new_test_client_with_url(auth_level, &url).await
+    new_test_client_with_url(auth_level, CELESTIA_RPC_URL).await
 }
 
 pub async fn blob_submit<C>(client: &C, blobs: &[Blob]) -> Result<u64, ClientError>

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -38,10 +38,6 @@ fn env_or(var_name: &str, or_value: &str) -> String {
     env::var(var_name).unwrap_or_else(|_| or_value.to_owned())
 }
 
-pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
-    new_test_client_with_url(auth_level, CELESTIA_RPC_URL).await
-}
-
 pub async fn new_test_client_with_url(
     auth_level: AuthLevel,
     celestia_rpc_url: &str,
@@ -56,6 +52,11 @@ pub async fn new_test_client_with_url(
     client.header_wait_for_height(2).await?;
 
     Ok(client)
+}
+
+pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
+    let url = env_or("CELESTIA_RPC_URL", CELESTIA_RPC_URL);
+    new_test_client_with_url(auth_level, &url).await
 }
 
 pub async fn blob_submit<C>(client: &C, blobs: &[Blob]) -> Result<u64, ClientError>

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -39,16 +39,7 @@ fn env_or(var_name: &str, or_value: &str) -> String {
 }
 
 pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
-    let _ = dotenvy::dotenv();
-    let token = token_from_env(auth_level)?;
-    let url = env_or("CELESTIA_RPC_URL", CELESTIA_RPC_URL);
-
-    let client = Client::new(&url, token.as_deref()).await?;
-
-    // minimum 2 blocks
-    client.header_wait_for_height(2).await?;
-
-    Ok(client)
+    new_test_client_with_url(auth_level, CELESTIA_RPC_URL).await
 }
 
 pub async fn new_test_client_with_url(

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -19,7 +19,7 @@ async fn write_lock() -> MutexGuard<'static, ()> {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AuthLevel {
-    Public,
+    Skip,
     Read,
     Write,
     Admin,
@@ -27,7 +27,7 @@ pub enum AuthLevel {
 
 fn token_from_env(auth_level: AuthLevel) -> Result<Option<String>> {
     match auth_level {
-        AuthLevel::Public => Ok(None),
+        AuthLevel::Skip => Ok(None),
         AuthLevel::Read => Ok(Some(env::var("CELESTIA_NODE_AUTH_TOKEN_READ")?)),
         AuthLevel::Write => Ok(Some(env::var("CELESTIA_NODE_AUTH_TOKEN_WRITE")?)),
         AuthLevel::Admin => Ok(Some(env::var("CELESTIA_NODE_AUTH_TOKEN_ADMIN")?)),
@@ -38,10 +38,16 @@ fn env_or(var_name: &str, or_value: &str) -> String {
     env::var(var_name).unwrap_or_else(|_| or_value.to_owned())
 }
 
-pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
+pub async fn new_test_client(
+    auth_level: AuthLevel,
+    celestia_rpc_url: Option<&str>,
+) -> Result<Client> {
     let _ = dotenvy::dotenv();
     let token = token_from_env(auth_level)?;
-    let url = env_or("CELESTIA_RPC_URL", CELESTIA_RPC_URL);
+    let url = env_or(
+        "CELESTIA_RPC_URL",
+        celestia_rpc_url.unwrap_or(CELESTIA_RPC_URL),
+    );
 
     let client = Client::new(&url, token.as_deref()).await?;
 

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -53,7 +53,7 @@ pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
 
 pub async fn new_test_client_with_url(
     auth_level: AuthLevel,
-    celestia_rpc_url: &str
+    celestia_rpc_url: &str,
 ) -> Result<Client> {
     let _ = dotenvy::dotenv();
     let token = token_from_env(auth_level)?;

--- a/rpc/tests/utils/client.rs
+++ b/rpc/tests/utils/client.rs
@@ -38,16 +38,26 @@ fn env_or(var_name: &str, or_value: &str) -> String {
     env::var(var_name).unwrap_or_else(|_| or_value.to_owned())
 }
 
-pub async fn new_test_client(
+pub async fn new_test_client(auth_level: AuthLevel) -> Result<Client> {
+    let _ = dotenvy::dotenv();
+    let token = token_from_env(auth_level)?;
+    let url = env_or("CELESTIA_RPC_URL", CELESTIA_RPC_URL);
+
+    let client = Client::new(&url, token.as_deref()).await?;
+
+    // minimum 2 blocks
+    client.header_wait_for_height(2).await?;
+
+    Ok(client)
+}
+
+pub async fn new_test_client_with_url(
     auth_level: AuthLevel,
-    celestia_rpc_url: Option<&str>,
+    celestia_rpc_url: &str
 ) -> Result<Client> {
     let _ = dotenvy::dotenv();
     let token = token_from_env(auth_level)?;
-    let url = env_or(
-        "CELESTIA_RPC_URL",
-        celestia_rpc_url.unwrap_or(CELESTIA_RPC_URL),
-    );
+    let url = env_or("CELESTIA_RPC_URL", celestia_rpc_url);
 
     let client = Client::new(&url, token.as_deref()).await?;
 


### PR DESCRIPTION
Hi @zvolin,

Following my review of https://github.com/eigerco/lumina/issues/570, I've slightly adjusted the `auth_level` logic within `new_test_client`. The tests now correctly handle both scenarios:

- Light node (`node-2`) with the **_skip-auth_** flag enabled.
- Bridge node (`node-1`) without the **_skip-auth_** flag.

I'd greatly appreciate your feedback on this update before I move forward with the remaining RPC methods.

Thanks!