### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.12.0", path = "node" }
-lumina-node-wasm = { version = "0.8.4", path = "node-wasm" }
+lumina-node = { version = "0.12.1", path = "node" }
+lumina-node-wasm = { version = "0.8.5", path = "node-wasm" }
 lumina-utils = { version = "0.2.0", path = "utils" }
 celestia-proto = { version = "0.7.2", path = "proto" }
 celestia-grpc = { version = "0.3.1", path = "grpc" }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.4...lumina-cli-v0.6.5) - 2025-06-17
+
+### Other
+
+- updated the following local packages: lumina-node
+
 ## [0.6.4](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.3...lumina-cli-v0.6.4) - 2025-06-09
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.3...lumina-node-uniffi-v0.1.4) - 2025-06-17
+
+### Other
+
+- updated the following local packages: lumina-node
+
 ## [0.1.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.2...lumina-node-uniffi-v0.1.3) - 2025-06-09
 
 ### Added

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.4...lumina-node-wasm-v0.8.5) - 2025-06-17
+
+### Other
+
+- updated the following local packages: lumina-node
+
 ## [0.8.4](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.3...lumina-node-wasm-v0.8.4) - 2025-06-09
 
 ### Other

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.12.0...lumina-node-v0.12.1) - 2025-06-17
+
+### Other
+
+- *(node)* Fix lifetime warning on nightly ([#656](https://github.com/eigerco/lumina/pull/656))
+
 ## [0.12.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.11.0...lumina-node-v0.12.0) - 2025-06-09
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"


### PR DESCRIPTION



## 🤖 New release

* `lumina-node`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `lumina-cli`: 0.6.4 -> 0.6.5
* `lumina-node-wasm`: 0.8.4 -> 0.8.5
* `lumina-node-uniffi`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-node`

<blockquote>

## [0.12.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.12.0...lumina-node-v0.12.1) - 2025-06-17

### Other

- *(node)* Fix lifetime warning on nightly ([#656](https://github.com/eigerco/lumina/pull/656))
</blockquote>

## `lumina-cli`

<blockquote>

## [0.6.5](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.4...lumina-cli-v0.6.5) - 2025-06-17

### Other

- updated the following local packages: lumina-node
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.8.5](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.4...lumina-node-wasm-v0.8.5) - 2025-06-17

### Other

- updated the following local packages: lumina-node
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.1.4](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.3...lumina-node-uniffi-v0.1.4) - 2025-06-17

### Other

- updated the following local packages: lumina-node
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).