### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "celestia-grpc-macros",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytes",
  "prost",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "base64",
  "bech32",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "blockstore",
  "celestia-types",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "blockstore",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.10.0", path = "node" }
-lumina-node-wasm = { version = "0.8.2", path = "node-wasm" }
-lumina-utils = { version = "0.1.0", path = "utils" }
-celestia-proto = { version = "0.7.0", path = "proto" }
-celestia-grpc = { version = "0.2.2", path = "grpc" }
-celestia-rpc = { version = "0.10.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.11.0", path = "types", default-features = false }
+lumina-node = { version = "0.11.0", path = "node" }
+lumina-node-wasm = { version = "0.8.3", path = "node-wasm" }
+lumina-utils = { version = "0.2.0", path = "utils" }
+celestia-proto = { version = "0.7.1", path = "proto" }
+celestia-grpc = { version = "0.3.0", path = "grpc" }
+celestia-rpc = { version = "0.11.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.11.1", path = "types", default-features = false }
 tendermint = { version = "0.40.3", default-features = false }
 tendermint-proto = "0.40.3"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.2...lumina-cli-v0.6.3) - 2025-05-26
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.6.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.1...lumina-cli-v0.6.2) - 2025-04-02
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.2...celestia-grpc-v0.3.0) - 2025-05-26
+
+### Added
+
+- *(grpc)* expose DocSigner and IntoAny ([#604](https://github.com/eigerco/lumina/pull/604))
+
+### Other
+
+- *(rpc,node)* [**breaking**] Fix clippy issues ([#626](https://github.com/eigerco/lumina/pull/626))
+
 ## [0.2.2](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.1...celestia-grpc-v0.2.2) - 2025-04-02
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.1...lumina-node-uniffi-v0.1.2) - 2025-05-26
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.0...lumina-node-uniffi-v0.1.1) - 2025-04-02
 
 ### Other

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.2...lumina-node-wasm-v0.8.3) - 2025-05-26
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.8.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.1...lumina-node-wasm-v0.8.2) - 2025-04-02
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -3683,7 +3683,7 @@ Auth module parameters
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:88
+lumina\_node\_wasm.d.ts:78
 
 ***
 
@@ -3693,7 +3693,7 @@ lumina\_node\_wasm.d.ts:88
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:91
+lumina\_node\_wasm.d.ts:81
 
 ***
 
@@ -3703,7 +3703,7 @@ lumina\_node\_wasm.d.ts:91
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:92
+lumina\_node\_wasm.d.ts:82
 
 ***
 
@@ -3713,7 +3713,7 @@ lumina\_node\_wasm.d.ts:92
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:89
+lumina\_node\_wasm.d.ts:79
 
 ***
 
@@ -3723,7 +3723,7 @@ lumina\_node\_wasm.d.ts:89
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:90
+lumina\_node\_wasm.d.ts:80
 
 
 <a name="interfacesbaseaccountmd"></a>
@@ -3746,7 +3746,7 @@ Common data of all account types
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:80
+lumina\_node\_wasm.d.ts:70
 
 ***
 
@@ -3756,7 +3756,7 @@ lumina\_node\_wasm.d.ts:80
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:78
+lumina\_node\_wasm.d.ts:68
 
 ***
 
@@ -3766,7 +3766,7 @@ lumina\_node\_wasm.d.ts:78
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:79
+lumina\_node\_wasm.d.ts:69
 
 ***
 
@@ -3776,7 +3776,7 @@ lumina\_node\_wasm.d.ts:79
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:81
+lumina\_node\_wasm.d.ts:71
 
 
 <a name="interfacescoinmd"></a>
@@ -3799,7 +3799,7 @@ Coin
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:61
+lumina\_node\_wasm.d.ts:92
 
 ***
 
@@ -3809,7 +3809,7 @@ lumina\_node\_wasm.d.ts:61
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:60
+lumina\_node\_wasm.d.ts:91
 
 
 <a name="interfacesprotoanymd"></a>
@@ -3865,7 +3865,7 @@ Public key
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:70
+lumina\_node\_wasm.d.ts:60
 
 ***
 
@@ -3875,7 +3875,7 @@ lumina\_node\_wasm.d.ts:70
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:71
+lumina\_node\_wasm.d.ts:61
 
 
 <a name="interfacessigndocmd"></a>

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.8.2",
+            "version": "0.8.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.8.2",
+            "version": "0.8.3",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.10.0...lumina-node-v0.11.0) - 2025-05-26
+
+### Fixed
+
+- *(utils)* [**breaking**] Fix `timeout` when duration is more than 24.9 days ([#617](https://github.com/eigerco/lumina/pull/617))
+
+### Other
+
+- *(rpc,node)* [**breaking**] Fix clippy issues ([#626](https://github.com/eigerco/lumina/pull/626))
+- Update bootstrappers for mainnet ([#605](https://github.com/eigerco/lumina/pull/605))
+
 ## [0.10.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.9.1...lumina-node-v0.10.0) - 2025-04-02
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.0...celestia-proto-v0.7.1) - 2025-05-26
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.6.0...celestia-proto-v0.7.0) - 2025-01-28
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.10.0...celestia-rpc-v0.11.0) - 2025-05-26
+
+### Added
+
+- *(rpc)* [**breaking**] switch to passing self and add new tx config fields ([#629](https://github.com/eigerco/lumina/pull/629))
+- *(rpc)* [**breaking**] update jsonrpsee to version 0.25.1 and refactor RPC methods ([#620](https://github.com/eigerco/lumina/pull/620))
+- *(rpc)* support the share.GetRow RPC endpoint ([#583](https://github.com/eigerco/lumina/pull/583))
+- *(rpc)* Add Blobstream API ([#543](https://github.com/eigerco/lumina/pull/543))
+
+### Other
+
+- *(rpc)* Use `AuthLevel::Skip` and provide `new_test_client_with_url` ([#582](https://github.com/eigerco/lumina/pull/582))
+
 ## [0.10.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.9.1...celestia-rpc-v0.10.0) - 2025-04-02
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.0...celestia-types-v0.11.1) - 2025-05-26
+
+### Fixed
+
+- *(types)* Fix clippy issues ([#594](https://github.com/eigerco/lumina/pull/594))
+
+### Other
+
+- Upgrade to tendermint 0.40.3 ([#622](https://github.com/eigerco/lumina/pull/622))
+
 ## [0.11.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.10.1...celestia-types-v0.11.0) - 2025-04-02
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-utils-v0.1.0...lumina-utils-v0.2.0) - 2025-05-26
+
+### Fixed
+
+- *(utils)* [**breaking**] Fix `timeout` when duration is more than 24.9 days ([#617](https://github.com/eigerco/lumina/pull/617))
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/lumina-utils-v0.1.0) - 2025-04-02
 
 ### Added

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-utils"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Platform abstraction utilities used across lumina project"


### PR DESCRIPTION



## 🤖 New release

* `celestia-proto`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `celestia-types`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `celestia-rpc`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `lumina-utils`: 0.1.0 -> 0.2.0 (✓ API compatible changes)
* `lumina-node`: 0.10.0 -> 0.11.0 (✓ API compatible changes)
* `lumina-cli`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `celestia-grpc`: 0.2.2 -> 0.3.0 (✓ API compatible changes)
* `lumina-node-wasm`: 0.8.2 -> 0.8.3 (✓ API compatible changes)
* `lumina-node-uniffi`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

### ⚠ `celestia-rpc` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TxConfig.max_gas_price in /tmp/.tmpICpRQp/lumina/rpc/src/tx_config.rs:47
  field TxConfig.priority in /tmp/.tmpICpRQp/lumina/rpc/src/tx_config.rs:53
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-proto`

<blockquote>

## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.0...celestia-proto-v0.7.1) - 2025-05-26

### Other

- update Cargo.toml dependencies
</blockquote>

## `celestia-types`

<blockquote>

## [0.11.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.0...celestia-types-v0.11.1) - 2025-05-26

### Fixed

- *(types)* Fix clippy issues ([#594](https://github.com/eigerco/lumina/pull/594))

### Other

- Upgrade to tendermint 0.40.3 ([#622](https://github.com/eigerco/lumina/pull/622))
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.11.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.10.0...celestia-rpc-v0.11.0) - 2025-05-26

### Added

- *(rpc)* [**breaking**] switch to passing self and add new tx config fields ([#629](https://github.com/eigerco/lumina/pull/629))
- *(rpc)* [**breaking**] update jsonrpsee to version 0.25.1 and refactor RPC methods ([#620](https://github.com/eigerco/lumina/pull/620))
- *(rpc)* support the share.GetRow RPC endpoint ([#583](https://github.com/eigerco/lumina/pull/583))
- *(rpc)* Add Blobstream API ([#543](https://github.com/eigerco/lumina/pull/543))

### Other

- *(rpc)* Use `AuthLevel::Skip` and provide `new_test_client_with_url` ([#582](https://github.com/eigerco/lumina/pull/582))
</blockquote>

## `lumina-utils`

<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-utils-v0.1.0...lumina-utils-v0.2.0) - 2025-05-26

### Fixed

- *(utils)* [**breaking**] Fix `timeout` when duration is more than 24.9 days ([#617](https://github.com/eigerco/lumina/pull/617))
</blockquote>

## `lumina-node`

<blockquote>

## [0.11.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.10.0...lumina-node-v0.11.0) - 2025-05-26

### Fixed

- *(utils)* [**breaking**] Fix `timeout` when duration is more than 24.9 days ([#617](https://github.com/eigerco/lumina/pull/617))

### Other

- *(rpc,node)* [**breaking**] Fix clippy issues ([#626](https://github.com/eigerco/lumina/pull/626))
- Update bootstrappers for mainnet ([#605](https://github.com/eigerco/lumina/pull/605))
</blockquote>

## `lumina-cli`

<blockquote>

## [0.6.3](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.2...lumina-cli-v0.6.3) - 2025-05-26

### Other

- update Cargo.lock dependencies
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.2...celestia-grpc-v0.3.0) - 2025-05-26

### Added

- *(grpc)* expose DocSigner and IntoAny ([#604](https://github.com/eigerco/lumina/pull/604))

### Other

- *(rpc,node)* [**breaking**] Fix clippy issues ([#626](https://github.com/eigerco/lumina/pull/626))
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.8.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.2...lumina-node-wasm-v0.8.3) - 2025-05-26

### Other

- update Cargo.toml dependencies
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.1.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.1...lumina-node-uniffi-v0.1.2) - 2025-05-26

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).