### PR TITLE
feat(rpc): support the share.GetRow RPC endpoint

### DIFF
--- a/rpc/src/share.rs
+++ b/rpc/src/share.rs
@@ -22,11 +22,16 @@ pub struct GetRangeResponse {
     pub proof: ShareProof,
 }
 
+/// Side of a row within the EDS.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
-pub enum HalfSide {
+pub enum RowSide {
+    /// The row data is on the left of the EDS (i.e. in the ODS).
     Left,
+    /// The row data is on the right of the EDS (i.e. it's parity data).
     Right,
+    /// The row contains both the original data and the parity data.
+    Both,
 }
 
 /// Response type for [`ShareClient::share_get_row`].
@@ -34,8 +39,8 @@ pub enum HalfSide {
 pub struct GetRowResponse {
     /// Shares contained in given range.
     pub shares: Vec<Share>,
-    /// Proof of inclusion of the shares.
-    pub side: HalfSide,
+    /// Side of the row within the EDS.
+    pub side: RowSide,
 }
 
 mod rpc {

--- a/rpc/tests/share.rs
+++ b/rpc/tests/share.rs
@@ -1,10 +1,9 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use celestia_rpc::prelude::*;
-use celestia_rpc::Client;
 use celestia_types::consts::appconsts::AppVersion;
 use celestia_types::nmt::{Namespace, NamespacedSha2Hasher};
-use celestia_types::{consts, Blob};
+use celestia_types::Blob;
 
 pub mod utils;
 

--- a/rpc/tests/share.rs
+++ b/rpc/tests/share.rs
@@ -268,7 +268,7 @@ async fn get_shares_by_row() {
     let row_index = blob_index / ods_width;
     let index_in_row = (blob_index % ods_width) as usize;
 
-    let n_rows_to_fetch = (index_in_row + shares.len() + ods_width - 1) / ods_width;
+    let n_rows_to_fetch = (index_in_row + shares.len()).div_ceil(ods_width);
     let mut rows = Vec::with_capacity(n_rows_to_fetch);
     for i in 0..n_rows_to_fetch {
         let row = client
@@ -278,10 +278,10 @@ async fn get_shares_by_row() {
         rows.push(row);
     }
 
-    for i in 0..shares.len() {
+    for (i, share) in shares.iter().enumerate() {
         let row_index = (blob_index + i) / ods_width;
         let index_in_row = (blob_index + i) % ods_width;
 
-        assert_eq!(shares[i], rows[row_index].shares[index_in_row]);
+        assert_eq!(share, &rows[row_index].shares[index_in_row]);
     }
 }

--- a/rpc/tests/share.rs
+++ b/rpc/tests/share.rs
@@ -1,9 +1,10 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use celestia_rpc::prelude::*;
+use celestia_rpc::Client;
 use celestia_types::consts::appconsts::AppVersion;
 use celestia_types::nmt::{Namespace, NamespacedSha2Hasher};
-use celestia_types::Blob;
+use celestia_types::{consts, Blob};
 
 pub mod utils;
 


### PR DESCRIPTION
Tested with a QuickNode RPC. The CI setup uses light nodes v0.20.4 which does not support the endpoint and upgrading the repository to the latest version was out of scope for this.