### PR TITLE
chore(ci): Unpin nightly toolchain version for unused deps check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,11 +287,7 @@ jobs:
     - name: Setup toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        # cargo complains about #[cfg(test)]
-        # TODO: remove when this lands (1.85)
-        # https://github.com/rust-lang/cargo/pull/14963
-        # https://github.com/est31/cargo-udeps/issues/293#issuecomment-2573300340
-        toolchain: nightly-2025-01-01
+        toolchain: nightly
 
     - name: Install cargo-udeps
       uses: taiki-e/cache-cargo-install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
     - test-wasm
     - test-bindings
     - build-wasm
+    - build-android
     - build-ios
     - fmt
     - docs


### PR DESCRIPTION
Both blocking issues are fixed, plus pinned version is starting to get too old, see https://github.com/eigerco/lumina/actions/runs/16117643628/job/45475170952?pr=673