### PR TITLE
feat: make Merkle proof fields pub for Blobstream validation

### DIFF
--- a/types/src/data_availability_header.rs
+++ b/types/src/data_availability_header.rs
@@ -346,7 +346,7 @@ impl ValidateBasicWithAppVersion for DataAvailabilityHeader {
 #[serde(try_from = "RawRowProof", into = "RawRowProof")]
 pub struct RowProof {
     row_roots: Vec<NamespacedHash>,
-    proofs: Vec<MerkleProof>,
+    pub proofs: Vec<MerkleProof>,
     start_row: u16,
     end_row: u16,
 }

--- a/types/src/data_availability_header.rs
+++ b/types/src/data_availability_header.rs
@@ -346,8 +346,7 @@ impl ValidateBasicWithAppVersion for DataAvailabilityHeader {
 #[serde(try_from = "RawRowProof", into = "RawRowProof")]
 pub struct RowProof {
     row_roots: Vec<NamespacedHash>,
-    /// Proofs of inclusion of each row root in the data availability header.
-    pub proofs: Vec<MerkleProof>,
+    proofs: Vec<MerkleProof>,
     start_row: u16,
     end_row: u16,
 }
@@ -356,6 +355,11 @@ impl RowProof {
     /// Get the list of row roots this proof proves.
     pub fn row_roots(&self) -> &[NamespacedHash] {
         &self.row_roots
+    }
+
+    /// Get the inclusion proofs of each row root in the data availability header.
+    pub fn proofs(&self) -> &[MerkleProof] {
+        &self.proofs
     }
 
     /// Verify the proof against the hash of [`DataAvailabilityHeader`], proving

--- a/types/src/data_availability_header.rs
+++ b/types/src/data_availability_header.rs
@@ -346,6 +346,7 @@ impl ValidateBasicWithAppVersion for DataAvailabilityHeader {
 #[serde(try_from = "RawRowProof", into = "RawRowProof")]
 pub struct RowProof {
     row_roots: Vec<NamespacedHash>,
+    /// Proofs of inclusion of each row root in the data availability header.
     pub proofs: Vec<MerkleProof>,
     start_row: u16,
     end_row: u16,

--- a/types/src/merkle_proof.rs
+++ b/types/src/merkle_proof.rs
@@ -12,10 +12,10 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "RawMerkleProof", into = "RawMerkleProof")]
 pub struct MerkleProof {
-    index: usize,
-    total: usize,
-    leaf_hash: Hash,
-    aunts: Vec<Hash>,
+    pub index: usize,
+    pub total: usize,
+    pub leaf_hash: Hash,
+    pub aunts: Vec<Hash>,
 }
 
 impl MerkleProof {

--- a/types/src/merkle_proof.rs
+++ b/types/src/merkle_proof.rs
@@ -12,9 +12,13 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "RawMerkleProof", into = "RawMerkleProof")]
 pub struct MerkleProof {
+    /// Leaf index.
     pub index: usize,
+    /// Total number of leaves in the Merkle tree.
     pub total: usize,
+    /// Hash of the leaf.
     pub leaf_hash: Hash,
+    /// Hashes of the sibling nodes at each level of the tree.
     pub aunts: Vec<Hash>,
 }
 


### PR DESCRIPTION
In the context of implementing DA bridging with Blobstream, it is necessary to access specific fields of the `MerkleProof` and `RowProof` structs returned by the RPC client.

This PR makes the fields we found to be necessary public.