### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "celestia-grpc-macros",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3573,7 +3573,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blockstore",
  "celestia-types",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.9.1", path = "node" }
-lumina-node-wasm = { version = "0.8.1", path = "node-wasm" }
+lumina-node = { version = "0.10.0", path = "node" }
+lumina-node-wasm = { version = "0.8.2", path = "node-wasm" }
 lumina-utils = { version = "0.1.0", path = "utils" }
 celestia-proto = { version = "0.7.0", path = "proto" }
-celestia-grpc = { version = "0.2.1", path = "grpc" }
-celestia-rpc = { version = "0.9.1", path = "rpc", default-features = false }
-celestia-types = { version = "0.10.1", path = "types", default-features = false }
+celestia-grpc = { version = "0.2.2", path = "grpc" }
+celestia-rpc = { version = "0.9.2", path = "rpc", default-features = false }
+celestia-types = { version = "0.11.0", path = "types", default-features = false }
 tendermint = { version = "0.40.0", default-features = false }
 tendermint-proto = "0.40.0"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.1...lumina-cli-v0.6.2) - 2025-03-31
+
+### Added
+
+- *(node-wasm)* Multiplex message channel connection to worker ([#563](https://github.com/eigerco/lumina/pull/563))
+- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
+
 ## [0.6.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.0...lumina-cli-v0.6.1) - 2025-02-24
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.1...celestia-grpc-v0.2.2) - 2025-03-31
+
+### Added
+
+- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))
+- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
+
 ## [0.2.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.0...celestia-grpc-v0.2.1) - 2025-02-24
 
 ### Other

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"
@@ -22,7 +22,7 @@ categories = [
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-celestia-grpc-macros = { version = "0.2.0", path = "grpc-macros" }
+celestia-grpc-macros = { version = "0.2.1", path = "grpc-macros" }
 celestia-proto = { workspace = true, features = ["tonic"] }
 celestia-types.workspace = true
 prost.workspace = true

--- a/grpc/grpc-macros/CHANGELOG.md
+++ b/grpc/grpc-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.2.0...celestia-grpc-macros-v0.2.1) - 2025-03-31
+
+### Added
+
+- *(grpc)* increase max message size to handle big celestia blocks ([#559](https://github.com/eigerco/lumina/pull/559))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.1.0...celestia-grpc-macros-v0.2.0) - 2025-01-28
 
 ### Added

--- a/grpc/grpc-macros/Cargo.toml
+++ b/grpc/grpc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc-macros"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Helper crate for grpc_method macro for creating gRPC client, used by celestia-grpc"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.0...lumina-node-uniffi-v0.1.1) - 2025-03-31
+
+### Other
+
+- *(node-uniffi)* Add minimal test case in Kotlin and Swift ([#535](https://github.com/eigerco/lumina/pull/535))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-node-uniffi-v0.1.0) - 2025-02-24
 
 ### Added

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.1...lumina-node-wasm-v0.8.2) - 2025-03-31
+
+### Added
+
+- *(node-wasm)* Multiplex message channel connection to worker ([#563](https://github.com/eigerco/lumina/pull/563))
+- *(node)* Resolve dnsaddr in lumina-node ([#577](https://github.com/eigerco/lumina/pull/577))
+- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))
+- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
+
 ## [0.8.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.0...lumina-node-wasm-v0.8.1) - 2025-02-24
 
 ### Other

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.8.1",
+            "version": "0.8.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.8.1",
+            "version": "0.8.2",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.9.1...lumina-node-v0.10.0) - 2025-03-31
+
+### Added
+
+- *(node)* Resolve dnsaddr in lumina-node ([#577](https://github.com/eigerco/lumina/pull/577))
+- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))
+- *(node)* update bootstrappers ([#561](https://github.com/eigerco/lumina/pull/561))
+- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
+- *(node)* [**breaking**] Replace `Store::remove_tail` with `Store::remove_height` ([#553](https://github.com/eigerco/lumina/pull/553))
+
 ## [0.9.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.9.0...lumina-node-v0.9.1) - 2025-02-24
 
 ### Other

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.9.1...celestia-rpc-v0.9.2) - 2025-03-31
+
+### Added
+
+- *(rpc)* add DAS module with sampling stats and catch-up methods ([#557](https://github.com/eigerco/lumina/pull/557))
+
 ## [0.9.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.9.0...celestia-rpc-v0.9.1) - 2025-02-24
 
 ### Other

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.10.1...celestia-types-v0.11.0) - 2025-03-31
+
+### Added
+
+- *(types)* remove Deserialize from Row & Sample ([#580](https://github.com/eigerco/lumina/pull/580))
+- *(types)* [**breaking**] add state error codes related to blob submission ([#560](https://github.com/eigerco/lumina/pull/560))
+
+### Other
+
+- *(types)* fix flaky blob reconstruct when len == 0 ([#541](https://github.com/eigerco/lumina/pull/541))
+
 ## [0.10.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.10.0...celestia-types-v0.10.1) - 2025-02-24
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-utils-v0.1.0) - 2025-03-31
+
+### Added
+
+- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))


### PR DESCRIPTION



## 🤖 New release

* `celestia-types`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)
* `celestia-rpc`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `lumina-utils`: 0.1.0
* `lumina-node`: 0.9.1 -> 0.10.0 (⚠ API breaking changes)
* `lumina-cli`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `celestia-grpc-macros`: 0.2.0 -> 0.2.1
* `celestia-grpc`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `lumina-node-wasm`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `lumina-node-uniffi`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

### ⚠ `celestia-types` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant ErrorCode:ReservedNamespace in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:339
  variant ErrorCode:InvalidNamespaceLen in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:341
  variant ErrorCode:InvalidDataSize in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:343
  variant ErrorCode:BlobSizeMismatch in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:345
  variant ErrorCode:CommittedSquareSizeNotPowOf2 in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:347
  variant ErrorCode:CalculateCommitment in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:349
  variant ErrorCode:InvalidShareCommitment in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:351
  variant ErrorCode:ParitySharesNamespace in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:353
  variant ErrorCode:TailPaddingNamespace in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:355
  variant ErrorCode:TxNamespace in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:357
  variant ErrorCode:InvalidShareCommitments in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:359
  variant ErrorCode:UnsupportedShareVersion in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:361
  variant ErrorCode:ZeroBlobSize in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:363
  variant ErrorCode:MismatchedNumberOfPFBorBlob in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:365
  variant ErrorCode:NoPFB in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:367
  variant ErrorCode:NamespaceMismatch in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:369
  variant ErrorCode:ProtoParsing in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:371
  variant ErrorCode:MultipleMsgsInBlobTx in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:373
  variant ErrorCode:MismatchedNumberOfPFBComponent in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:375
  variant ErrorCode:NoBlobs in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:377
  variant ErrorCode:NoNamespaces in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:379
  variant ErrorCode:NoShareVersions in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:381
  variant ErrorCode:NoBlobSizes in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:383
  variant ErrorCode:NoShareCommitments in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:385
  variant ErrorCode:InvalidNamespace in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:387
  variant ErrorCode:InvalidNamespaceVersion in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:389
  variant ErrorCode:TotalBlobSizeTooLarge in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:393
  variant ErrorCode:BlobsTooLarge in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:395
  variant ErrorCode:InvalidBlobSigner in /tmp/.tmpKxJj6K/lumina/types/src/state/tx.rs:397
```

### ⚠ `lumina-node` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant NodeBuilderError:FailedResolvingBootnodes in /tmp/.tmpKxJj6K/lumina/node/src/node/builder.rs:64

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_method_added.ron

Failed in:
  trait method lumina_node::store::Store::remove_height in file /tmp/.tmpKxJj6K/lumina/node/src/store.rs:169

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_method_missing.ron

Failed in:
  method remove_last of trait Store, previously in file /tmp/.tmpQIRTHr/lumina-node/src/store.rs:169
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`

<blockquote>

## [0.11.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.10.1...celestia-types-v0.11.0) - 2025-03-31

### Added

- *(types)* remove Deserialize from Row & Sample ([#580](https://github.com/eigerco/lumina/pull/580))
- *(types)* [**breaking**] add state error codes related to blob submission ([#560](https://github.com/eigerco/lumina/pull/560))

### Other

- *(types)* fix flaky blob reconstruct when len == 0 ([#541](https://github.com/eigerco/lumina/pull/541))
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.9.2](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.9.1...celestia-rpc-v0.9.2) - 2025-03-31

### Added

- *(rpc)* add DAS module with sampling stats and catch-up methods ([#557](https://github.com/eigerco/lumina/pull/557))
</blockquote>

## `lumina-utils`

<blockquote>

## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-utils-v0.1.0) - 2025-03-31

### Added

- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))
</blockquote>

## `lumina-node`

<blockquote>

## [0.10.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.9.1...lumina-node-v0.10.0) - 2025-03-31

### Added

- *(node)* Resolve dnsaddr in lumina-node ([#577](https://github.com/eigerco/lumina/pull/577))
- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))
- *(node)* update bootstrappers ([#561](https://github.com/eigerco/lumina/pull/561))
- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
- *(node)* [**breaking**] Replace `Store::remove_tail` with `Store::remove_height` ([#553](https://github.com/eigerco/lumina/pull/553))
</blockquote>

## `lumina-cli`

<blockquote>

## [0.6.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.1...lumina-cli-v0.6.2) - 2025-03-31

### Added

- *(node-wasm)* Multiplex message channel connection to worker ([#563](https://github.com/eigerco/lumina/pull/563))
- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
</blockquote>

## `celestia-grpc-macros`

<blockquote>

## [0.2.1](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.2.0...celestia-grpc-macros-v0.2.1) - 2025-03-31

### Added

- *(grpc)* increase max message size to handle big celestia blocks ([#559](https://github.com/eigerco/lumina/pull/559))
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.2.2](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.1...celestia-grpc-v0.2.2) - 2025-03-31

### Added

- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))
- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.8.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.1...lumina-node-wasm-v0.8.2) - 2025-03-31

### Added

- *(node-wasm)* Multiplex message channel connection to worker ([#563](https://github.com/eigerco/lumina/pull/563))
- *(node)* Resolve dnsaddr in lumina-node ([#577](https://github.com/eigerco/lumina/pull/577))
- lumina-utils crate ([#564](https://github.com/eigerco/lumina/pull/564))
- *(ci)* allow other node types than bridge ([#562](https://github.com/eigerco/lumina/pull/562))
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.0...lumina-node-uniffi-v0.1.1) - 2025-03-31

### Other

- *(node-uniffi)* Add minimal test case in Kotlin and Swift ([#535](https://github.com/eigerco/lumina/pull/535))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).