### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "prost",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "base64",
  "bech32",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.11.0", path = "node" }
-lumina-node-wasm = { version = "0.8.3", path = "node-wasm" }
+lumina-node = { version = "0.12.0", path = "node" }
+lumina-node-wasm = { version = "0.8.4", path = "node-wasm" }
 lumina-utils = { version = "0.2.0", path = "utils" }
-celestia-proto = { version = "0.7.1", path = "proto" }
-celestia-grpc = { version = "0.3.0", path = "grpc" }
-celestia-rpc = { version = "0.11.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.11.1", path = "types", default-features = false }
+celestia-proto = { version = "0.7.2", path = "proto" }
+celestia-grpc = { version = "0.3.1", path = "grpc" }
+celestia-rpc = { version = "0.11.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.11.2", path = "types", default-features = false }
 tendermint = { version = "0.40.3", default-features = false }
 tendermint-proto = "0.40.3"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.3...lumina-cli-v0.6.4) - 2025-06-09
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.6.3](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.2...lumina-cli-v0.6.3) - 2025-05-26
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.3.0...celestia-grpc-v0.3.1) - 2025-06-09
+
+### Added
+
+- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.2.2...celestia-grpc-v0.3.0) - 2025-05-26
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.2...lumina-node-uniffi-v0.1.3) - 2025-06-09
+
+### Added
+
+- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
+
 ## [0.1.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.1...lumina-node-uniffi-v0.1.2) - 2025-05-26
 
 ### Other

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.3...lumina-node-wasm-v0.8.4) - 2025-06-09
+
+### Other
+
+- updated the following local packages: celestia-types, lumina-node, celestia-grpc, celestia-rpc
+
 ## [0.8.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.2...lumina-node-wasm-v0.8.3) - 2025-05-26
 
 ### Other

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.11.0...lumina-node-v0.12.0) - 2025-06-09
+
+### Added
+
+- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
+
+### Fixed
+
+- Fix doc builds, new rust? :thinking: ([#650](https://github.com/eigerco/lumina/pull/650))
+- *(node)* [**breaking**] Do not fail fast on dns-over-https ([#648](https://github.com/eigerco/lumina/pull/648))
+
+### Other
+
+- update mocha validators to match celestia ([#633](https://github.com/eigerco/lumina/pull/633))
+
 ## [0.11.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.10.0...lumina-node-v0.11.0) - 2025-05-26
 
 ### Fixed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.1...celestia-proto-v0.7.2) - 2025-06-09
+
+### Added
+
+- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
+
 ## [0.7.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.0...celestia-proto-v0.7.1) - 2025-05-26
 
 ### Other

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.0...celestia-rpc-v0.11.1) - 2025-06-09
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.11.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.10.0...celestia-rpc-v0.11.0) - 2025-05-26
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.1...celestia-types-v0.11.2) - 2025-06-09
+
+### Added
+
+- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
+
 ## [0.11.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.0...celestia-types-v0.11.1) - 2025-05-26
 
 ### Fixed

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION



## 🤖 New release

* `celestia-proto`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `celestia-types`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `lumina-node`: 0.11.0 -> 0.12.0 (⚠ API breaking changes)
* `lumina-cli`: 0.6.3 -> 0.6.4 (✓ API compatible changes)
* `celestia-grpc`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `lumina-node-uniffi`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `celestia-rpc`: 0.11.0 -> 0.11.1
* `lumina-node-wasm`: 0.8.3 -> 0.8.4

### ⚠ `lumina-node` breaking changes

```text
--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant NodeBuilderError::FailedResolvingBootnodes in /tmp/.tmpox3Wse/lumina/node/src/node/builder.rs:64
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-proto`

<blockquote>

## [0.7.2](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.1...celestia-proto-v0.7.2) - 2025-06-09

### Added

- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
</blockquote>

## `celestia-types`

<blockquote>

## [0.11.2](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.1...celestia-types-v0.11.2) - 2025-06-09

### Added

- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
</blockquote>

## `lumina-node`

<blockquote>

## [0.12.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.11.0...lumina-node-v0.12.0) - 2025-06-09

### Added

- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))

### Fixed

- Fix doc builds, new rust? :thinking: ([#650](https://github.com/eigerco/lumina/pull/650))
- *(node)* [**breaking**] Do not fail fast on dns-over-https ([#648](https://github.com/eigerco/lumina/pull/648))

### Other

- update mocha validators to match celestia ([#633](https://github.com/eigerco/lumina/pull/633))
</blockquote>

## `lumina-cli`

<blockquote>

## [0.6.4](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.3...lumina-cli-v0.6.4) - 2025-06-09

### Other

- update Cargo.lock dependencies
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.3.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.3.0...celestia-grpc-v0.3.1) - 2025-06-09

### Added

- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.1.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.2...lumina-node-uniffi-v0.1.3) - 2025-06-09

### Added

- *(node-uniffi)* Add grpc types and client for uniffi ([#627](https://github.com/eigerco/lumina/pull/627))
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.11.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.0...celestia-rpc-v0.11.1) - 2025-06-09

### Other

- updated the following local packages: celestia-types
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.8.4](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.3...lumina-node-wasm-v0.8.4) - 2025-06-09

### Other

- updated the following local packages: celestia-types, lumina-node, celestia-grpc, celestia-rpc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).