### PR TITLE
chore(node): Fix lifetime warning on nightly

### DIFF
--- a/node/src/block_ranges.rs
+++ b/node/src/block_ranges.rs
@@ -37,7 +37,7 @@ pub enum BlockRangesError {
 type Result<T, E = BlockRangesError> = std::result::Result<T, E>;
 
 pub(crate) trait BlockRangeExt {
-    fn display(&self) -> BlockRangeDisplay;
+    fn display(&self) -> BlockRangeDisplay<'_>;
     fn validate(&self) -> Result<()>;
     fn len(&self) -> u64;
     fn is_adjacent(&self, other: &BlockRange) -> bool;


### PR DESCRIPTION
```
warning: lifetime flowing from input to output with different syntax can be confusing
  --> node/src/block_ranges.rs:40:16
   |
40 |     fn display(&self) -> BlockRangeDisplay;
   |                ^^^^^     ----------------- the lifetime gets resolved as `'_`
   |                |
   |                this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
40 |     fn display(&self) -> BlockRangeDisplay<'_>;
   |                                           ++++
```