### PR TITLE
chore: Use celestia grpc-web directly

### DIFF
--- a/ci/Dockerfile.validator
+++ b/ci/Dockerfile.validator
@@ -5,7 +5,7 @@ FROM docker.io/alpine:3.19.1
 
 ENV CELESTIA_HOME=/root
 
-RUN apk update && apk add --no-cache bash jq
+RUN apk update && apk add --no-cache bash jq dasel
 
 # Copy in the binary
 COPY --from=ghcr.io/celestiaorg/celestia-app:v3.4.2-mocha /bin/celestia-appd /bin/celestia-appd

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -9,20 +9,11 @@ services:
       # provide amount of DA nodes to provision (default: 1)
       - NODE_COUNT=3
     ports:
-      - 19090:9090
+      - 19090:9090 # grpc
+      - 18080:9091 # grpc-web
     volumes:
       - credentials:/credentials
       - genesis:/genesis
-
-  grpcwebproxy:
-    image: grpcwebproxy
-    platform: "linux/amd64"
-    build:
-      context: .
-      dockerfile: Dockerfile.grpcwebproxy
-    command: --backend_addr=validator:9090 --run_tls_server=false --allow_all_origins
-    ports:
-      - 18080:8080
 
   node-0:
     image: node

--- a/ci/run-validator.sh
+++ b/ci/run-validator.sh
@@ -130,14 +130,13 @@ setup_private_validator() {
   celestia-appd collect-gentxs
 
   # Set proper defaults and change ports
-  # If you encounter: `sed: -I or -i may not be used with stdin` on MacOS you can mitigate by installing gnu-sed
-  # https://gist.github.com/andre3k1/e3a1a7133fded5de5a9ee99c87c6fa0d?permalink_comment_id=3082272#gistcomment-3082272
-  sed -i'.bak' 's|"tcp://127.0.0.1:26657"|"tcp://0.0.0.0:26657"|g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v 'tcp://0.0.0.0:26657' rpc.laddr
   # enable transaction indexing
-  sed -i'.bak' 's|indexer = .*|indexer = "kv"|g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v 'kv' tx_index.indexer
 
   # enable grpc-web
   dasel put -f "$CONFIG_DIR/config/app.toml" -t bool -v true grpc-web.enable
+  # enable unsafe CORS since we don't do security properly in CI
   dasel put -f "$CONFIG_DIR/config/app.toml" -t bool -v true grpc-web.enable-unsafe-cors
 }
 

--- a/ci/run-validator.sh
+++ b/ci/run-validator.sh
@@ -135,6 +135,10 @@ setup_private_validator() {
   sed -i'.bak' 's|"tcp://127.0.0.1:26657"|"tcp://0.0.0.0:26657"|g' "$CONFIG_DIR/config/config.toml"
   # enable transaction indexing
   sed -i'.bak' 's|indexer = .*|indexer = "kv"|g' "$CONFIG_DIR/config/config.toml"
+
+  # enable grpc-web
+  dasel put -f "$CONFIG_DIR/config/app.toml" -t bool -v true grpc-web.enable
+  dasel put -f "$CONFIG_DIR/config/app.toml" -t bool -v true grpc-web.enable-unsafe-cors
 }
 
 main() {


### PR DESCRIPTION
Use grpc-web directly via celestia node and remove grpcwebproxy from ci: https://github.com/celestiaorg/celestia-app/issues/4105