### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.12.1", path = "node" }
-lumina-node-wasm = { version = "0.8.5", path = "node-wasm" }
+lumina-node = { version = "0.13.0", path = "node" }
+lumina-node-wasm = { version = "0.9.0", path = "node-wasm" }
 lumina-utils = { version = "0.2.0", path = "utils" }
 celestia-proto = { version = "0.7.2", path = "proto" }
-celestia-grpc = { version = "0.4.0", path = "grpc" }
-celestia-rpc = { version = "0.11.1", path = "rpc", default-features = false }
-celestia-types = { version = "0.11.2", path = "types", default-features = false }
+celestia-grpc = { version = "0.4.1", path = "grpc" }
+celestia-rpc = { version = "0.11.2", path = "rpc", default-features = false }
+celestia-types = { version = "0.12.0", path = "types", default-features = false }
 tendermint = { version = "0.40.3", default-features = false }
 tendermint-proto = "0.40.3"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.7.0...lumina-cli-v0.8.0) - 2025-07-02
+
+### Added
+
+- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
+
 ## [0.7.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.6.4...lumina-cli-v0.7.0) - 2025-06-20
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.4.0...celestia-grpc-v0.4.1) - 2025-07-02
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.3.1...celestia-grpc-v0.4.0) - 2025-06-20
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.4...lumina-node-uniffi-v0.2.0) - 2025-07-02
+
+### Added
+
+- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
+
+### Other
+
+- Fix uninlined-format-args clippy ([#671](https://github.com/eigerco/lumina/pull/671))
+
 ## [0.1.4](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.3...lumina-node-uniffi-v0.1.4) - 2025-06-20
 
 ### Other

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.5...lumina-node-wasm-v0.9.0) - 2025-07-02
+
+### Added
+
+- *(node)* [**breaking**] Use `block_height` for `Node::request_all_blobs` and return error on missing header ([#669](https://github.com/eigerco/lumina/pull/669))
+- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
+
 ## [0.8.5](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.4...lumina-node-wasm-v0.8.5) - 2025-06-20
 
 ### Other

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -86,7 +86,7 @@ Address of an account.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:155
+lumina\_node\_wasm.d.ts:138
 
 ***
 
@@ -102,7 +102,7 @@ lumina\_node\_wasm.d.ts:155
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:150
+lumina\_node\_wasm.d.ts:133
 
 ***
 
@@ -118,7 +118,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:154
+lumina\_node\_wasm.d.ts:137
 
 
 <a name="classesappversionmd"></a>
@@ -143,7 +143,7 @@ App v1
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:170
+lumina\_node\_wasm.d.ts:153
 
 ***
 
@@ -155,7 +155,7 @@ App v2
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:174
+lumina\_node\_wasm.d.ts:157
 
 ***
 
@@ -167,7 +167,19 @@ App v3
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:178
+lumina\_node\_wasm.d.ts:161
+
+***
+
+#### V4
+
+> `readonly` `static` **V4**: [`AppVersion`](#classesappversionmd)
+
+App v4
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:165
 
 ### Methods
 
@@ -181,7 +193,7 @@ lumina\_node\_wasm.d.ts:178
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:162
+lumina\_node\_wasm.d.ts:145
 
 ***
 
@@ -197,7 +209,7 @@ Latest App version variant.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:166
+lumina\_node\_wasm.d.ts:149
 
 
 <a name="classesblobmd"></a>
@@ -240,7 +252,7 @@ Create a new blob with the given data within the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:196
+lumina\_node\_wasm.d.ts:183
 
 ### Properties
 
@@ -252,7 +264,7 @@ A [`Commitment`] computed from the [`Blob`]s data.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:216
+lumina\_node\_wasm.d.ts:203
 
 ***
 
@@ -264,7 +276,7 @@ Data stored within the [`Blob`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:208
+lumina\_node\_wasm.d.ts:195
 
 ***
 
@@ -276,7 +288,7 @@ A [`Namespace`] the [`Blob`] belongs to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:204
+lumina\_node\_wasm.d.ts:191
 
 ***
 
@@ -288,7 +300,7 @@ Version indicating the format in which [`Share`]s should be created from this [`
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:212
+lumina\_node\_wasm.d.ts:199
 
 ### Accessors
 
@@ -322,7 +334,7 @@ Index of the blob's first share in the EDS. Only set for blobs retrieved from ch
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:220
+lumina\_node\_wasm.d.ts:207
 
 ***
 
@@ -360,7 +372,7 @@ Must be present in `share_version 1` and absent otherwise.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:230
+lumina\_node\_wasm.d.ts:217
 
 ### Methods
 
@@ -376,7 +388,7 @@ Clone a blob creating a new deep copy of it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:200
+lumina\_node\_wasm.d.ts:187
 
 ***
 
@@ -390,7 +402,7 @@ lumina\_node\_wasm.d.ts:200
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:192
+lumina\_node\_wasm.d.ts:179
 
 ***
 
@@ -406,7 +418,7 @@ lumina\_node\_wasm.d.ts:192
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:187
+lumina\_node\_wasm.d.ts:174
 
 ***
 
@@ -422,7 +434,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:191
+lumina\_node\_wasm.d.ts:178
 
 
 <a name="classesblockrangemd"></a>
@@ -447,7 +459,7 @@ Last block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:259
+lumina\_node\_wasm.d.ts:246
 
 ***
 
@@ -459,7 +471,7 @@ First block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:255
+lumina\_node\_wasm.d.ts:242
 
 ### Methods
 
@@ -473,7 +485,7 @@ lumina\_node\_wasm.d.ts:255
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:251
+lumina\_node\_wasm.d.ts:238
 
 ***
 
@@ -489,7 +501,7 @@ lumina\_node\_wasm.d.ts:251
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:246
+lumina\_node\_wasm.d.ts:233
 
 ***
 
@@ -505,7 +517,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:250
+lumina\_node\_wasm.d.ts:237
 
 
 <a name="classescommitmentmd"></a>
@@ -566,7 +578,7 @@ read more about that in the [`share commitment rules`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:309
+lumina\_node\_wasm.d.ts:296
 
 ***
 
@@ -582,7 +594,7 @@ Hash of the commitment
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:313
+lumina\_node\_wasm.d.ts:300
 
 ***
 
@@ -598,7 +610,7 @@ lumina\_node\_wasm.d.ts:313
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:304
+lumina\_node\_wasm.d.ts:291
 
 ***
 
@@ -614,7 +626,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:308
+lumina\_node\_wasm.d.ts:295
 
 
 <a name="classesconnectioncounterssnapshotmd"></a>
@@ -637,7 +649,7 @@ The total number of connections, both pending and established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:329
+lumina\_node\_wasm.d.ts:316
 
 ***
 
@@ -649,7 +661,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:345
+lumina\_node\_wasm.d.ts:332
 
 ***
 
@@ -661,7 +673,7 @@ The number of established incoming connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:349
+lumina\_node\_wasm.d.ts:336
 
 ***
 
@@ -673,7 +685,7 @@ The number of established outgoing connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:353
+lumina\_node\_wasm.d.ts:340
 
 ***
 
@@ -685,7 +697,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:333
+lumina\_node\_wasm.d.ts:320
 
 ***
 
@@ -697,7 +709,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:337
+lumina\_node\_wasm.d.ts:324
 
 ***
 
@@ -709,7 +721,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:341
+lumina\_node\_wasm.d.ts:328
 
 ### Methods
 
@@ -723,7 +735,7 @@ lumina\_node\_wasm.d.ts:341
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:325
+lumina\_node\_wasm.d.ts:312
 
 ***
 
@@ -739,7 +751,7 @@ lumina\_node\_wasm.d.ts:325
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:320
+lumina\_node\_wasm.d.ts:307
 
 ***
 
@@ -755,7 +767,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:324
+lumina\_node\_wasm.d.ts:311
 
 
 <a name="classesconsaddressmd"></a>
@@ -782,7 +794,7 @@ Address of a consensus node.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:368
+lumina\_node\_wasm.d.ts:355
 
 ***
 
@@ -798,7 +810,7 @@ lumina\_node\_wasm.d.ts:368
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:363
+lumina\_node\_wasm.d.ts:350
 
 ***
 
@@ -814,7 +826,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:367
+lumina\_node\_wasm.d.ts:354
 
 
 <a name="classesdataavailabilityheadermd"></a>
@@ -882,7 +894,7 @@ Get the a root of the column with the given index.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:432
+lumina\_node\_wasm.d.ts:419
 
 ***
 
@@ -898,7 +910,7 @@ Merkle roots of the [`ExtendedDataSquare`] columns.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:424
+lumina\_node\_wasm.d.ts:411
 
 ***
 
@@ -912,7 +924,7 @@ lumina\_node\_wasm.d.ts:424
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:416
+lumina\_node\_wasm.d.ts:403
 
 ***
 
@@ -930,7 +942,7 @@ This is the data commitment for the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:438
+lumina\_node\_wasm.d.ts:425
 
 ***
 
@@ -952,7 +964,7 @@ Get a root of the row with the given index.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:428
+lumina\_node\_wasm.d.ts:415
 
 ***
 
@@ -968,7 +980,7 @@ Merkle roots of the [`ExtendedDataSquare`] rows.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:420
+lumina\_node\_wasm.d.ts:407
 
 ***
 
@@ -984,7 +996,7 @@ Get the size of the [`ExtendedDataSquare`] for which this header was built.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:442
+lumina\_node\_wasm.d.ts:429
 
 ***
 
@@ -1000,7 +1012,7 @@ lumina\_node\_wasm.d.ts:442
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:411
+lumina\_node\_wasm.d.ts:398
 
 ***
 
@@ -1016,7 +1028,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:415
+lumina\_node\_wasm.d.ts:402
 
 
 <a name="classesextendedheadermd"></a>
@@ -1067,7 +1079,7 @@ Commit metadata and signatures from validators committing the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:573
+lumina\_node\_wasm.d.ts:560
 
 ***
 
@@ -1079,7 +1091,7 @@ Header of the block data availability.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:565
+lumina\_node\_wasm.d.ts:552
 
 ***
 
@@ -1091,7 +1103,7 @@ Tendermint block header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:569
+lumina\_node\_wasm.d.ts:556
 
 ***
 
@@ -1103,7 +1115,7 @@ Information about the set of validators commiting the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:577
+lumina\_node\_wasm.d.ts:564
 
 ### Methods
 
@@ -1119,7 +1131,7 @@ Clone a header producing a deep copy of it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:487
+lumina\_node\_wasm.d.ts:474
 
 ***
 
@@ -1133,7 +1145,7 @@ lumina\_node\_wasm.d.ts:487
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:483
+lumina\_node\_wasm.d.ts:470
 
 ***
 
@@ -1149,7 +1161,7 @@ Get the block hash.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:499
+lumina\_node\_wasm.d.ts:486
 
 ***
 
@@ -1165,7 +1177,7 @@ Get the block height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:491
+lumina\_node\_wasm.d.ts:478
 
 ***
 
@@ -1181,7 +1193,7 @@ Get the hash of the previous header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:503
+lumina\_node\_wasm.d.ts:490
 
 ***
 
@@ -1197,7 +1209,7 @@ Get the block time.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:495
+lumina\_node\_wasm.d.ts:482
 
 ***
 
@@ -1213,7 +1225,7 @@ lumina\_node\_wasm.d.ts:495
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:478
+lumina\_node\_wasm.d.ts:465
 
 ***
 
@@ -1229,7 +1241,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:482
+lumina\_node\_wasm.d.ts:469
 
 ***
 
@@ -1245,7 +1257,7 @@ Decode protobuf encoded header and then validate it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:507
+lumina\_node\_wasm.d.ts:494
 
 ***
 
@@ -1273,7 +1285,7 @@ This function will also return an error if untrusted headers and `self` don't fo
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:517
+lumina\_node\_wasm.d.ts:504
 
 ***
 
@@ -1313,7 +1325,7 @@ This function will also return an error if untrusted headers and `self` don't fo
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:561
+lumina\_node\_wasm.d.ts:548
 
 ***
 
@@ -1353,7 +1365,7 @@ to each other.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:539
+lumina\_node\_wasm.d.ts:526
 
 
 <a name="classesintounderlyingbytesourcemd"></a>
@@ -1374,7 +1386,7 @@ lumina\_node\_wasm.d.ts:539
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:586
+lumina\_node\_wasm.d.ts:573
 
 ***
 
@@ -1384,7 +1396,7 @@ lumina\_node\_wasm.d.ts:586
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:585
+lumina\_node\_wasm.d.ts:572
 
 ### Methods
 
@@ -1398,7 +1410,7 @@ lumina\_node\_wasm.d.ts:585
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:584
+lumina\_node\_wasm.d.ts:571
 
 ***
 
@@ -1412,7 +1424,7 @@ lumina\_node\_wasm.d.ts:584
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:581
+lumina\_node\_wasm.d.ts:568
 
 ***
 
@@ -1432,7 +1444,7 @@ lumina\_node\_wasm.d.ts:581
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:583
+lumina\_node\_wasm.d.ts:570
 
 ***
 
@@ -1452,7 +1464,7 @@ lumina\_node\_wasm.d.ts:583
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:582
+lumina\_node\_wasm.d.ts:569
 
 
 <a name="classesintounderlyingsinkmd"></a>
@@ -1483,7 +1495,7 @@ lumina\_node\_wasm.d.ts:582
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:593
+lumina\_node\_wasm.d.ts:580
 
 ***
 
@@ -1497,7 +1509,7 @@ lumina\_node\_wasm.d.ts:593
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:592
+lumina\_node\_wasm.d.ts:579
 
 ***
 
@@ -1511,7 +1523,7 @@ lumina\_node\_wasm.d.ts:592
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:590
+lumina\_node\_wasm.d.ts:577
 
 ***
 
@@ -1531,7 +1543,7 @@ lumina\_node\_wasm.d.ts:590
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:591
+lumina\_node\_wasm.d.ts:578
 
 
 <a name="classesintounderlyingsourcemd"></a>
@@ -1556,7 +1568,7 @@ lumina\_node\_wasm.d.ts:591
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:599
+lumina\_node\_wasm.d.ts:586
 
 ***
 
@@ -1570,7 +1582,7 @@ lumina\_node\_wasm.d.ts:599
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:597
+lumina\_node\_wasm.d.ts:584
 
 ***
 
@@ -1590,7 +1602,7 @@ lumina\_node\_wasm.d.ts:597
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:598
+lumina\_node\_wasm.d.ts:585
 
 
 <a name="classesnamespacemd"></a>
@@ -1633,7 +1645,7 @@ Returns the trailing 28 bytes indicating the id of the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:708
+lumina\_node\_wasm.d.ts:695
 
 ***
 
@@ -1645,7 +1657,7 @@ Returns the first byte indicating the version of the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:704
+lumina\_node\_wasm.d.ts:691
 
 ***
 
@@ -1659,7 +1671,7 @@ Used to indicate the end of the primary reserved group.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:679
+lumina\_node\_wasm.d.ts:666
 
 ***
 
@@ -1673,7 +1685,7 @@ Used to indicate the beginning of the secondary reserved group.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:685
+lumina\_node\_wasm.d.ts:672
 
 ***
 
@@ -1685,7 +1697,7 @@ Namespace size in bytes.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:658
+lumina\_node\_wasm.d.ts:645
 
 ***
 
@@ -1701,7 +1713,7 @@ merkle roots.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:700
+lumina\_node\_wasm.d.ts:687
 
 ***
 
@@ -1713,7 +1725,7 @@ Primary reserved [`Namespace`] for the compact Shares with MsgPayForBlobs transa
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:666
+lumina\_node\_wasm.d.ts:653
 
 ***
 
@@ -1728,7 +1740,7 @@ so that user-defined namespaces are correctly aligned in `ExtendedDataSquare`
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:673
+lumina\_node\_wasm.d.ts:660
 
 ***
 
@@ -1743,7 +1755,7 @@ blobs before the parity data is generated for the `ExtendedDataSquare`.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:692
+lumina\_node\_wasm.d.ts:679
 
 ***
 
@@ -1755,7 +1767,7 @@ Primary reserved [`Namespace`] for the compact `Share`s with `cosmos SDK` transa
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:662
+lumina\_node\_wasm.d.ts:649
 
 ### Methods
 
@@ -1771,7 +1783,7 @@ Converts the [`Namespace`] to a byte slice.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:654
+lumina\_node\_wasm.d.ts:641
 
 ***
 
@@ -1785,7 +1797,7 @@ lumina\_node\_wasm.d.ts:654
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:632
+lumina\_node\_wasm.d.ts:619
 
 ***
 
@@ -1801,7 +1813,7 @@ lumina\_node\_wasm.d.ts:632
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:627
+lumina\_node\_wasm.d.ts:614
 
 ***
 
@@ -1817,7 +1829,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:631
+lumina\_node\_wasm.d.ts:618
 
 ***
 
@@ -1845,7 +1857,7 @@ version `0` namespace, check [`newV0`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:650
+lumina\_node\_wasm.d.ts:637
 
 ***
 
@@ -1870,7 +1882,7 @@ Check [`Namespace::new_v0`] for more details.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:640
+lumina\_node\_wasm.d.ts:627
 
 
 <a name="classesnetworkinfosnapshotmd"></a>
@@ -1895,7 +1907,7 @@ Gets counters for ongoing network connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:731
+lumina\_node\_wasm.d.ts:718
 
 ***
 
@@ -1907,7 +1919,7 @@ The number of connected peers, i.e. peers with whom at least one established con
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:727
+lumina\_node\_wasm.d.ts:714
 
 ### Methods
 
@@ -1921,7 +1933,7 @@ lumina\_node\_wasm.d.ts:727
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:723
+lumina\_node\_wasm.d.ts:710
 
 ***
 
@@ -1937,7 +1949,7 @@ lumina\_node\_wasm.d.ts:723
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:718
+lumina\_node\_wasm.d.ts:705
 
 ***
 
@@ -1953,7 +1965,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:722
+lumina\_node\_wasm.d.ts:709
 
 
 <a name="classesnodeclientmd"></a>
@@ -1992,7 +2004,7 @@ expected to have `MessagePort`-like interface for sending and receiving messages
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:745
+lumina\_node\_wasm.d.ts:732
 
 ### Methods
 
@@ -2014,7 +2026,7 @@ Establish a new connection to the existing worker over provided port
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:749
+lumina\_node\_wasm.d.ts:736
 
 ***
 
@@ -2030,7 +2042,7 @@ Get all the peers that node is connected to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:786
+lumina\_node\_wasm.d.ts:773
 
 ***
 
@@ -2046,7 +2058,7 @@ Returns a [`BroadcastChannel`] for events generated by [`Node`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:853
+lumina\_node\_wasm.d.ts:840
 
 ***
 
@@ -2060,7 +2072,7 @@ lumina\_node\_wasm.d.ts:853
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:740
+lumina\_node\_wasm.d.ts:727
 
 ***
 
@@ -2082,7 +2094,7 @@ Get a synced header for the block with a given hash.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:829
+lumina\_node\_wasm.d.ts:816
 
 ***
 
@@ -2104,7 +2116,7 @@ Get a synced header for the block with a given height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:833
+lumina\_node\_wasm.d.ts:820
 
 ***
 
@@ -2138,7 +2150,7 @@ If range contains a height of a header that is not found in the store.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:845
+lumina\_node\_wasm.d.ts:832
 
 ***
 
@@ -2154,7 +2166,7 @@ Get the latest locally synced header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:825
+lumina\_node\_wasm.d.ts:812
 
 ***
 
@@ -2170,7 +2182,7 @@ Get the latest header announced in the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:821
+lumina\_node\_wasm.d.ts:808
 
 ***
 
@@ -2192,7 +2204,7 @@ Get data sampling metadata of an already sampled height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:849
+lumina\_node\_wasm.d.ts:836
 
 ***
 
@@ -2208,7 +2220,7 @@ Check whether Lumina is currently running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:753
+lumina\_node\_wasm.d.ts:740
 
 ***
 
@@ -2224,7 +2236,7 @@ Get all the multiaddresses on which the node listens.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:782
+lumina\_node\_wasm.d.ts:769
 
 ***
 
@@ -2240,7 +2252,7 @@ Get node's local peer ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:762
+lumina\_node\_wasm.d.ts:749
 
 ***
 
@@ -2256,7 +2268,7 @@ Get current network info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:778
+lumina\_node\_wasm.d.ts:765
 
 ***
 
@@ -2272,26 +2284,26 @@ Get current [`PeerTracker`] info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:766
+lumina\_node\_wasm.d.ts:753
 
 ***
 
 #### requestAllBlobs()
 
-> **requestAllBlobs**(`header`, `namespace`, `timeout_secs`?): `Promise`\<[`Blob`](#classesblobmd)[]\>
+> **requestAllBlobs**(`namespace`, `block_height`, `timeout_secs`?): `Promise`\<[`Blob`](#classesblobmd)[]\>
 
 Request all blobs with provided namespace in the block corresponding to this header
 using bitswap protocol.
 
 ##### Parameters
 
-###### header
-
-[`ExtendedHeader`](#classesextendedheadermd)
-
 ###### namespace
 
 [`Namespace`](#classesnamespacemd)
+
+###### block\_height
+
+`bigint`
 
 ###### timeout\_secs?
 
@@ -2303,7 +2315,7 @@ using bitswap protocol.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:813
+lumina\_node\_wasm.d.ts:800
 
 ***
 
@@ -2325,7 +2337,7 @@ Request a header for the block with a given hash from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:798
+lumina\_node\_wasm.d.ts:785
 
 ***
 
@@ -2347,7 +2359,7 @@ Request a header for the block with a given height from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:802
+lumina\_node\_wasm.d.ts:789
 
 ***
 
@@ -2363,7 +2375,7 @@ Request the head header from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:794
+lumina\_node\_wasm.d.ts:781
 
 ***
 
@@ -2391,7 +2403,7 @@ The headers will be verified with the `from` header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:808
+lumina\_node\_wasm.d.ts:795
 
 ***
 
@@ -2417,7 +2429,7 @@ Trust or untrust the peer with a given ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:790
+lumina\_node\_wasm.d.ts:777
 
 ***
 
@@ -2439,7 +2451,7 @@ Start a node with the provided config, if it's not running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:757
+lumina\_node\_wasm.d.ts:744
 
 ***
 
@@ -2453,7 +2465,7 @@ lumina\_node\_wasm.d.ts:757
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:758
+lumina\_node\_wasm.d.ts:745
 
 ***
 
@@ -2469,7 +2481,7 @@ Get current header syncing info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:817
+lumina\_node\_wasm.d.ts:804
 
 ***
 
@@ -2485,7 +2497,7 @@ Wait until the node is connected to at least 1 peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:770
+lumina\_node\_wasm.d.ts:757
 
 ***
 
@@ -2501,7 +2513,7 @@ Wait until the node is connected to at least 1 trusted peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:774
+lumina\_node\_wasm.d.ts:761
 
 
 <a name="classesnodeconfigmd"></a>
@@ -2526,7 +2538,7 @@ A list of bootstrap peers to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:880
+lumina\_node\_wasm.d.ts:867
 
 ***
 
@@ -2538,7 +2550,7 @@ A network to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:876
+lumina\_node\_wasm.d.ts:863
 
 ***
 
@@ -2552,25 +2564,26 @@ Whether to store data in persistent memory or not.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:886
+lumina\_node\_wasm.d.ts:873
 
 ### Accessors
 
-#### customPruningDelaySecs
+#### customPruningWindowSecs
 
 ##### Get Signature
 
-> **get** **customPruningDelaySecs**(): `number`
+> **get** **customPruningWindowSecs**(): `number`
 
-Pruning delay defines how much time the pruner should wait after sampling window in
-order to prune the block.
+Pruning window defines maximum age of a block for it to be retained in store.
+
+If pruning window is smaller than sampling window, then blocks will be pruned
+right after they are sampled. This is useful when you want to keep low
+memory footprint but still validate the blockchain.
 
 If this is not set, then default value will apply:
 
-* If `use_persistent_memory == true`, default value is 1 hour.
-* If `use_persistent_memory == false`, default value is 60 seconds.
-
-The minimum value that can be set is 60 seconds.
+* If `use_persistent_memory == true`, default value is 30 days plus 1 hour.
+* If `use_persistent_memory == false`, default value is 0 seconds.
 
 ###### Returns
 
@@ -2578,17 +2591,18 @@ The minimum value that can be set is 60 seconds.
 
 ##### Set Signature
 
-> **set** **customPruningDelaySecs**(`value`): `void`
+> **set** **customPruningWindowSecs**(`value`): `void`
 
-Pruning delay defines how much time the pruner should wait after sampling window in
-order to prune the block.
+Pruning window defines maximum age of a block for it to be retained in store.
+
+If pruning window is smaller than sampling window, then blocks will be pruned
+right after they are sampled. This is useful when you want to keep low
+memory footprint but still validate the blockchain.
 
 If this is not set, then default value will apply:
 
-* If `use_persistent_memory == true`, default value is 1 hour.
-* If `use_persistent_memory == false`, default value is 60 seconds.
-
-The minimum value that can be set is 60 seconds.
+* If `use_persistent_memory == true`, default value is 30 days plus 1 hour.
+* If `use_persistent_memory == false`, default value is 0 seconds.
 
 ###### Parameters
 
@@ -2602,7 +2616,7 @@ The minimum value that can be set is 60 seconds.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:920
+lumina\_node\_wasm.d.ts:900
 
 ***
 
@@ -2614,12 +2628,8 @@ lumina\_node\_wasm.d.ts:920
 
 Sampling window defines maximum age of a block considered for syncing and sampling.
 
-If this is not set, then default value will apply:
-
-* If `use_persistent_memory == true`, default value is 30 days.
-* If `use_persistent_memory == false`, default value is 60 seconds.
-
-The minimum value that can be set is 60 seconds.
+**Default value:** 2592000 seconds (30 days)\
+**Minimum:** 60 seconds
 
 ###### Returns
 
@@ -2631,12 +2641,8 @@ The minimum value that can be set is 60 seconds.
 
 Sampling window defines maximum age of a block considered for syncing and sampling.
 
-If this is not set, then default value will apply:
-
-* If `use_persistent_memory == true`, default value is 30 days.
-* If `use_persistent_memory == false`, default value is 60 seconds.
-
-The minimum value that can be set is 60 seconds.
+**Default value:** 2592000 seconds (30 days)\
+**Minimum:** 60 seconds
 
 ###### Parameters
 
@@ -2650,7 +2656,7 @@ The minimum value that can be set is 60 seconds.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:897
+lumina\_node\_wasm.d.ts:880
 
 ### Methods
 
@@ -2664,7 +2670,7 @@ lumina\_node\_wasm.d.ts:897
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:868
+lumina\_node\_wasm.d.ts:855
 
 ***
 
@@ -2680,7 +2686,7 @@ lumina\_node\_wasm.d.ts:868
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:863
+lumina\_node\_wasm.d.ts:850
 
 ***
 
@@ -2696,7 +2702,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:867
+lumina\_node\_wasm.d.ts:854
 
 ***
 
@@ -2718,7 +2724,7 @@ Get the configuration with default bootnodes for provided network
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:872
+lumina\_node\_wasm.d.ts:859
 
 
 <a name="classesnodeworkermd"></a>
@@ -2754,7 +2760,7 @@ them and sending a response back, as well as accepting new `NodeClient` connecti
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:942
+lumina\_node\_wasm.d.ts:923
 
 ### Methods
 
@@ -2768,7 +2774,7 @@ lumina\_node\_wasm.d.ts:942
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:941
+lumina\_node\_wasm.d.ts:922
 
 ***
 
@@ -2782,7 +2788,7 @@ lumina\_node\_wasm.d.ts:941
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:943
+lumina\_node\_wasm.d.ts:924
 
 
 <a name="classespeertrackerinfosnapshotmd"></a>
@@ -2807,7 +2813,7 @@ Number of the connected peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:962
+lumina\_node\_wasm.d.ts:943
 
 ***
 
@@ -2819,7 +2825,7 @@ Number of the connected trusted peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:966
+lumina\_node\_wasm.d.ts:947
 
 ### Methods
 
@@ -2833,7 +2839,7 @@ lumina\_node\_wasm.d.ts:966
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:958
+lumina\_node\_wasm.d.ts:939
 
 ***
 
@@ -2849,7 +2855,7 @@ lumina\_node\_wasm.d.ts:958
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:953
+lumina\_node\_wasm.d.ts:934
 
 ***
 
@@ -2865,7 +2871,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:957
+lumina\_node\_wasm.d.ts:938
 
 
 <a name="classessamplingmetadatamd"></a>
@@ -2892,19 +2898,7 @@ Return Array of cids
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:983
-
-***
-
-#### status
-
-> **status**: [`SamplingStatus`](#enumerationssamplingstatusmd)
-
-Indicates whether this node was able to successfuly sample the block
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:979
+lumina\_node\_wasm.d.ts:960
 
 ### Methods
 
@@ -2918,7 +2912,7 @@ lumina\_node\_wasm.d.ts:979
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:975
+lumina\_node\_wasm.d.ts:956
 
 
 <a name="classessyncinginfosnapshotmd"></a>
@@ -2943,7 +2937,7 @@ Ranges of headers that are already synchronised
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1002
+lumina\_node\_wasm.d.ts:979
 
 ***
 
@@ -2955,7 +2949,7 @@ Syncing target. The latest height seen in the network that was successfully veri
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1006
+lumina\_node\_wasm.d.ts:983
 
 ### Methods
 
@@ -2969,7 +2963,7 @@ lumina\_node\_wasm.d.ts:1006
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:998
+lumina\_node\_wasm.d.ts:975
 
 ***
 
@@ -2985,7 +2979,7 @@ lumina\_node\_wasm.d.ts:998
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:993
+lumina\_node\_wasm.d.ts:970
 
 ***
 
@@ -3001,7 +2995,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:997
+lumina\_node\_wasm.d.ts:974
 
 
 <a name="classestxclientmd"></a>
@@ -3080,7 +3074,7 @@ const tx_client = await new TxClient("http://127.0.0.1:18080", keys.bech32Addres
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1048
+lumina\_node\_wasm.d.ts:1025
 
 ### Properties
 
@@ -3092,7 +3086,7 @@ AppVersion of the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1143
+lumina\_node\_wasm.d.ts:1120
 
 ***
 
@@ -3104,7 +3098,7 @@ Chain id of the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1139
+lumina\_node\_wasm.d.ts:1116
 
 ### Methods
 
@@ -3118,7 +3112,7 @@ lumina\_node\_wasm.d.ts:1139
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1012
+lumina\_node\_wasm.d.ts:989
 
 ***
 
@@ -3140,7 +3134,7 @@ Get account
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1115
+lumina\_node\_wasm.d.ts:1092
 
 ***
 
@@ -3156,7 +3150,7 @@ Get accounts
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1119
+lumina\_node\_wasm.d.ts:1096
 
 ***
 
@@ -3178,7 +3172,7 @@ Get balance of all coins
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1127
+lumina\_node\_wasm.d.ts:1104
 
 ***
 
@@ -3194,7 +3188,7 @@ Get auth params
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1111
+lumina\_node\_wasm.d.ts:1088
 
 ***
 
@@ -3220,7 +3214,7 @@ Get balance of coins with given denom
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1123
+lumina\_node\_wasm.d.ts:1100
 
 ***
 
@@ -3242,7 +3236,7 @@ Get balance of all spendable coins
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1131
+lumina\_node\_wasm.d.ts:1108
 
 ***
 
@@ -3258,7 +3252,7 @@ Get total supply
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1135
+lumina\_node\_wasm.d.ts:1112
 
 ***
 
@@ -3274,7 +3268,7 @@ Last gas price fetched by the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1052
+lumina\_node\_wasm.d.ts:1029
 
 ***
 
@@ -3325,7 +3319,7 @@ await txClient.submitBlobs(blobs.map(b => b.clone()));
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1081
+lumina\_node\_wasm.d.ts:1058
 
 ***
 
@@ -3373,7 +3367,7 @@ const txInfo = await txClient.submitMessage(sendMsgAny);
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1107
+lumina\_node\_wasm.d.ts:1084
 
 
 <a name="classesvaladdressmd"></a>
@@ -3400,7 +3394,7 @@ Address of a validator.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1158
+lumina\_node\_wasm.d.ts:1135
 
 ***
 
@@ -3416,7 +3410,7 @@ lumina\_node\_wasm.d.ts:1158
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1153
+lumina\_node\_wasm.d.ts:1130
 
 ***
 
@@ -3432,7 +3426,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1157
+lumina\_node\_wasm.d.ts:1134
 
 # Enumerations
 
@@ -3496,55 +3490,6 @@ Private local network.
 ##### Defined in
 
 lumina\_node\_wasm.d.ts:30
-
-
-<a name="enumerationssamplingstatusmd"></a>
-
-[**lumina-node-wasm**](#readmemd)
-
-***
-
-[lumina-node-wasm](#globalsmd) / SamplingStatus
-
-## Enumeration: SamplingStatus
-
-Sampling status for a block.
-
-### Enumeration Members
-
-#### Accepted
-
-> **Accepted**: `1`
-
-Sampling is done and block is accepted.
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:43
-
-***
-
-#### Rejected
-
-> **Rejected**: `2`
-
-Sampling is done and block is rejected.
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:47
-
-***
-
-#### Unknown
-
-> **Unknown**: `0`
-
-Sampling is not done.
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:39
 
 # Functions
 
@@ -3612,7 +3557,6 @@ lumina\_node\_wasm.d.ts:6
 ## Enumerations
 
 - [Network](#enumerationsnetworkmd)
-- [SamplingStatus](#enumerationssamplingstatusmd)
 
 ## Classes
 
@@ -3683,7 +3627,7 @@ Auth module parameters
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:78
+lumina\_node\_wasm.d.ts:80
 
 ***
 
@@ -3693,7 +3637,7 @@ lumina\_node\_wasm.d.ts:78
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:81
+lumina\_node\_wasm.d.ts:83
 
 ***
 
@@ -3703,7 +3647,7 @@ lumina\_node\_wasm.d.ts:81
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:82
+lumina\_node\_wasm.d.ts:84
 
 ***
 
@@ -3713,7 +3657,7 @@ lumina\_node\_wasm.d.ts:82
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:79
+lumina\_node\_wasm.d.ts:81
 
 ***
 
@@ -3723,7 +3667,7 @@ lumina\_node\_wasm.d.ts:79
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:80
+lumina\_node\_wasm.d.ts:82
 
 
 <a name="interfacesbaseaccountmd"></a>
@@ -3746,7 +3690,7 @@ Common data of all account types
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:70
+lumina\_node\_wasm.d.ts:72
 
 ***
 
@@ -3756,7 +3700,7 @@ lumina\_node\_wasm.d.ts:70
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:68
+lumina\_node\_wasm.d.ts:70
 
 ***
 
@@ -3766,7 +3710,7 @@ lumina\_node\_wasm.d.ts:68
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:69
+lumina\_node\_wasm.d.ts:71
 
 ***
 
@@ -3776,7 +3720,7 @@ lumina\_node\_wasm.d.ts:69
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:71
+lumina\_node\_wasm.d.ts:73
 
 
 <a name="interfacescoinmd"></a>
@@ -3799,7 +3743,7 @@ Coin
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:92
+lumina\_node\_wasm.d.ts:94
 
 ***
 
@@ -3809,7 +3753,7 @@ lumina\_node\_wasm.d.ts:92
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:91
+lumina\_node\_wasm.d.ts:93
 
 
 <a name="interfacesprotoanymd"></a>
@@ -3832,7 +3776,7 @@ Protobuf Any type
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:118
+lumina\_node\_wasm.d.ts:120
 
 ***
 
@@ -3842,7 +3786,7 @@ lumina\_node\_wasm.d.ts:118
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:119
+lumina\_node\_wasm.d.ts:121
 
 
 <a name="interfacespublickeymd"></a>
@@ -3865,7 +3809,7 @@ Public key
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:60
+lumina\_node\_wasm.d.ts:62
 
 ***
 
@@ -3875,7 +3819,7 @@ lumina\_node\_wasm.d.ts:60
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:61
+lumina\_node\_wasm.d.ts:63
 
 
 <a name="interfacessigndocmd"></a>
@@ -3898,7 +3842,7 @@ A payload to be signed
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:104
+lumina\_node\_wasm.d.ts:106
 
 ***
 
@@ -3908,7 +3852,7 @@ lumina\_node\_wasm.d.ts:104
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:102
+lumina\_node\_wasm.d.ts:104
 
 ***
 
@@ -3918,7 +3862,7 @@ lumina\_node\_wasm.d.ts:102
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:101
+lumina\_node\_wasm.d.ts:103
 
 ***
 
@@ -3928,7 +3872,7 @@ lumina\_node\_wasm.d.ts:101
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:103
+lumina\_node\_wasm.d.ts:105
 
 
 <a name="interfacestxconfigmd"></a>
@@ -3951,7 +3895,7 @@ Transaction config.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:136
+lumina\_node\_wasm.d.ts:51
 
 ***
 
@@ -3961,7 +3905,7 @@ lumina\_node\_wasm.d.ts:136
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:137
+lumina\_node\_wasm.d.ts:52
 
 ***
 
@@ -3971,7 +3915,7 @@ lumina\_node\_wasm.d.ts:137
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:138
+lumina\_node\_wasm.d.ts:53
 
 
 <a name="interfacestxinfomd"></a>
@@ -3994,7 +3938,7 @@ Transaction info
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:128
+lumina\_node\_wasm.d.ts:43
 
 ***
 
@@ -4004,7 +3948,7 @@ lumina\_node\_wasm.d.ts:128
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:129
+lumina\_node\_wasm.d.ts:44
 
 # Type Aliases
 
@@ -4027,7 +3971,7 @@ The `ReadableStreamType` enum.
 
 ### Defined in
 
-lumina\_node\_wasm.d.ts:54
+lumina\_node\_wasm.d.ts:37
 
 
 <a name="type-aliasessignerfnmd"></a>
@@ -4046,4 +3990,4 @@ A function that produces a signature of a payload
 
 ### Defined in
 
-lumina\_node\_wasm.d.ts:110
+lumina\_node\_wasm.d.ts:112

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.8.5",
+    "version": "0.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.8.5",
+            "version": "0.9.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.8.5",
+            "version": "0.9.0",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.8.5",
+    "version": "0.9.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.12.1...lumina-node-v0.13.0) - 2025-07-02
+
+### Added
+
+- *(node)* [**breaking**] Use `block_height` for `Node::request_all_blobs` and return error on missing header ([#669](https://github.com/eigerco/lumina/pull/669))
+- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
+
+### Other
+
+- Fix uninlined-format-args clippy ([#671](https://github.com/eigerco/lumina/pull/671))
+
 ## [0.12.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.12.0...lumina-node-v0.12.1) - 2025-06-20
 
 ### Other

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.1...celestia-rpc-v0.11.2) - 2025-07-02
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.11.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.0...celestia-rpc-v0.11.1) - 2025-06-09
 
 ### Other

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.2...celestia-types-v0.12.0) - 2025-07-02
+
+### Added
+
+- *(types, node, grpc)* Network v4 upgrade, grpcwebproxy is back ([#674](https://github.com/eigerco/lumina/pull/674))
+- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
+- make Merkle proof fields pub for Blobstream validation ([#658](https://github.com/eigerco/lumina/pull/658))
+
+### Other
+
+- Fix uninlined-format-args clippy ([#671](https://github.com/eigerco/lumina/pull/671))
+
 ## [0.11.2](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.1...celestia-types-v0.11.2) - 2025-06-09
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION



## 🤖 New release

* `celestia-types`: 0.11.2 -> 0.12.0 (⚠ API breaking changes)
* `lumina-node`: 0.12.1 -> 0.13.0 (⚠ API breaking changes)
* `lumina-cli`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `lumina-node-wasm`: 0.8.5 -> 0.9.0 (✓ API compatible changes)
* `lumina-node-uniffi`: 0.1.4 -> 0.2.0 (✓ API compatible changes)
* `celestia-rpc`: 0.11.1 -> 0.11.2
* `celestia-grpc`: 0.4.0 -> 0.4.1

### ⚠ `celestia-types` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant AppVersion:V4 in /tmp/.tmpJeyiGq/lumina/types/src/consts.rs:114
  variant AppVersion:V4 in /tmp/.tmpJeyiGq/lumina/types/src/consts.rs:114
```

### ⚠ `lumina-node` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum lumina_node::store::SamplingStatus, previously in file /tmp/.tmpqSLhMb/lumina-node/src/store.rs:59

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field timed_out of variant NodeEvent::ShareSamplingResult in /tmp/.tmpJeyiGq/lumina/node/src/events.rs:207
  field from_height of variant NodeEvent::PrunedHeaders in /tmp/.tmpJeyiGq/lumina/node/src/events.rs:282

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field accepted of variant NodeEvent::ShareSamplingResult, previously in file /tmp/.tmpqSLhMb/lumina-node/src/events.rs:207

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant P2pError:Store in /tmp/.tmpJeyiGq/lumina/node/src/p2p.rs:157
  variant P2pError:HeaderPruned in /tmp/.tmpJeyiGq/lumina/node/src/p2p.rs:161
  variant P2pError:HeaderNotSynced in /tmp/.tmpJeyiGq/lumina/node/src/p2p.rs:165
  variant DaserError:WorkerDied in /tmp/.tmpJeyiGq/lumina/node/src/daser.rs:48
  variant DaserError:ChannelClosedUnexpectedly in /tmp/.tmpJeyiGq/lumina/node/src/daser.rs:52

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant NodeEvent::SamplingFinished, previously in file /tmp/.tmpqSLhMb/lumina-node/src/events.rs:211
  variant NodeBuilderError::PruningDelayTooSmall, previously in file /tmp/.tmpqSLhMb/lumina-node/src/node/builder.rs:60

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  NodeBuilder::pruning_delay, previously in file /tmp/.tmpqSLhMb/lumina-node/src/node/builder.rs:242
  NodeBuilder::pruning_delay, previously in file /tmp/.tmpqSLhMb/lumina-node/src/node/builder.rs:242

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  MIN_PRUNING_DELAY in file /tmp/.tmpqSLhMb/lumina-node/src/node/builder.rs:28
  DEFAULT_PRUNING_DELAY in file /tmp/.tmpqSLhMb/lumina-node/src/node/builder.rs:26

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field status of struct SamplingMetadata, previously in file /tmp/.tmpqSLhMb/lumina-node/src/store.rs:45

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_added.ron

Failed in:
  trait method lumina_node::store::Store::mark_as_sampled in file /tmp/.tmpJeyiGq/lumina/node/src/store.rs:133
  trait method lumina_node::store::Store::get_sampled_ranges in file /tmp/.tmpJeyiGq/lumina/node/src/store.rs:148
  trait method lumina_node::store::Store::get_pruned_ranges in file /tmp/.tmpJeyiGq/lumina/node/src/store.rs:151

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method get_accepted_sampling_ranges of trait Store, previously in file /tmp/.tmpqSLhMb/lumina-node/src/store.rs:166

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  Store::update_sampling_metadata now takes 3 instead of 4 parameters, in file /tmp/.tmpJeyiGq/lumina/node/src/store.rs:122
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`

<blockquote>

## [0.12.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.2...celestia-types-v0.12.0) - 2025-07-02

### Added

- *(types, node, grpc)* Network v4 upgrade, grpcwebproxy is back ([#674](https://github.com/eigerco/lumina/pull/674))
- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
- make Merkle proof fields pub for Blobstream validation ([#658](https://github.com/eigerco/lumina/pull/658))

### Other

- Fix uninlined-format-args clippy ([#671](https://github.com/eigerco/lumina/pull/671))
</blockquote>

## `lumina-node`

<blockquote>

## [0.13.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.12.1...lumina-node-v0.13.0) - 2025-07-02

### Added

- *(node)* [**breaking**] Use `block_height` for `Node::request_all_blobs` and return error on missing header ([#669](https://github.com/eigerco/lumina/pull/669))
- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))

### Other

- Fix uninlined-format-args clippy ([#671](https://github.com/eigerco/lumina/pull/671))
</blockquote>

## `lumina-cli`

<blockquote>

## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.7.0...lumina-cli-v0.8.0) - 2025-07-02

### Added

- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.5...lumina-node-wasm-v0.9.0) - 2025-07-02

### Added

- *(node)* [**breaking**] Use `block_height` for `Node::request_all_blobs` and return error on missing header ([#669](https://github.com/eigerco/lumina/pull/669))
- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.4...lumina-node-uniffi-v0.2.0) - 2025-07-02

### Added

- *(node)* [**breaking**] Implement adaptive backward syncing/sampling ([#606](https://github.com/eigerco/lumina/pull/606))

### Other

- Fix uninlined-format-args clippy ([#671](https://github.com/eigerco/lumina/pull/671))
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.11.2](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.1...celestia-rpc-v0.11.2) - 2025-07-02

### Other

- updated the following local packages: celestia-types
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.4.0...celestia-grpc-v0.4.1) - 2025-07-02

### Other

- updated the following local packages: celestia-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).