### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blockstore",
  "celestia-types",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.11.0", path = "node" }
-lumina-node-wasm = { version = "0.8.3", path = "node-wasm" }
+lumina-node = { version = "0.12.0", path = "node" }
+lumina-node-wasm = { version = "0.8.4", path = "node-wasm" }
 lumina-utils = { version = "0.2.0", path = "utils" }
 celestia-proto = { version = "0.7.1", path = "proto" }
 celestia-grpc = { version = "0.3.0", path = "grpc" }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.3...lumina-cli-v0.6.4) - 2025-06-09
+
+### Other
+
+- updated the following local packages: lumina-node
+
 ## [0.6.3](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.2...lumina-cli-v0.6.3) - 2025-05-26
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.2...lumina-node-uniffi-v0.1.3) - 2025-06-09
+
+### Other
+
+- updated the following local packages: lumina-node
+
 ## [0.1.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.1...lumina-node-uniffi-v0.1.2) - 2025-05-26
 
 ### Other

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.3...lumina-node-wasm-v0.8.4) - 2025-06-09
+
+### Other
+
+- updated the following local packages: lumina-node
+
 ## [0.8.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.2...lumina-node-wasm-v0.8.3) - 2025-05-26
 
 ### Other

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.11.0...lumina-node-v0.12.0) - 2025-06-09
+
+### Fixed
+
+- Fix doc builds, new rust? :thinking: ([#650](https://github.com/eigerco/lumina/pull/650))
+- *(node)* [**breaking**] Do not fail fast on dns-over-https ([#648](https://github.com/eigerco/lumina/pull/648))
+
+### Other
+
+- update mocha validators to match celestia ([#633](https://github.com/eigerco/lumina/pull/633))
+
 ## [0.11.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.10.0...lumina-node-v0.11.0) - 2025-05-26
 
 ### Fixed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"


### PR DESCRIPTION



## 🤖 New release

* `lumina-node`: 0.11.0 -> 0.12.0 (⚠ API breaking changes)
* `lumina-cli`: 0.6.3 -> 0.6.4
* `lumina-node-wasm`: 0.8.3 -> 0.8.4
* `lumina-node-uniffi`: 0.1.2 -> 0.1.3

### ⚠ `lumina-node` breaking changes

```text
--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant NodeBuilderError::FailedResolvingBootnodes in /tmp/.tmpz6Wyss/lumina/node/src/node/builder.rs:64
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-node`

<blockquote>

## [0.12.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.11.0...lumina-node-v0.12.0) - 2025-06-09

### Fixed

- Fix doc builds, new rust? :thinking: ([#650](https://github.com/eigerco/lumina/pull/650))
- *(node)* [**breaking**] Do not fail fast on dns-over-https ([#648](https://github.com/eigerco/lumina/pull/648))

### Other

- update mocha validators to match celestia ([#633](https://github.com/eigerco/lumina/pull/633))
</blockquote>

## `lumina-cli`

<blockquote>

## [0.6.4](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.3...lumina-cli-v0.6.4) - 2025-06-09

### Other

- updated the following local packages: lumina-node
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.8.4](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.3...lumina-node-wasm-v0.8.4) - 2025-06-09

### Other

- updated the following local packages: lumina-node
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.1.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.2...lumina-node-uniffi-v0.1.3) - 2025-06-09

### Other

- updated the following local packages: lumina-node
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).