### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "prost",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "blockstore",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = ["cli", "grpc", "node", "node-wasm", "node-uniffi", "proto", "rpc", "t
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.13.0", path = "node" }
-lumina-node-wasm = { version = "0.9.0", path = "node-wasm" }
-lumina-utils = { version = "0.2.0", path = "utils" }
-celestia-proto = { version = "0.7.2", path = "proto" }
-celestia-grpc = { version = "0.4.1", path = "grpc" }
-celestia-rpc = { version = "0.11.2", path = "rpc", default-features = false }
-celestia-types = { version = "0.12.0", path = "types", default-features = false }
+lumina-node = { version = "0.14.0", path = "node" }
+lumina-node-wasm = { version = "0.9.1", path = "node-wasm" }
+lumina-utils = { version = "0.3.0", path = "utils" }
+celestia-proto = { version = "0.8.0", path = "proto" }
+celestia-grpc = { version = "0.5.0", path = "grpc" }
+celestia-rpc = { version = "0.11.3", path = "rpc", default-features = false }
+celestia-types = { version = "0.13.0", path = "types", default-features = false }
 tendermint = { version = "0.40.3", default-features = false }
 tendermint-proto = "0.40.3"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.8.0...lumina-cli-v0.9.0) - 2025-07-18
+
+### Added
+
+- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
+- *(grpc)* Streamline TxClient creation API, add docs with example ([#673](https://github.com/eigerco/lumina/pull/673))
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.7.0...lumina-cli-v0.8.0) - 2025-07-02
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.4.1...celestia-grpc-v0.5.0) - 2025-07-18
+
+### Added
+
+- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
+- *(grpc)* Streamline TxClient creation API, add docs with example ([#673](https://github.com/eigerco/lumina/pull/673))
+
 ## [0.4.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.4.0...celestia-grpc-v0.4.1) - 2025-07-02
 
 ### Other

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.2.0...lumina-node-uniffi-v0.2.1) - 2025-07-18
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.1.4...lumina-node-uniffi-v0.2.0) - 2025-07-02
 
 ### Added

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.9.0...lumina-node-wasm-v0.9.1) - 2025-07-18
+
+### Other
+
+- updated the following local packages: lumina-utils, celestia-types, lumina-node, celestia-grpc, celestia-rpc
+
 ## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.8.5...lumina-node-wasm-v0.9.0) - 2025-07-02
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -62,6 +62,66 @@ JavaScript API's goal is to provide similar interface to Rust when possible, e.g
 # Classes
 
 
+<a name="classesabcimessagelogmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / AbciMessageLog
+
+## Class: AbciMessageLog
+
+ABCIMessageLog defines a structure containing an indexed tx ABCI message log.
+
+### Properties
+
+#### events
+
+> **events**: [`StringEvent`](#classesstringeventmd)[]
+
+Events contains a slice of Event objects that were emitted during some
+execution.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:493
+
+***
+
+#### log
+
+> **log**: `string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:488
+
+***
+
+#### msg\_index
+
+> **msg\_index**: `number`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:487
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:486
+
+
 <a name="classesaccaddressmd"></a>
 
 [**lumina-node-wasm**](#readmemd)
@@ -86,7 +146,7 @@ Address of an account.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:138
+lumina\_node\_wasm.d.ts:508
 
 ***
 
@@ -102,7 +162,7 @@ lumina\_node\_wasm.d.ts:138
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:133
+lumina\_node\_wasm.d.ts:503
 
 ***
 
@@ -118,7 +178,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:137
+lumina\_node\_wasm.d.ts:507
 
 
 <a name="classesappversionmd"></a>
@@ -143,7 +203,7 @@ App v1
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:153
+lumina\_node\_wasm.d.ts:523
 
 ***
 
@@ -155,7 +215,7 @@ App v2
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:157
+lumina\_node\_wasm.d.ts:527
 
 ***
 
@@ -167,7 +227,7 @@ App v3
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:161
+lumina\_node\_wasm.d.ts:531
 
 ***
 
@@ -179,7 +239,7 @@ App v4
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:165
+lumina\_node\_wasm.d.ts:535
 
 ### Methods
 
@@ -193,7 +253,7 @@ lumina\_node\_wasm.d.ts:165
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:145
+lumina\_node\_wasm.d.ts:515
 
 ***
 
@@ -209,7 +269,114 @@ Latest App version variant.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:149
+lumina\_node\_wasm.d.ts:519
+
+
+<a name="classesattributemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Attribute
+
+## Class: Attribute
+
+Attribute defines an attribute wrapper where the key and value are
+strings instead of raw bytes.
+
+### Properties
+
+#### key
+
+> **key**: `string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:544
+
+***
+
+#### value
+
+> **value**: `string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:545
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:543
+
+
+<a name="classesauthinfomd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / AuthInfo
+
+## Class: AuthInfo
+
+[`AuthInfo`] describes the fee and signer modes that are used to sign a transaction.
+
+### Properties
+
+#### fee
+
+> **fee**: [`Fee`](#classesfeemd)
+
+[`Fee`] and gas limit for the transaction.
+
+The first signer is the primary signer and the one which pays the fee.
+The fee can be calculated based on the cost of evaluating the body and doing signature
+verification of the signers. This can be estimated via simulation.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:568
+
+***
+
+#### signer\_infos
+
+> **signer\_infos**: [`SignerInfo`](#classessignerinfomd)[]
+
+Defines the signing modes for the required signers.
+
+The number and order of elements must match the required signers from transaction
+[`TxBody`]’s messages. The first element is the primary signer and the one
+which pays the [`Fee`].
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:560
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:552
 
 
 <a name="classesblobmd"></a>
@@ -252,7 +419,7 @@ Create a new blob with the given data within the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:183
+lumina\_node\_wasm.d.ts:586
 
 ### Properties
 
@@ -264,7 +431,7 @@ A [`Commitment`] computed from the [`Blob`]s data.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:203
+lumina\_node\_wasm.d.ts:606
 
 ***
 
@@ -276,7 +443,7 @@ Data stored within the [`Blob`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:195
+lumina\_node\_wasm.d.ts:598
 
 ***
 
@@ -288,7 +455,7 @@ A [`Namespace`] the [`Blob`] belongs to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:191
+lumina\_node\_wasm.d.ts:594
 
 ***
 
@@ -300,7 +467,7 @@ Version indicating the format in which [`Share`]s should be created from this [`
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:199
+lumina\_node\_wasm.d.ts:602
 
 ### Accessors
 
@@ -334,7 +501,7 @@ Index of the blob's first share in the EDS. Only set for blobs retrieved from ch
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:207
+lumina\_node\_wasm.d.ts:610
 
 ***
 
@@ -372,7 +539,7 @@ Must be present in `share_version 1` and absent otherwise.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:217
+lumina\_node\_wasm.d.ts:620
 
 ### Methods
 
@@ -388,7 +555,7 @@ Clone a blob creating a new deep copy of it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:187
+lumina\_node\_wasm.d.ts:590
 
 ***
 
@@ -402,7 +569,7 @@ lumina\_node\_wasm.d.ts:187
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:179
+lumina\_node\_wasm.d.ts:582
 
 ***
 
@@ -418,7 +585,7 @@ lumina\_node\_wasm.d.ts:179
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:174
+lumina\_node\_wasm.d.ts:577
 
 ***
 
@@ -434,7 +601,233 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:178
+lumina\_node\_wasm.d.ts:581
+
+
+<a name="classesblobparamsmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / BlobParams
+
+## Class: BlobParams
+
+Params defines the parameters for the blob module.
+
+### Properties
+
+#### gas\_per\_blob\_byte
+
+> **gas\_per\_blob\_byte**: `number`
+
+Gas cost per blob byte
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:645
+
+***
+
+#### gov\_max\_square\_size
+
+> **gov\_max\_square\_size**: `bigint`
+
+Max square size
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:649
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:641
+
+***
+
+#### toJSON()
+
+> **toJSON**(): `Object`
+
+* Return copy of self without private attributes.
+
+##### Returns
+
+`Object`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:636
+
+***
+
+#### toString()
+
+> **toString**(): `string`
+
+Return stringified version of self.
+
+##### Returns
+
+`string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:640
+
+
+<a name="classesblockmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Block
+
+## Class: Block
+
+Blocks consist of a header, transactions, votes (the commit), and a list of
+evidence of malfeasance (i.e. signing conflicting votes).
+
+This is a modified version of [`tendermint::block::Block`] which contains
+[modifications](data-mod) that Celestia introduced.
+
+[data-mod]: https://github.com/celestiaorg/celestia-core/blob/a1268f7ae3e688144a613c8a439dd31818aae07d/proto/tendermint/types/types.proto#L84-L104
+### Properties
+
+#### data
+
+> **data**: [`Data`](#classesdatamd)
+
+Transaction data
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:666
+
+***
+
+#### evidence
+
+> `readonly` **evidence**: [`Evidence`](#classesevidencemd)[]
+
+Evidence of malfeasance
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:674
+
+***
+
+#### header
+
+> `readonly` **header**: [`Header`](#classesheadermd)
+
+Block header
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:670
+
+***
+
+#### lastCommit
+
+> `readonly` **lastCommit**: [`Commit`](#classescommitmd)
+
+Last commit, should be `None` for the initial block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:678
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:662
+
+
+<a name="classesblockidmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / BlockId
+
+## Class: BlockId
+
+Block identifiers which contain two distinct Merkle roots of the block, as well as the number of parts in the block.
+
+### Properties
+
+#### hash
+
+> **hash**: `string`
+
+The block’s main hash is the Merkle root of all the fields in the block header.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:689
+
+***
+
+#### part\_set\_header
+
+> **part\_set\_header**: [`PartsHeader`](#classespartsheadermd)
+
+Parts header (if available) is used for secure gossipping of the block during
+consensus. It is the Merkle root of the complete serialized block cut into parts.
+
+PartSet is used to split a byteslice of data into parts (pieces) for transmission.
+By splitting data into smaller parts and computing a Merkle root hash on the list,
+you can verify that a part is legitimately part of the complete data, and the part
+can be forwarded to other peers before all the parts are known. In short, it’s
+a fast way to propagate a large file over a gossip network.
+
+<https://github.com/tendermint/tendermint/wiki/Block-Structure#partset>
+
+PartSetHeader in protobuf is defined as never nil using the gogoproto annotations.
+This does not translate to Rust, but we can indicate this in the domain type.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:705
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:685
 
 
 <a name="classesblockrangemd"></a>
@@ -459,7 +852,7 @@ Last block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:246
+lumina\_node\_wasm.d.ts:728
 
 ***
 
@@ -471,7 +864,7 @@ First block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:242
+lumina\_node\_wasm.d.ts:724
 
 ### Methods
 
@@ -485,7 +878,7 @@ lumina\_node\_wasm.d.ts:242
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:238
+lumina\_node\_wasm.d.ts:720
 
 ***
 
@@ -501,7 +894,7 @@ lumina\_node\_wasm.d.ts:238
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:233
+lumina\_node\_wasm.d.ts:715
 
 ***
 
@@ -517,7 +910,371 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:237
+lumina\_node\_wasm.d.ts:719
+
+
+<a name="classesbroadcastmodemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / BroadcastMode
+
+## Class: BroadcastMode
+
+BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC method.
+
+### Properties
+
+#### Async
+
+> `readonly` `static` **Async**: [`BroadcastMode`](#classesbroadcastmodemd)
+
+`BroadcastMode` `Async` defines a tx broadcasting mode where the client returns
+immediately.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:754
+
+***
+
+#### Block
+
+> `readonly` `static` **Block**: [`BroadcastMode`](#classesbroadcastmodemd)
+
+`BroadcastMode` `Block` defines a tx broadcasting mode where the client waits for
+the tx to be committed in a block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:744
+
+***
+
+#### Sync
+
+> `readonly` `static` **Sync**: [`BroadcastMode`](#classesbroadcastmodemd)
+
+`BroadcastMode` `Sync` defines a tx broadcasting mode where the client waits for
+a CheckTx execution response only.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:749
+
+***
+
+#### Unspecified
+
+> `readonly` `static` **Unspecified**: [`BroadcastMode`](#classesbroadcastmodemd)
+
+zero-value for mode ordering
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:739
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:735
+
+
+<a name="classescoinmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Coin
+
+## Class: Coin
+
+Coin defines a token with a denomination and an amount.
+
+### Properties
+
+#### amount
+
+> **amount**: `bigint`
+
+Coin amount
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:410
+
+***
+
+#### denom
+
+> **denom**: `string`
+
+Coin denomination
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:409
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:761
+
+
+<a name="classescommitmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Commit
+
+## Class: Commit
+
+Commit contains the justification (ie. a set of signatures) that a block was
+committed by a set of validators.
+
+### Properties
+
+#### block\_id
+
+> **block\_id**: [`BlockId`](#classesblockidmd)
+
+Block ID
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:789
+
+***
+
+#### height
+
+> **height**: `bigint`
+
+Block height
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:781
+
+***
+
+#### round
+
+> **round**: `number`
+
+Round
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:785
+
+***
+
+#### signatures
+
+> **signatures**: [`CommitSig`](#classescommitsigmd)[]
+
+Signatures
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:793
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:777
+
+
+<a name="classescommitsigmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / CommitSig
+
+## Class: CommitSig
+
+CommitSig represents a signature of a validator. It’s a part of the Commit and can
+be used to reconstruct the vote set given the validator set.
+
+### Properties
+
+#### vote\_type
+
+> **vote\_type**: [`CommitVoteType`](#enumerationscommitvotetypemd)
+
+vote type of a validator
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:805
+
+### Accessors
+
+#### vote
+
+##### Get Signature
+
+> **get** **vote**(): [`CommitVote`](#classescommitvotemd)
+
+vote, if received
+
+###### Returns
+
+[`CommitVote`](#classescommitvotemd)
+
+##### Set Signature
+
+> **set** **vote**(`value`): `void`
+
+vote, if received
+
+###### Parameters
+
+####### value
+
+[`CommitVote`](#classescommitvotemd)
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:809
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:801
+
+
+<a name="classescommitvotemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / CommitVote
+
+## Class: CommitVote
+
+Value of the validator vote
+
+### Properties
+
+#### timestamp
+
+> **timestamp**: `string`
+
+Timestamp
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:828
+
+***
+
+#### validator\_address
+
+> **validator\_address**: `string`
+
+Address of the voting validator
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:824
+
+### Accessors
+
+#### signature
+
+##### Get Signature
+
+> **get** **signature**(): [`Signature`](#classessignaturemd)
+
+Signature
+
+###### Returns
+
+[`Signature`](#classessignaturemd)
+
+##### Set Signature
+
+> **set** **signature**(`value`): `void`
+
+Signature
+
+###### Parameters
+
+####### value
+
+[`Signature`](#classessignaturemd)
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:832
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:820
 
 
 <a name="classescommitmentmd"></a>
@@ -578,7 +1335,7 @@ read more about that in the [`share commitment rules`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:296
+lumina\_node\_wasm.d.ts:886
 
 ***
 
@@ -594,7 +1351,7 @@ Hash of the commitment
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:300
+lumina\_node\_wasm.d.ts:890
 
 ***
 
@@ -610,7 +1367,7 @@ lumina\_node\_wasm.d.ts:300
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:291
+lumina\_node\_wasm.d.ts:881
 
 ***
 
@@ -626,7 +1383,58 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:295
+lumina\_node\_wasm.d.ts:885
+
+
+<a name="classesconflictingblockmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ConflictingBlock
+
+## Class: ConflictingBlock
+
+Conflicting block detected in light client attack
+
+### Properties
+
+#### signed\_header
+
+> **signed\_header**: [`SignedHeader`](#classessignedheadermd)
+
+Signed header
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:901
+
+***
+
+#### validator\_set
+
+> **validator\_set**: [`ValidatorSet`](#classesvalidatorsetmd)
+
+Validator set
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:905
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:897
 
 
 <a name="classesconnectioncounterssnapshotmd"></a>
@@ -649,7 +1457,7 @@ The total number of connections, both pending and established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:316
+lumina\_node\_wasm.d.ts:921
 
 ***
 
@@ -661,7 +1469,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:332
+lumina\_node\_wasm.d.ts:937
 
 ***
 
@@ -673,7 +1481,7 @@ The number of established incoming connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:336
+lumina\_node\_wasm.d.ts:941
 
 ***
 
@@ -685,7 +1493,7 @@ The number of established outgoing connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:340
+lumina\_node\_wasm.d.ts:945
 
 ***
 
@@ -697,7 +1505,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:320
+lumina\_node\_wasm.d.ts:925
 
 ***
 
@@ -709,7 +1517,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:324
+lumina\_node\_wasm.d.ts:929
 
 ***
 
@@ -721,7 +1529,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:328
+lumina\_node\_wasm.d.ts:933
 
 ### Methods
 
@@ -735,7 +1543,7 @@ lumina\_node\_wasm.d.ts:328
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:312
+lumina\_node\_wasm.d.ts:917
 
 ***
 
@@ -751,7 +1559,7 @@ lumina\_node\_wasm.d.ts:312
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:307
+lumina\_node\_wasm.d.ts:912
 
 ***
 
@@ -767,7 +1575,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:311
+lumina\_node\_wasm.d.ts:916
 
 
 <a name="classesconsaddressmd"></a>
@@ -794,7 +1602,7 @@ Address of a consensus node.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:355
+lumina\_node\_wasm.d.ts:960
 
 ***
 
@@ -810,7 +1618,7 @@ lumina\_node\_wasm.d.ts:355
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:350
+lumina\_node\_wasm.d.ts:955
 
 ***
 
@@ -826,7 +1634,74 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:354
+lumina\_node\_wasm.d.ts:959
+
+
+<a name="classesdatamd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Data
+
+## Class: Data
+
+Data contained in a [`Block`].
+
+[`Block`]: crate::block::Block
+
+### Properties
+
+#### hash
+
+> **hash**: `Uint8Array`\<`ArrayBuffer`\>
+
+Hash is the root of a binary Merkle tree where the leaves of the tree are
+the row and column roots of an extended data square. Hash is often referred
+to as the "data root".
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:979
+
+***
+
+#### square\_size
+
+> **square\_size**: `bigint`
+
+Square width of original data square.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:973
+
+***
+
+#### transactions
+
+> `readonly` **transactions**: `Uint8Array`\<`ArrayBuffer`\>[]
+
+Transactions
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:983
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:969
 
 
 <a name="classesdataavailabilityheadermd"></a>
@@ -894,7 +1769,7 @@ Get the a root of the column with the given index.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:419
+lumina\_node\_wasm.d.ts:1047
 
 ***
 
@@ -910,7 +1785,7 @@ Merkle roots of the [`ExtendedDataSquare`] columns.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:411
+lumina\_node\_wasm.d.ts:1039
 
 ***
 
@@ -924,7 +1799,7 @@ lumina\_node\_wasm.d.ts:411
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:403
+lumina\_node\_wasm.d.ts:1031
 
 ***
 
@@ -942,7 +1817,7 @@ This is the data commitment for the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:425
+lumina\_node\_wasm.d.ts:1053
 
 ***
 
@@ -964,7 +1839,7 @@ Get a root of the row with the given index.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:415
+lumina\_node\_wasm.d.ts:1043
 
 ***
 
@@ -980,7 +1855,7 @@ Merkle roots of the [`ExtendedDataSquare`] rows.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:407
+lumina\_node\_wasm.d.ts:1035
 
 ***
 
@@ -996,7 +1871,7 @@ Get the size of the [`ExtendedDataSquare`] for which this header was built.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:429
+lumina\_node\_wasm.d.ts:1057
 
 ***
 
@@ -1012,7 +1887,7 @@ lumina\_node\_wasm.d.ts:429
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:398
+lumina\_node\_wasm.d.ts:1026
 
 ***
 
@@ -1028,7 +1903,121 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:402
+lumina\_node\_wasm.d.ts:1030
+
+
+<a name="classesduplicatevoteevidencemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / DuplicateVoteEvidence
+
+## Class: DuplicateVoteEvidence
+
+Duplicate vote evidence
+
+### Properties
+
+#### timestamp
+
+> **timestamp**: `string`
+
+Timestamp
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1084
+
+***
+
+#### total\_voting\_power
+
+> **total\_voting\_power**: `bigint`
+
+Total voting power
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1076
+
+***
+
+#### validator\_power
+
+> **validator\_power**: `bigint`
+
+Validator power
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1080
+
+***
+
+#### vote\_a
+
+> **vote\_a**: [`Vote`](#classesvotemd)
+
+Vote A
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1068
+
+***
+
+#### vote\_b
+
+> **vote\_b**: [`Vote`](#classesvotemd)
+
+Vote B
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1072
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1064
+
+
+<a name="classesevidencemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Evidence
+
+## Class: Evidence
+
+Evidence of malfeasance by validators (i.e. signing conflicting votes or light client attack).
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1091
 
 
 <a name="classesextendedheadermd"></a>
@@ -1079,7 +2068,7 @@ Commit metadata and signatures from validators committing the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:560
+lumina\_node\_wasm.d.ts:1222
 
 ***
 
@@ -1091,7 +2080,7 @@ Header of the block data availability.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:552
+lumina\_node\_wasm.d.ts:1214
 
 ***
 
@@ -1103,7 +2092,7 @@ Tendermint block header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:556
+lumina\_node\_wasm.d.ts:1218
 
 ***
 
@@ -1115,7 +2104,7 @@ Information about the set of validators commiting the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:564
+lumina\_node\_wasm.d.ts:1226
 
 ### Methods
 
@@ -1131,7 +2120,7 @@ Clone a header producing a deep copy of it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:474
+lumina\_node\_wasm.d.ts:1136
 
 ***
 
@@ -1145,7 +2134,7 @@ lumina\_node\_wasm.d.ts:474
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:470
+lumina\_node\_wasm.d.ts:1132
 
 ***
 
@@ -1161,7 +2150,7 @@ Get the block hash.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:486
+lumina\_node\_wasm.d.ts:1148
 
 ***
 
@@ -1177,7 +2166,7 @@ Get the block height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:478
+lumina\_node\_wasm.d.ts:1140
 
 ***
 
@@ -1193,7 +2182,7 @@ Get the hash of the previous header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:490
+lumina\_node\_wasm.d.ts:1152
 
 ***
 
@@ -1209,7 +2198,7 @@ Get the block time.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:482
+lumina\_node\_wasm.d.ts:1144
 
 ***
 
@@ -1225,7 +2214,7 @@ lumina\_node\_wasm.d.ts:482
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:465
+lumina\_node\_wasm.d.ts:1127
 
 ***
 
@@ -1241,7 +2230,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:469
+lumina\_node\_wasm.d.ts:1131
 
 ***
 
@@ -1257,7 +2246,7 @@ Decode protobuf encoded header and then validate it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:494
+lumina\_node\_wasm.d.ts:1156
 
 ***
 
@@ -1285,7 +2274,7 @@ This function will also return an error if untrusted headers and `self` don't fo
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:504
+lumina\_node\_wasm.d.ts:1166
 
 ***
 
@@ -1325,7 +2314,7 @@ This function will also return an error if untrusted headers and `self` don't fo
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:548
+lumina\_node\_wasm.d.ts:1210
 
 ***
 
@@ -1365,7 +2354,849 @@ to each other.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:526
+lumina\_node\_wasm.d.ts:1188
+
+
+<a name="classesfeemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Fee
+
+## Class: Fee
+
+Fee includes the amount of coins paid in fees and the maximum
+gas to be used by the transaction. The ratio yields an effective "gasprice",
+which must be above some miminum to be accepted into the mempool.
+
+### Properties
+
+#### amount
+
+> **amount**: [`Coin`](#classescoinmd)[]
+
+amount is the amount of coins to be paid as a fee
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1239
+
+***
+
+#### gas\_limit
+
+> **gas\_limit**: `bigint`
+
+gas_limit is the maximum gas that can be used in transaction processing
+before an out of gas error occurs
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1244
+
+***
+
+#### granter
+
+> `readonly` **granter**: `string`
+
+if set, the fee payer (either the first signer or the value of the payer field) requests that a fee grant be used
+to pay fees instead of the fee payer's own balance. If an appropriate fee grant does not exist or the chain does
+not support fee grants, this will fail
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1256
+
+***
+
+#### payer
+
+> `readonly` **payer**: `string`
+
+if unset, the first signer is responsible for paying the fees. If set, the specified account must pay the fees.
+the payer must be a tx signer (and thus have signed this field in AuthInfo).
+setting this field does *not* change the ordering of required signers for the transaction.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1250
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1235
+
+
+<a name="classesgasinfomd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / GasInfo
+
+## Class: GasInfo
+
+GasInfo defines tx execution gas context.
+
+### Properties
+
+#### gas\_used
+
+> **gas\_used**: `bigint`
+
+GasUsed is the amount of gas actually consumed.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1271
+
+***
+
+#### gas\_wanted
+
+> **gas\_wanted**: `bigint`
+
+GasWanted is the maximum units of work we allow this tx to perform.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1267
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1263
+
+
+<a name="classesgettxresponsemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / GetTxResponse
+
+## Class: GetTxResponse
+
+Response to GetTx
+
+### Properties
+
+#### tx
+
+> **tx**: [`Tx`](#classestxmd)
+
+Response Transaction
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1282
+
+***
+
+#### tx\_response
+
+> **tx\_response**: [`TxResponse`](#classestxresponsemd)
+
+TxResponse to a Query
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1286
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1278
+
+
+<a name="classesgrpcclientmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / GrpcClient
+
+## Class: GrpcClient
+
+Celestia GRPC client
+
+### Methods
+
+#### broadcast\_tx()
+
+> **broadcast\_tx**(`tx_bytes`, `mode`): `Promise`\<[`TxResponse`](#classestxresponsemd)\>
+
+Broadcast prepared and serialised transaction
+
+##### Parameters
+
+###### tx\_bytes
+
+`Uint8Array`\<`ArrayBuffer`\>
+
+###### mode
+
+[`BroadcastMode`](#classesbroadcastmodemd)
+
+##### Returns
+
+`Promise`\<[`TxResponse`](#classestxresponsemd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1341
+
+***
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1293
+
+***
+
+#### get\_account()
+
+> **get\_account**(`account`): `Promise`\<[`BaseAccount`](#interfacesbaseaccountmd)\>
+
+Get account
+
+##### Parameters
+
+###### account
+
+`string`
+
+##### Returns
+
+`Promise`\<[`BaseAccount`](#interfacesbaseaccountmd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1305
+
+***
+
+#### get\_accounts()
+
+> **get\_accounts**(): `Promise`\<[`BaseAccount`](#interfacesbaseaccountmd)[]\>
+
+Get accounts
+
+##### Returns
+
+`Promise`\<[`BaseAccount`](#interfacesbaseaccountmd)[]\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1309
+
+***
+
+#### get\_all\_balances()
+
+> **get\_all\_balances**(`address`): `Promise`\<[`Coin`](#classescoinmd)[]\>
+
+Get balance of all coins
+
+##### Parameters
+
+###### address
+
+`string`
+
+##### Returns
+
+`Promise`\<[`Coin`](#classescoinmd)[]\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1317
+
+***
+
+#### get\_auth\_params()
+
+> **get\_auth\_params**(): `Promise`\<[`AuthParams`](#interfacesauthparamsmd)\>
+
+Get auth params
+
+##### Returns
+
+`Promise`\<[`AuthParams`](#interfacesauthparamsmd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1301
+
+***
+
+#### get\_balance()
+
+> **get\_balance**(`address`, `denom`): `Promise`\<[`Coin`](#classescoinmd)\>
+
+Get balance of coins with given denom
+
+##### Parameters
+
+###### address
+
+`string`
+
+###### denom
+
+`string`
+
+##### Returns
+
+`Promise`\<[`Coin`](#classescoinmd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1313
+
+***
+
+#### get\_blob\_params()
+
+> **get\_blob\_params**(): `Promise`\<[`BlobParams`](#classesblobparamsmd)\>
+
+Get blob params
+
+##### Returns
+
+`Promise`\<[`BlobParams`](#classesblobparamsmd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1353
+
+***
+
+#### get\_block\_by\_height()
+
+> **get\_block\_by\_height**(`height`): `Promise`\<[`Block`](#classesblockmd)\>
+
+Get block by height
+
+##### Parameters
+
+###### height
+
+`bigint`
+
+##### Returns
+
+`Promise`\<[`Block`](#classesblockmd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1337
+
+***
+
+#### get\_latest\_block()
+
+> **get\_latest\_block**(): `Promise`\<[`Block`](#classesblockmd)\>
+
+Get latest block
+
+##### Returns
+
+`Promise`\<[`Block`](#classesblockmd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1333
+
+***
+
+#### get\_min\_gas\_price()
+
+> **get\_min\_gas\_price**(): `Promise`\<`number`\>
+
+Get Minimum Gas price
+
+##### Returns
+
+`Promise`\<`number`\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1329
+
+***
+
+#### get\_spendable\_balances()
+
+> **get\_spendable\_balances**(`address`): `Promise`\<[`Coin`](#classescoinmd)[]\>
+
+Get balance of all spendable coins
+
+##### Parameters
+
+###### address
+
+`string`
+
+##### Returns
+
+`Promise`\<[`Coin`](#classescoinmd)[]\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1321
+
+***
+
+#### get\_total\_supply()
+
+> **get\_total\_supply**(): `Promise`\<[`Coin`](#classescoinmd)[]\>
+
+Get total supply
+
+##### Returns
+
+`Promise`\<[`Coin`](#classescoinmd)[]\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1325
+
+***
+
+#### get\_tx()
+
+> **get\_tx**(`hash`): `Promise`\<[`GetTxResponse`](#classesgettxresponsemd)\>
+
+Get Tx
+
+##### Parameters
+
+###### hash
+
+`string`
+
+##### Returns
+
+`Promise`\<[`GetTxResponse`](#classesgettxresponsemd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1345
+
+***
+
+#### simulate()
+
+> **simulate**(`tx_bytes`): `Promise`\<[`GasInfo`](#classesgasinfomd)\>
+
+Simulate prepared and serialised transaction, returning simulated gas usage
+
+##### Parameters
+
+###### tx\_bytes
+
+`Uint8Array`\<`ArrayBuffer`\>
+
+##### Returns
+
+`Promise`\<[`GasInfo`](#classesgasinfomd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1349
+
+***
+
+#### tx\_status()
+
+> **tx\_status**(`hash`): `Promise`\<[`TxStatusResponse`](#classestxstatusresponsemd)\>
+
+Get status of the transaction
+
+##### Parameters
+
+###### hash
+
+`string`
+
+##### Returns
+
+`Promise`\<[`TxStatusResponse`](#classestxstatusresponsemd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1357
+
+***
+
+#### new()
+
+> `static` **new**(`url`): `Promise`\<[`GrpcClient`](#classesgrpcclientmd)\>
+
+Create a new client connected with the given `url`
+
+##### Parameters
+
+###### url
+
+`string`
+
+##### Returns
+
+`Promise`\<[`GrpcClient`](#classesgrpcclientmd)\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1297
+
+
+<a name="classesheadermd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Header
+
+## Class: Header
+
+Block Header values contain metadata about the block and about the consensus,
+as well as commitments to the data in the current block, the previous block,
+and the results returned by the application.
+
+### Properties
+
+#### app\_hash
+
+> **app\_hash**: `string`
+
+State after txs from the previous block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1422
+
+***
+
+#### chain\_id
+
+> **chain\_id**: `string`
+
+Chain ID
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1374
+
+***
+
+#### consensus\_hash
+
+> **consensus\_hash**: `string`
+
+Consensus params for the current block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1418
+
+***
+
+#### height
+
+> **height**: `bigint`
+
+Current block height
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1378
+
+***
+
+#### next\_validators\_hash
+
+> **next\_validators\_hash**: `string`
+
+Validators for the next block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1414
+
+***
+
+#### proposer\_address
+
+> **proposer\_address**: `string`
+
+Original proposer of the block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1442
+
+***
+
+#### time
+
+> **time**: `string`
+
+Current timestamp encoded as rfc3339
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1382
+
+***
+
+#### validators\_hash
+
+> **validators\_hash**: `string`
+
+Validators for the current block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1410
+
+***
+
+#### version
+
+> **version**: [`ProtocolVersion`](#classesprotocolversionmd)
+
+Header version
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1370
+
+### Accessors
+
+#### data\_hash
+
+##### Get Signature
+
+> **get** **data\_hash**(): `string`
+
+Merkle root of transaction hashes
+
+###### Returns
+
+`string`
+
+##### Set Signature
+
+> **set** **data\_hash**(`value`): `void`
+
+Merkle root of transaction hashes
+
+###### Parameters
+
+####### value
+
+`string`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1402
+
+***
+
+#### evidence\_hash
+
+##### Get Signature
+
+> **get** **evidence\_hash**(): `string`
+
+Hash of evidence included in the block
+
+###### Returns
+
+`string`
+
+##### Set Signature
+
+> **set** **evidence\_hash**(`value`): `void`
+
+Hash of evidence included in the block
+
+###### Parameters
+
+####### value
+
+`string`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1434
+
+***
+
+#### last\_block\_id
+
+##### Get Signature
+
+> **get** **last\_block\_id**(): [`BlockId`](#classesblockidmd)
+
+Previous block info
+
+###### Returns
+
+[`BlockId`](#classesblockidmd)
+
+##### Set Signature
+
+> **set** **last\_block\_id**(`value`): `void`
+
+Previous block info
+
+###### Parameters
+
+####### value
+
+[`BlockId`](#classesblockidmd)
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1386
+
+***
+
+#### last\_commit\_hash
+
+##### Get Signature
+
+> **get** **last\_commit\_hash**(): `string`
+
+Commit from validators from the last block
+
+###### Returns
+
+`string`
+
+##### Set Signature
+
+> **set** **last\_commit\_hash**(`value`): `void`
+
+Commit from validators from the last block
+
+###### Parameters
+
+####### value
+
+`string`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1394
+
+***
+
+#### last\_results\_hash
+
+##### Get Signature
+
+> **get** **last\_results\_hash**(): `string`
+
+Root hash of all results from the txs from the previous block
+
+###### Returns
+
+`string`
+
+##### Set Signature
+
+> **set** **last\_results\_hash**(`value`): `void`
+
+Root hash of all results from the txs from the previous block
+
+###### Parameters
+
+####### value
+
+`string`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1426
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1366
 
 
 <a name="classesintounderlyingbytesourcemd"></a>
@@ -1386,7 +3217,7 @@ lumina\_node\_wasm.d.ts:526
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:573
+lumina\_node\_wasm.d.ts:1451
 
 ***
 
@@ -1396,7 +3227,7 @@ lumina\_node\_wasm.d.ts:573
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:572
+lumina\_node\_wasm.d.ts:1450
 
 ### Methods
 
@@ -1410,7 +3241,7 @@ lumina\_node\_wasm.d.ts:572
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:571
+lumina\_node\_wasm.d.ts:1449
 
 ***
 
@@ -1424,7 +3255,7 @@ lumina\_node\_wasm.d.ts:571
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:568
+lumina\_node\_wasm.d.ts:1446
 
 ***
 
@@ -1444,7 +3275,7 @@ lumina\_node\_wasm.d.ts:568
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:570
+lumina\_node\_wasm.d.ts:1448
 
 ***
 
@@ -1464,7 +3295,7 @@ lumina\_node\_wasm.d.ts:570
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:569
+lumina\_node\_wasm.d.ts:1447
 
 
 <a name="classesintounderlyingsinkmd"></a>
@@ -1495,7 +3326,7 @@ lumina\_node\_wasm.d.ts:569
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:580
+lumina\_node\_wasm.d.ts:1458
 
 ***
 
@@ -1509,7 +3340,7 @@ lumina\_node\_wasm.d.ts:580
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:579
+lumina\_node\_wasm.d.ts:1457
 
 ***
 
@@ -1523,7 +3354,7 @@ lumina\_node\_wasm.d.ts:579
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:577
+lumina\_node\_wasm.d.ts:1455
 
 ***
 
@@ -1543,7 +3374,7 @@ lumina\_node\_wasm.d.ts:577
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:578
+lumina\_node\_wasm.d.ts:1456
 
 
 <a name="classesintounderlyingsourcemd"></a>
@@ -1568,7 +3399,7 @@ lumina\_node\_wasm.d.ts:578
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:586
+lumina\_node\_wasm.d.ts:1464
 
 ***
 
@@ -1582,7 +3413,7 @@ lumina\_node\_wasm.d.ts:586
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:584
+lumina\_node\_wasm.d.ts:1462
 
 ***
 
@@ -1602,7 +3433,428 @@ lumina\_node\_wasm.d.ts:584
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:585
+lumina\_node\_wasm.d.ts:1463
+
+
+<a name="classesjsbitvectormd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / JsBitVector
+
+## Class: JsBitVector
+
+Array of bits
+
+### Properties
+
+#### 0
+
+> **0**: `Uint8Array`\<`ArrayBuffer`\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1472
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1471
+
+
+<a name="classesjseventmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / JsEvent
+
+## Class: JsEvent
+
+Event allows application developers to attach additional information to
+ResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.
+Later, transactions may be queried using these events.
+
+### Properties
+
+#### attributes
+
+> **attributes**: [`JsEventAttribute`](#classesjseventattributemd)[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1483
+
+***
+
+#### type
+
+> **type**: `string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1482
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1481
+
+
+<a name="classesjseventattributemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / JsEventAttribute
+
+## Class: JsEventAttribute
+
+### Properties
+
+#### index
+
+> **index**: `boolean`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1490
+
+***
+
+#### key
+
+> **key**: `Uint8Array`\<`ArrayBuffer`\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1488
+
+***
+
+#### value
+
+> **value**: `Uint8Array`\<`ArrayBuffer`\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1489
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1487
+
+
+<a name="classesjsvalidatorinfomd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / JsValidatorInfo
+
+## Class: JsValidatorInfo
+
+Validator information
+
+### Properties
+
+#### address
+
+> **address**: `string`
+
+Validator account address
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1501
+
+***
+
+#### power
+
+> **power**: `bigint`
+
+Validator voting power
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1509
+
+***
+
+#### proposer\_priority
+
+> **proposer\_priority**: `bigint`
+
+Validator proposer priority
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1521
+
+***
+
+#### pub\_key
+
+> **pub\_key**: [`PublicKey`](#interfacespublickeymd)
+
+Validator public key
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1505
+
+### Accessors
+
+#### name
+
+##### Get Signature
+
+> **get** **name**(): `string`
+
+Validator name
+
+###### Returns
+
+`string`
+
+##### Set Signature
+
+> **set** **name**(`value`): `void`
+
+Validator name
+
+###### Parameters
+
+####### value
+
+`string`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1513
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1497
+
+
+<a name="classeslightclientattackevidencemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / LightClientAttackEvidence
+
+## Class: LightClientAttackEvidence
+
+LightClient attack evidence
+
+### Properties
+
+#### byzantine\_validators
+
+> **byzantine\_validators**: [`JsValidatorInfo`](#classesjsvalidatorinfomd)[]
+
+Byzantine validators
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1540
+
+***
+
+#### common\_height
+
+> **common\_height**: `bigint`
+
+Common height
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1536
+
+***
+
+#### conflicting\_block
+
+> **conflicting\_block**: [`ConflictingBlock`](#classesconflictingblockmd)
+
+Conflicting block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1532
+
+***
+
+#### timestamp
+
+> **timestamp**: `string`
+
+Timestamp
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1548
+
+***
+
+#### total\_voting\_power
+
+> **total\_voting\_power**: `bigint`
+
+Total voting power
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1544
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1528
+
+
+<a name="classesmodeinfomd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ModeInfo
+
+## Class: ModeInfo
+
+ModeInfo describes the signing mode of a single or nested multisig signer.
+
+### Properties
+
+#### bitarray
+
+> `readonly` **bitarray**: [`JsBitVector`](#classesjsbitvectormd)
+
+Multi is the mode info for a multisig public key
+bitarray specifies which keys within the multisig are signing
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1570
+
+***
+
+#### mode
+
+> `readonly` **mode**: `number`
+
+Single is the mode info for a single signer. It is structured as a message
+to allow for additional fields such as locale for SIGN_MODE_TEXTUAL in the
+future
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1565
+
+***
+
+#### mode\_infos
+
+> `readonly` **mode\_infos**: [`ModeInfo`](#classesmodeinfomd)[]
+
+Multi is the mode info for a multisig public key
+mode_infos is the corresponding modes of the signers of the multisig
+which could include nested multisig public keys
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1576
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1555
+
+***
+
+#### signature\_mode()
+
+> **signature\_mode**(): [`SignatureMode`](#enumerationssignaturemodemd)
+
+Return signature mode for the stored signature(s)
+
+##### Returns
+
+[`SignatureMode`](#enumerationssignaturemodemd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1559
 
 
 <a name="classesnamespacemd"></a>
@@ -1645,7 +3897,7 @@ Returns the trailing 28 bytes indicating the id of the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:695
+lumina\_node\_wasm.d.ts:1685
 
 ***
 
@@ -1657,7 +3909,7 @@ Returns the first byte indicating the version of the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:691
+lumina\_node\_wasm.d.ts:1681
 
 ***
 
@@ -1671,7 +3923,7 @@ Used to indicate the end of the primary reserved group.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:666
+lumina\_node\_wasm.d.ts:1656
 
 ***
 
@@ -1685,7 +3937,7 @@ Used to indicate the beginning of the secondary reserved group.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:672
+lumina\_node\_wasm.d.ts:1662
 
 ***
 
@@ -1697,7 +3949,7 @@ Namespace size in bytes.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:645
+lumina\_node\_wasm.d.ts:1635
 
 ***
 
@@ -1713,7 +3965,7 @@ merkle roots.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:687
+lumina\_node\_wasm.d.ts:1677
 
 ***
 
@@ -1725,7 +3977,7 @@ Primary reserved [`Namespace`] for the compact Shares with MsgPayForBlobs transa
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:653
+lumina\_node\_wasm.d.ts:1643
 
 ***
 
@@ -1740,7 +3992,7 @@ so that user-defined namespaces are correctly aligned in `ExtendedDataSquare`
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:660
+lumina\_node\_wasm.d.ts:1650
 
 ***
 
@@ -1755,7 +4007,7 @@ blobs before the parity data is generated for the `ExtendedDataSquare`.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:679
+lumina\_node\_wasm.d.ts:1669
 
 ***
 
@@ -1767,7 +4019,7 @@ Primary reserved [`Namespace`] for the compact `Share`s with `cosmos SDK` transa
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:649
+lumina\_node\_wasm.d.ts:1639
 
 ### Methods
 
@@ -1783,7 +4035,7 @@ Converts the [`Namespace`] to a byte slice.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:641
+lumina\_node\_wasm.d.ts:1631
 
 ***
 
@@ -1797,7 +4049,7 @@ lumina\_node\_wasm.d.ts:641
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:619
+lumina\_node\_wasm.d.ts:1609
 
 ***
 
@@ -1813,7 +4065,7 @@ lumina\_node\_wasm.d.ts:619
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:614
+lumina\_node\_wasm.d.ts:1604
 
 ***
 
@@ -1829,7 +4081,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:618
+lumina\_node\_wasm.d.ts:1608
 
 ***
 
@@ -1857,7 +4109,7 @@ version `0` namespace, check [`newV0`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:637
+lumina\_node\_wasm.d.ts:1627
 
 ***
 
@@ -1882,7 +4134,7 @@ Check [`Namespace::new_v0`] for more details.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:627
+lumina\_node\_wasm.d.ts:1617
 
 
 <a name="classesnetworkinfosnapshotmd"></a>
@@ -1907,7 +4159,7 @@ Gets counters for ongoing network connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:718
+lumina\_node\_wasm.d.ts:1708
 
 ***
 
@@ -1919,7 +4171,7 @@ The number of connected peers, i.e. peers with whom at least one established con
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:714
+lumina\_node\_wasm.d.ts:1704
 
 ### Methods
 
@@ -1933,7 +4185,7 @@ lumina\_node\_wasm.d.ts:714
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:710
+lumina\_node\_wasm.d.ts:1700
 
 ***
 
@@ -1949,7 +4201,7 @@ lumina\_node\_wasm.d.ts:710
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:705
+lumina\_node\_wasm.d.ts:1695
 
 ***
 
@@ -1965,7 +4217,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:709
+lumina\_node\_wasm.d.ts:1699
 
 
 <a name="classesnodeclientmd"></a>
@@ -2004,7 +4256,7 @@ expected to have `MessagePort`-like interface for sending and receiving messages
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:732
+lumina\_node\_wasm.d.ts:1722
 
 ### Methods
 
@@ -2026,7 +4278,7 @@ Establish a new connection to the existing worker over provided port
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:736
+lumina\_node\_wasm.d.ts:1726
 
 ***
 
@@ -2042,7 +4294,7 @@ Get all the peers that node is connected to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:773
+lumina\_node\_wasm.d.ts:1763
 
 ***
 
@@ -2058,7 +4310,7 @@ Returns a [`BroadcastChannel`] for events generated by [`Node`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:840
+lumina\_node\_wasm.d.ts:1830
 
 ***
 
@@ -2072,7 +4324,7 @@ lumina\_node\_wasm.d.ts:840
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:727
+lumina\_node\_wasm.d.ts:1717
 
 ***
 
@@ -2094,7 +4346,7 @@ Get a synced header for the block with a given hash.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:816
+lumina\_node\_wasm.d.ts:1806
 
 ***
 
@@ -2116,7 +4368,7 @@ Get a synced header for the block with a given height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:820
+lumina\_node\_wasm.d.ts:1810
 
 ***
 
@@ -2150,7 +4402,7 @@ If range contains a height of a header that is not found in the store.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:832
+lumina\_node\_wasm.d.ts:1822
 
 ***
 
@@ -2166,7 +4418,7 @@ Get the latest locally synced header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:812
+lumina\_node\_wasm.d.ts:1802
 
 ***
 
@@ -2182,7 +4434,7 @@ Get the latest header announced in the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:808
+lumina\_node\_wasm.d.ts:1798
 
 ***
 
@@ -2204,7 +4456,7 @@ Get data sampling metadata of an already sampled height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:836
+lumina\_node\_wasm.d.ts:1826
 
 ***
 
@@ -2220,7 +4472,7 @@ Check whether Lumina is currently running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:740
+lumina\_node\_wasm.d.ts:1730
 
 ***
 
@@ -2236,7 +4488,7 @@ Get all the multiaddresses on which the node listens.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:769
+lumina\_node\_wasm.d.ts:1759
 
 ***
 
@@ -2252,7 +4504,7 @@ Get node's local peer ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:749
+lumina\_node\_wasm.d.ts:1739
 
 ***
 
@@ -2268,7 +4520,7 @@ Get current network info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:765
+lumina\_node\_wasm.d.ts:1755
 
 ***
 
@@ -2284,7 +4536,7 @@ Get current [`PeerTracker`] info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:753
+lumina\_node\_wasm.d.ts:1743
 
 ***
 
@@ -2315,7 +4567,7 @@ using bitswap protocol.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:800
+lumina\_node\_wasm.d.ts:1790
 
 ***
 
@@ -2337,7 +4589,7 @@ Request a header for the block with a given hash from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:785
+lumina\_node\_wasm.d.ts:1775
 
 ***
 
@@ -2359,7 +4611,7 @@ Request a header for the block with a given height from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:789
+lumina\_node\_wasm.d.ts:1779
 
 ***
 
@@ -2375,7 +4627,7 @@ Request the head header from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:781
+lumina\_node\_wasm.d.ts:1771
 
 ***
 
@@ -2403,7 +4655,7 @@ The headers will be verified with the `from` header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:795
+lumina\_node\_wasm.d.ts:1785
 
 ***
 
@@ -2429,7 +4681,7 @@ Trust or untrust the peer with a given ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:777
+lumina\_node\_wasm.d.ts:1767
 
 ***
 
@@ -2451,7 +4703,7 @@ Start a node with the provided config, if it's not running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:744
+lumina\_node\_wasm.d.ts:1734
 
 ***
 
@@ -2465,7 +4717,7 @@ lumina\_node\_wasm.d.ts:744
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:745
+lumina\_node\_wasm.d.ts:1735
 
 ***
 
@@ -2481,7 +4733,7 @@ Get current header syncing info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:804
+lumina\_node\_wasm.d.ts:1794
 
 ***
 
@@ -2497,7 +4749,7 @@ Wait until the node is connected to at least 1 peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:757
+lumina\_node\_wasm.d.ts:1747
 
 ***
 
@@ -2513,7 +4765,7 @@ Wait until the node is connected to at least 1 trusted peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:761
+lumina\_node\_wasm.d.ts:1751
 
 
 <a name="classesnodeconfigmd"></a>
@@ -2538,7 +4790,7 @@ A list of bootstrap peers to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:867
+lumina\_node\_wasm.d.ts:1857
 
 ***
 
@@ -2550,7 +4802,7 @@ A network to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:863
+lumina\_node\_wasm.d.ts:1853
 
 ***
 
@@ -2564,7 +4816,7 @@ Whether to store data in persistent memory or not.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:873
+lumina\_node\_wasm.d.ts:1863
 
 ### Accessors
 
@@ -2616,7 +4868,7 @@ If this is not set, then default value will apply:
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:900
+lumina\_node\_wasm.d.ts:1890
 
 ***
 
@@ -2656,7 +4908,7 @@ Sampling window defines maximum age of a block considered for syncing and sampli
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:880
+lumina\_node\_wasm.d.ts:1870
 
 ### Methods
 
@@ -2670,7 +4922,7 @@ lumina\_node\_wasm.d.ts:880
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:855
+lumina\_node\_wasm.d.ts:1845
 
 ***
 
@@ -2686,7 +4938,7 @@ lumina\_node\_wasm.d.ts:855
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:850
+lumina\_node\_wasm.d.ts:1840
 
 ***
 
@@ -2702,7 +4954,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:854
+lumina\_node\_wasm.d.ts:1844
 
 ***
 
@@ -2724,7 +4976,7 @@ Get the configuration with default bootnodes for provided network
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:859
+lumina\_node\_wasm.d.ts:1849
 
 
 <a name="classesnodeworkermd"></a>
@@ -2760,7 +5012,7 @@ them and sending a response back, as well as accepting new `NodeClient` connecti
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:923
+lumina\_node\_wasm.d.ts:1913
 
 ### Methods
 
@@ -2774,7 +5026,7 @@ lumina\_node\_wasm.d.ts:923
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:922
+lumina\_node\_wasm.d.ts:1912
 
 ***
 
@@ -2788,7 +5040,58 @@ lumina\_node\_wasm.d.ts:922
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:924
+lumina\_node\_wasm.d.ts:1914
+
+
+<a name="classespartsheadermd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / PartsHeader
+
+## Class: PartsHeader
+
+Block parts header
+
+### Properties
+
+#### hash
+
+> **hash**: `string`
+
+Hash of the parts set header
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1929
+
+***
+
+#### total
+
+> **total**: `number`
+
+Number of parts in this block
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1925
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1921
 
 
 <a name="classespeertrackerinfosnapshotmd"></a>
@@ -2813,7 +5116,7 @@ Number of the connected peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:943
+lumina\_node\_wasm.d.ts:1948
 
 ***
 
@@ -2825,7 +5128,7 @@ Number of the connected trusted peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:947
+lumina\_node\_wasm.d.ts:1952
 
 ### Methods
 
@@ -2839,7 +5142,7 @@ lumina\_node\_wasm.d.ts:947
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:939
+lumina\_node\_wasm.d.ts:1944
 
 ***
 
@@ -2855,7 +5158,7 @@ lumina\_node\_wasm.d.ts:939
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:934
+lumina\_node\_wasm.d.ts:1939
 
 ***
 
@@ -2871,7 +5174,58 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:938
+lumina\_node\_wasm.d.ts:1943
+
+
+<a name="classesprotocolversionmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ProtocolVersion
+
+## Class: ProtocolVersion
+
+Version contains the protocol version for the blockchain and the application.
+
+### Properties
+
+#### app
+
+> **app**: `bigint`
+
+app version
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1967
+
+***
+
+#### block
+
+> **block**: `bigint`
+
+blockchain version
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1963
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1959
 
 
 <a name="classessamplingmetadatamd"></a>
@@ -2898,7 +5252,7 @@ Return Array of cids
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:960
+lumina\_node\_wasm.d.ts:1980
 
 ### Methods
 
@@ -2912,7 +5266,216 @@ lumina\_node\_wasm.d.ts:960
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:956
+lumina\_node\_wasm.d.ts:1976
+
+
+<a name="classessignaturemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Signature
+
+## Class: Signature
+
+Signature
+
+### Properties
+
+#### 0
+
+> **0**: `Uint8Array`\<`ArrayBuffer`\>
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1988
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1987
+
+
+<a name="classessignedheadermd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / SignedHeader
+
+## Class: SignedHeader
+
+Signed block headers
+
+### Properties
+
+#### commit
+
+> **commit**: [`Commit`](#classescommitmd)
+
+Commit containing signatures for the header
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2003
+
+***
+
+#### header
+
+> **header**: [`Header`](#classesheadermd)
+
+Signed block headers
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1999
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1995
+
+
+<a name="classessignerinfomd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / SignerInfo
+
+## Class: SignerInfo
+
+SignerInfo describes the public key and signing mode of a single top-level
+signer.
+
+### Properties
+
+#### mode\_info
+
+> **mode\_info**: [`ModeInfo`](#classesmodeinfomd)
+
+mode_info describes the signing mode of the signer and is a nested
+structure to support nested multisig pubkey's
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2022
+
+***
+
+#### sequence
+
+> **sequence**: `bigint`
+
+sequence is the sequence of the account, which describes the
+number of committed transactions signed by a given address. It is used to
+prevent replay attacks.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2028
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2011
+
+***
+
+#### public\_key()
+
+> **public\_key**(): [`ProtoAny`](#interfacesprotoanymd)
+
+public_key is the public key of the signer. It is optional for accounts
+that already exist in state. If unset, the verifier can use the required \
+signer address for this position and lookup the public key.
+
+##### Returns
+
+[`ProtoAny`](#interfacesprotoanymd)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2017
+
+
+<a name="classesstringeventmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / StringEvent
+
+## Class: StringEvent
+
+StringEvent defines en Event object wrapper where all the attributes
+contain key/value pairs that are strings instead of raw bytes.
+
+### Properties
+
+#### attributes
+
+> **attributes**: [`Attribute`](#classesattributemd)[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2038
+
+***
+
+#### type
+
+> **type**: `string`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2037
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2036
 
 
 <a name="classessyncinginfosnapshotmd"></a>
@@ -2937,7 +5500,7 @@ Ranges of headers that are already synchronised
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:979
+lumina\_node\_wasm.d.ts:2057
 
 ***
 
@@ -2949,7 +5512,7 @@ Syncing target. The latest height seen in the network that was successfully veri
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:983
+lumina\_node\_wasm.d.ts:2061
 
 ### Methods
 
@@ -2963,7 +5526,7 @@ lumina\_node\_wasm.d.ts:983
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:975
+lumina\_node\_wasm.d.ts:2053
 
 ***
 
@@ -2979,7 +5542,7 @@ lumina\_node\_wasm.d.ts:975
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:970
+lumina\_node\_wasm.d.ts:2048
 
 ***
 
@@ -2995,7 +5558,183 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:974
+lumina\_node\_wasm.d.ts:2052
+
+
+<a name="classestxmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Tx
+
+## Class: Tx
+
+[`Tx`] is the standard type used for broadcasting transactions.
+
+### Properties
+
+#### auth\_info
+
+> **auth\_info**: [`AuthInfo`](#classesauthinfomd)
+
+Authorization related content of the transaction, specifically signers, signer modes
+and [`Fee`].
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2077
+
+***
+
+#### body
+
+> **body**: [`TxBody`](#classestxbodymd)
+
+Processable content of the transaction
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2072
+
+***
+
+#### signatures
+
+> `readonly` **signatures**: [`Signature`](#classessignaturemd)[]
+
+List of signatures that matches the length and order of [`AuthInfo`]’s `signer_info`s to
+allow connecting signature meta information like public key and signing mode by position.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2082
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2068
+
+
+<a name="classestxbodymd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / TxBody
+
+## Class: TxBody
+
+[`TxBody`] of a transaction that all signers sign over.
+
+### Properties
+
+#### memo
+
+> **memo**: `string`
+
+`memo` is any arbitrary memo to be added to the transaction.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2116
+
+***
+
+#### timeout\_height
+
+> `readonly` **timeout\_height**: `bigint`
+
+`timeout` is the block height after which this transaction will not
+be processed by the chain
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2121
+
+### Methods
+
+#### extension\_options()
+
+> **extension\_options**(): [`ProtoAny`](#interfacesprotoanymd)[]
+
+`extension_options` are arbitrary options that can be added by chains
+when the default options are not sufficient. If any of these are present
+and can't be handled, the transaction will be rejected
+
+##### Returns
+
+[`ProtoAny`](#interfacesprotoanymd)[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2106
+
+***
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2089
+
+***
+
+#### messages()
+
+> **messages**(): [`ProtoAny`](#interfacesprotoanymd)[]
+
+`messages` is a list of messages to be executed. The required signers of
+those messages define the number and order of elements in `AuthInfo`'s
+signer_infos and Tx's signatures. Each required signer address is added to
+the list only the first time it occurs.
+
+By convention, the first required signer (usually from the first message)
+is referred to as the primary signer and pays the fee for the whole
+transaction.
+
+##### Returns
+
+[`ProtoAny`](#interfacesprotoanymd)[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2100
+
+***
+
+#### non\_critical\_extension\_options()
+
+> **non\_critical\_extension\_options**(): [`ProtoAny`](#interfacesprotoanymd)[]
+
+`extension_options` are arbitrary options that can be added by chains
+when the default options are not sufficient. If any of these are present
+and can't be handled, they will be ignored
+
+##### Returns
+
+[`ProtoAny`](#interfacesprotoanymd)[]
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2112
 
 
 <a name="classestxclientmd"></a>
@@ -3014,7 +5753,7 @@ Celestia grpc transaction client.
 
 #### new TxClient()
 
-> **new TxClient**(`url`, `bech32_address`, `pubkey`, `signer_fn`): [`TxClient`](#classestxclientmd)
+> **new TxClient**(`url`, `pubkey`, `signer_fn`): [`TxClient`](#classestxclientmd)
 
 Create a new transaction client with the specified account.
 
@@ -3024,7 +5763,6 @@ Url must point to a [grpc-web proxy](https://github.com/grpc/grpc/blob/master/do
 ```js
 import { secp256k1 } from "@noble/curves/secp256k1";
 
-const address = "celestia169s50psyj2f4la9a2235329xz7rk6c53zhw9mm";
 const privKey = "fdc8ac75dfa1c142dbcba77938a14dd03078052ce0b49a529dcf72a9885a3abb";
 const pubKey = secp256k1.getPublicKey(privKey);
 
@@ -3034,7 +5772,7 @@ const signer = (signDoc) => {
   return sig.toCompactRawBytes();
 };
 
-const txClient = await new TxClient("http://127.0.0.1:18080", address, pubKey, signer);
+const txClient = await new TxClient("http://127.0.0.1:18080", pubKey, signer);
 ```
 
 ## Example with leap wallet
@@ -3047,16 +5785,12 @@ const signer = (signDoc) => {
     .then(sig => Uint8Array.from(atob(sig.signature.signature), c => c.charCodeAt(0)))
 }
 
-const tx_client = await new TxClient("http://127.0.0.1:18080", keys.bech32Address, keys.pubKey, signer)
+const tx_client = await new TxClient("http://127.0.0.1:18080", keys.pubKey, signer)
 ```
 
 ##### Parameters
 
 ###### url
-
-`string`
-
-###### bech32\_address
 
 `string`
 
@@ -3074,7 +5808,7 @@ const tx_client = await new TxClient("http://127.0.0.1:18080", keys.bech32Addres
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1025
+lumina\_node\_wasm.d.ts:2162
 
 ### Properties
 
@@ -3086,7 +5820,7 @@ AppVersion of the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1120
+lumina\_node\_wasm.d.ts:2257
 
 ***
 
@@ -3098,7 +5832,7 @@ Chain id of the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1116
+lumina\_node\_wasm.d.ts:2253
 
 ### Methods
 
@@ -3112,7 +5846,7 @@ lumina\_node\_wasm.d.ts:1116
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:989
+lumina\_node\_wasm.d.ts:2127
 
 ***
 
@@ -3134,7 +5868,7 @@ Get account
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1092
+lumina\_node\_wasm.d.ts:2229
 
 ***
 
@@ -3150,13 +5884,13 @@ Get accounts
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1096
+lumina\_node\_wasm.d.ts:2233
 
 ***
 
 #### getAllBalances()
 
-> **getAllBalances**(`address`): `Promise`\<[`Coin`](#interfacescoinmd)[]\>
+> **getAllBalances**(`address`): `Promise`\<[`Coin`](#classescoinmd)[]\>
 
 Get balance of all coins
 
@@ -3168,11 +5902,11 @@ Get balance of all coins
 
 ##### Returns
 
-`Promise`\<[`Coin`](#interfacescoinmd)[]\>
+`Promise`\<[`Coin`](#classescoinmd)[]\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1104
+lumina\_node\_wasm.d.ts:2241
 
 ***
 
@@ -3188,13 +5922,13 @@ Get auth params
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1088
+lumina\_node\_wasm.d.ts:2225
 
 ***
 
 #### getBalance()
 
-> **getBalance**(`address`, `denom`): `Promise`\<[`Coin`](#interfacescoinmd)\>
+> **getBalance**(`address`, `denom`): `Promise`\<[`Coin`](#classescoinmd)\>
 
 Get balance of coins with given denom
 
@@ -3210,17 +5944,17 @@ Get balance of coins with given denom
 
 ##### Returns
 
-`Promise`\<[`Coin`](#interfacescoinmd)\>
+`Promise`\<[`Coin`](#classescoinmd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1100
+lumina\_node\_wasm.d.ts:2237
 
 ***
 
 #### getSpendableBalances()
 
-> **getSpendableBalances**(`address`): `Promise`\<[`Coin`](#interfacescoinmd)[]\>
+> **getSpendableBalances**(`address`): `Promise`\<[`Coin`](#classescoinmd)[]\>
 
 Get balance of all spendable coins
 
@@ -3232,27 +5966,27 @@ Get balance of all spendable coins
 
 ##### Returns
 
-`Promise`\<[`Coin`](#interfacescoinmd)[]\>
+`Promise`\<[`Coin`](#classescoinmd)[]\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1108
+lumina\_node\_wasm.d.ts:2245
 
 ***
 
 #### getTotalSupply()
 
-> **getTotalSupply**(): `Promise`\<[`Coin`](#interfacescoinmd)[]\>
+> **getTotalSupply**(): `Promise`\<[`Coin`](#classescoinmd)[]\>
 
 Get total supply
 
 ##### Returns
 
-`Promise`\<[`Coin`](#interfacescoinmd)[]\>
+`Promise`\<[`Coin`](#classescoinmd)[]\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1112
+lumina\_node\_wasm.d.ts:2249
 
 ***
 
@@ -3268,7 +6002,7 @@ Last gas price fetched by the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1029
+lumina\_node\_wasm.d.ts:2166
 
 ***
 
@@ -3319,7 +6053,7 @@ await txClient.submitBlobs(blobs.map(b => b.clone()));
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1058
+lumina\_node\_wasm.d.ts:2195
 
 ***
 
@@ -3367,7 +6101,261 @@ const txInfo = await txClient.submitMessage(sendMsgAny);
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1084
+lumina\_node\_wasm.d.ts:2221
+
+
+<a name="classestxresponsemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / TxResponse
+
+## Class: TxResponse
+
+Response to a tx query
+
+### Properties
+
+#### code
+
+> **code**: [`ErrorCode`](#enumerationserrorcodemd)
+
+Response code.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2272
+
+***
+
+#### codespace
+
+> **codespace**: `string`
+
+Namespace for the Code
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2268
+
+***
+
+#### data
+
+> **data**: `string`
+
+Result bytes, if any.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2276
+
+***
+
+#### events
+
+> `readonly` **events**: [`JsEvent`](#classesjseventmd)[]
+
+Events defines all the events emitted by processing a transaction. Note,
+these events include those emitted by processing all the messages and those
+emitted from the ante. Whereas Logs contains the events, with
+additional metadata, emitted only by processing the messages.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2314
+
+***
+
+#### gas\_used
+
+> **gas\_used**: `bigint`
+
+Amount of gas consumed by transaction.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2297
+
+***
+
+#### gas\_wanted
+
+> **gas\_wanted**: `bigint`
+
+Amount of gas requested for transaction.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2293
+
+***
+
+#### height
+
+> `readonly` **height**: `bigint`
+
+The block height
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2307
+
+***
+
+#### info
+
+> **info**: `string`
+
+Additional information. May be non-deterministic.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2289
+
+***
+
+#### logs
+
+> **logs**: [`AbciMessageLog`](#classesabcimessagelogmd)[]
+
+The output of the application's logger (typed). May be non-deterministic.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2285
+
+***
+
+#### raw\_log
+
+> **raw\_log**: `string`
+
+The output of the application's logger (raw string). May be
+non-deterministic.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2281
+
+***
+
+#### timestamp
+
+> **timestamp**: `string`
+
+Time of the previous block. For heights > 1, it's the weighted median of
+the timestamps of the valid votes in the block.LastCommit. For height == 1,
+it's genesis time.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2303
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2264
+
+
+<a name="classestxstatusresponsemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / TxStatusResponse
+
+## Class: TxStatusResponse
+
+Response to a tx status query
+
+### Properties
+
+#### error
+
+> **error**: `string`
+
+Error log, if transaction failed.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2335
+
+***
+
+#### execution\_code
+
+> **execution\_code**: [`ErrorCode`](#enumerationserrorcodemd)
+
+Execution_code is returned when the transaction has been committed
+and returns whether it was successful or errored. A non zero
+execution code indicates an error.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2331
+
+***
+
+#### height
+
+> `readonly` **height**: `bigint`
+
+Height of the block in which the transaction was committed.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2343
+
+***
+
+#### index
+
+> **index**: `number`
+
+Index of the transaction in block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2325
+
+***
+
+#### status
+
+> **status**: [`TxStatus`](#enumerationstxstatusmd)
+
+Status of the transaction.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2339
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2321
 
 
 <a name="classesvaladdressmd"></a>
@@ -3394,7 +6382,7 @@ Address of a validator.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1135
+lumina\_node\_wasm.d.ts:2358
 
 ***
 
@@ -3410,7 +6398,7 @@ lumina\_node\_wasm.d.ts:1135
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1130
+lumina\_node\_wasm.d.ts:2353
 
 ***
 
@@ -3426,9 +6414,1281 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1134
+lumina\_node\_wasm.d.ts:2357
+
+
+<a name="classesvalidatorsetmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ValidatorSet
+
+## Class: ValidatorSet
+
+Validator set contains a vector of validators
+
+### Properties
+
+#### total\_voting\_power
+
+> **total\_voting\_power**: `bigint`
+
+Total voting power
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2381
+
+***
+
+#### validators
+
+> **validators**: [`JsValidatorInfo`](#classesjsvalidatorinfomd)[]
+
+Validators in the set
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2369
+
+### Accessors
+
+#### proposer
+
+##### Get Signature
+
+> **get** **proposer**(): [`JsValidatorInfo`](#classesjsvalidatorinfomd)
+
+Proposer
+
+###### Returns
+
+[`JsValidatorInfo`](#classesjsvalidatorinfomd)
+
+##### Set Signature
+
+> **set** **proposer**(`value`): `void`
+
+Proposer
+
+###### Parameters
+
+####### value
+
+[`JsValidatorInfo`](#classesjsvalidatorinfomd)
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2373
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2365
+
+
+<a name="classesvotemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / Vote
+
+## Class: Vote
+
+Votes are signed messages from validators for a particular block which include
+information about the validator signing it.
+
+### Properties
+
+#### extension
+
+> **extension**: `Uint8Array`\<`ArrayBuffer`\>
+
+Vote extension provided by the application. Only valid for precommit messages.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2437
+
+***
+
+#### height
+
+> **height**: `bigint`
+
+Block height
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2397
+
+***
+
+#### round
+
+> **round**: `number`
+
+Round
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2401
+
+***
+
+#### validator\_address
+
+> **validator\_address**: `string`
+
+Validator address
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2421
+
+***
+
+#### validator\_index
+
+> **validator\_index**: `number`
+
+Validator index
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2425
+
+***
+
+#### vote\_type
+
+> **vote\_type**: [`VoteType`](#enumerationsvotetypemd)
+
+Type of vote (prevote or precommit)
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2393
+
+### Accessors
+
+#### block\_id
+
+##### Get Signature
+
+> **get** **block\_id**(): [`BlockId`](#classesblockidmd)
+
+Block ID
+
+###### Returns
+
+[`BlockId`](#classesblockidmd)
+
+##### Set Signature
+
+> **set** **block\_id**(`value`): `void`
+
+Block ID
+
+###### Parameters
+
+####### value
+
+[`BlockId`](#classesblockidmd)
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2405
+
+***
+
+#### extension\_signature
+
+##### Get Signature
+
+> **get** **extension\_signature**(): [`Signature`](#classessignaturemd)
+
+Vote extension signature by the validator Only valid for precommit messages.
+
+###### Returns
+
+[`Signature`](#classessignaturemd)
+
+##### Set Signature
+
+> **set** **extension\_signature**(`value`): `void`
+
+Vote extension signature by the validator Only valid for precommit messages.
+
+###### Parameters
+
+####### value
+
+[`Signature`](#classessignaturemd)
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2441
+
+***
+
+#### signature
+
+##### Get Signature
+
+> **get** **signature**(): [`Signature`](#classessignaturemd)
+
+Signature
+
+###### Returns
+
+[`Signature`](#classessignaturemd)
+
+##### Set Signature
+
+> **set** **signature**(`value`): `void`
+
+Signature
+
+###### Parameters
+
+####### value
+
+[`Signature`](#classessignaturemd)
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2429
+
+***
+
+#### timestamp
+
+##### Get Signature
+
+> **get** **timestamp**(): `string`
+
+Timestamp
+
+###### Returns
+
+`string`
+
+##### Set Signature
+
+> **set** **timestamp**(`value`): `void`
+
+Timestamp
+
+###### Parameters
+
+####### value
+
+`string`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2413
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:2389
 
 # Enumerations
+
+
+<a name="enumerationsattacktypemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / AttackType
+
+## Enumeration: AttackType
+
+Attack type for the associated evidence
+
+### Enumeration Members
+
+#### DuplicateVote
+
+> **DuplicateVote**: `0`
+
+Duplicate vote
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:18
+
+***
+
+#### LightClient
+
+> **LightClient**: `1`
+
+LightClient attack
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:22
+
+
+<a name="enumerationscommitvotetypemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / CommitVoteType
+
+## Enumeration: CommitVoteType
+
+### Enumeration Members
+
+#### BlockIdFlagAbsent
+
+> **BlockIdFlagAbsent**: `0`
+
+no vote was received from a validator.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:28
+
+***
+
+#### BlockIdFlagCommit
+
+> **BlockIdFlagCommit**: `1`
+
+voted for the Commit.BlockID.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:32
+
+***
+
+#### BlockIdFlagNil
+
+> **BlockIdFlagNil**: `2`
+
+voted for nil
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:36
+
+
+<a name="enumerationserrorcodemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ErrorCode
+
+## Enumeration: ErrorCode
+
+Error codes associated with transaction responses.
+
+### Enumeration Members
+
+#### AppConfig
+
+> **AppConfig**: `40`
+
+Min-gas-prices field in BaseConfig is empty
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:201
+
+***
+
+#### BlobSizeMismatch
+
+> **BlobSizeMismatch**: `11113`
+
+actual blob size differs from that specified in the MsgPayForBlob
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:225
+
+***
+
+#### BlobsTooLarge
+
+> **BlobsTooLarge**: `11139`
+
+blob(s) too large
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:323
+
+***
+
+#### CalculateCommitment
+
+> **CalculateCommitment**: `11115`
+
+unexpected error calculating commitment for share
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:233
+
+***
+
+#### CommittedSquareSizeNotPowOf2
+
+> **CommittedSquareSizeNotPowOf2**: `11114`
+
+committed to invalid square size: must be power of two
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:229
+
+***
+
+#### Conflict
+
+> **Conflict**: `36`
+
+Conflict error, e.g. when two goroutines try to access the same resource and one of them fails
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:185
+
+***
+
+#### InsufficientFee
+
+> **InsufficientFee**: `13`
+
+Fee is insufficient
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:93
+
+***
+
+#### InsufficientFunds
+
+> **InsufficientFunds**: `5`
+
+Account cannot pay requested amount
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:61
+
+***
+
+#### InvalidAddress
+
+> **InvalidAddress**: `7`
+
+Address is invalid
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:69
+
+***
+
+#### InvalidBlobSigner
+
+> **InvalidBlobSigner**: `11140`
+
+invalid blob signer
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:327
+
+***
+
+#### InvalidChainID
+
+> **InvalidChainID**: `28`
+
+Chain-id is invalid
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:153
+
+***
+
+#### InvalidCoins
+
+> **InvalidCoins**: `10`
+
+Coin is invalid
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:81
+
+***
+
+#### InvalidDataSize
+
+> **InvalidDataSize**: `11112`
+
+data must be multiple of shareSize
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:221
+
+***
+
+#### InvalidGasAdjustment
+
+> **InvalidGasAdjustment**: `25`
+
+Invalid gas adjustment
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:141
+
+***
+
+#### InvalidGasLimit
+
+> **InvalidGasLimit**: `41`
+
+Invalid GasWanted value is supplied
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:205
+
+***
+
+#### InvalidHeight
+
+> **InvalidHeight**: `26`
+
+Invalid height
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:145
+
+***
+
+#### InvalidNamespace
+
+> **InvalidNamespace**: `11136`
+
+invalid namespace
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:309
+
+***
+
+#### InvalidNamespaceLen
+
+> **InvalidNamespaceLen**: `11111`
+
+invalid namespace length
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:217
+
+***
+
+#### InvalidNamespaceVersion
+
+> **InvalidNamespaceVersion**: `11137`
+
+invalid namespace version
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:313
+
+***
+
+#### InvalidPubKey
+
+> **InvalidPubKey**: `8`
+
+Pubkey is invalid
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:73
+
+***
+
+#### InvalidRequest
+
+> **InvalidRequest**: `18`
+
+Request contains invalid data
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:113
+
+***
+
+#### InvalidSequence
+
+> **InvalidSequence**: `3`
+
+Sequence number (nonce) is incorrect for the signature
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:53
+
+***
+
+#### InvalidShareCommitment
+
+> **InvalidShareCommitment**: `11116`
+
+invalid commitment for share
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:237
+
+***
+
+#### InvalidShareCommitments
+
+> **InvalidShareCommitments**: `11122`
+
+invalid share commitments: all relevant square sizes must be committed to
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:253
+
+***
+
+#### InvalidSigner
+
+> **InvalidSigner**: `24`
+
+Tx intended signer does not match the given signer
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:137
+
+***
+
+#### InvalidType
+
+> **InvalidType**: `29`
+
+Invalid type
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:157
+
+***
+
+#### InvalidVersion
+
+> **InvalidVersion**: `27`
+
+Invalid version
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:149
+
+***
+
+#### IO
+
+> **IO**: `39`
+
+Internal errors caused by external operation
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:197
+
+***
+
+#### JSONMarshal
+
+> **JSONMarshal**: `16`
+
+Error converting to json
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:105
+
+***
+
+#### JSONUnmarshal
+
+> **JSONUnmarshal**: `17`
+
+Error converting from json
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:109
+
+***
+
+#### KeyNotFound
+
+> **KeyNotFound**: `22`
+
+Key doesn't exist
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:129
+
+***
+
+#### Logic
+
+> **Logic**: `35`
+
+Internal logic error, e.g. an invariant or assertion that is violated
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:181
+
+***
+
+#### MemoTooLarge
+
+> **MemoTooLarge**: `12`
+
+Memo too large
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:89
+
+***
+
+#### MempoolIsFull
+
+> **MempoolIsFull**: `20`
+
+Mempool is full
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:121
+
+***
+
+#### MismatchedNumberOfPFBComponent
+
+> **MismatchedNumberOfPFBComponent**: `11130`
+
+number of each component in a MsgPayForBlobs must be identical
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:285
+
+***
+
+#### MismatchedNumberOfPFBorBlob
+
+> **MismatchedNumberOfPFBorBlob**: `11125`
+
+mismatched number of blobs per MsgPayForBlob
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:265
+
+***
+
+#### MultipleMsgsInBlobTx
+
+> **MultipleMsgsInBlobTx**: `11129`
+
+not yet supported: multiple sdk.Msgs found in BlobTx
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:281
+
+***
+
+#### NamespaceMismatch
+
+> **NamespaceMismatch**: `11127`
+
+namespace of blob and its respective MsgPayForBlobs differ
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:273
+
+***
+
+#### NoBlobs
+
+> **NoBlobs**: `11131`
+
+no blobs provided
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:289
+
+***
+
+#### NoBlobSizes
+
+> **NoBlobSizes**: `11134`
+
+no blob sizes provided
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:301
+
+***
+
+#### NoNamespaces
+
+> **NoNamespaces**: `11132`
+
+no namespaces provided
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:293
+
+***
+
+#### NoPFB
+
+> **NoPFB**: `11126`
+
+no MsgPayForBlobs found in blob transaction
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:269
+
+***
+
+#### NoShareCommitments
+
+> **NoShareCommitments**: `11135`
+
+no share commitments provided
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:305
+
+***
+
+#### NoShareVersions
+
+> **NoShareVersions**: `11133`
+
+no share versions provided
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:297
+
+***
+
+#### NoSignatures
+
+> **NoSignatures**: `15`
+
+No signatures in transaction
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:101
+
+***
+
+#### NotFound
+
+> **NotFound**: `38`
+
+Requested entity doesn't exist in the state
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:193
+
+***
+
+#### NotSupported
+
+> **NotSupported**: `37`
+
+Called a branch of a code which is currently not supported
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:189
+
+***
+
+#### OutOfGas
+
+> **OutOfGas**: `11`
+
+Gas exceeded
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:85
+
+***
+
+#### PackAny
+
+> **PackAny**: `33`
+
+Packing a protobuf message to Any failed
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:173
+
+***
+
+#### Panic
+
+> **Panic**: `111222`
+
+Node recovered from panic
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:209
+
+***
+
+#### ParitySharesNamespace
+
+> **ParitySharesNamespace**: `11117`
+
+cannot use parity shares namespace ID
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:241
+
+***
+
+#### ProtoParsing
+
+> **ProtoParsing**: `11128`
+
+failure to parse a transaction from its protobuf representation
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:277
+
+***
+
+#### ReservedNamespace
+
+> **ReservedNamespace**: `11110`
+
+cannot use reserved namespace IDs
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:213
+
+***
+
+#### Success
+
+> **Success**: `0`
+
+No error
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:45
+
+***
+
+#### TailPaddingNamespace
+
+> **TailPaddingNamespace**: `11118`
+
+cannot use tail padding namespace ID
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:245
+
+***
+
+#### TooManySignatures
+
+> **TooManySignatures**: `14`
+
+Too many signatures
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:97
+
+***
+
+#### TotalBlobSizeTooLarge
+
+> **TotalBlobSizeTooLarge**: `11138`
+
+total blob size too large
+
+TotalBlobSize is deprecated, use BlobsTooLarge instead.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:319
+
+***
+
+#### TxDecode
+
+> **TxDecode**: `2`
+
+Cannot parse a transaction
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:49
+
+***
+
+#### TxInMempoolCache
+
+> **TxInMempoolCache**: `19`
+
+Tx already exists in the mempool
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:117
+
+***
+
+#### TxNamespace
+
+> **TxNamespace**: `11119`
+
+cannot use transaction namespace ID
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:249
+
+***
+
+#### TxTimeoutHeight
+
+> **TxTimeoutHeight**: `30`
+
+Tx rejected due to an explicitly set timeout height
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:161
+
+***
+
+#### TxTooLarge
+
+> **TxTooLarge**: `21`
+
+Tx is too large
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:125
+
+***
+
+#### Unauthorized
+
+> **Unauthorized**: `4`
+
+Request without sufficient authorization is handled
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:57
+
+***
+
+#### UnknownAddress
+
+> **UnknownAddress**: `9`
+
+Address is unknown
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:77
+
+***
+
+#### UnknownExtensionOptions
+
+> **UnknownExtensionOptions**: `31`
+
+Unknown extension options.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:165
+
+***
+
+#### UnknownRequest
+
+> **UnknownRequest**: `6`
+
+Request is unknown
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:65
+
+***
+
+#### UnpackAny
+
+> **UnpackAny**: `34`
+
+Unpacking a protobuf message from Any failed
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:177
+
+***
+
+#### UnsupportedShareVersion
+
+> **UnsupportedShareVersion**: `11123`
+
+unsupported share version
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:257
+
+***
+
+#### WrongPassword
+
+> **WrongPassword**: `23`
+
+Key password is invalid
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:133
+
+***
+
+#### WrongSequence
+
+> **WrongSequence**: `32`
+
+Account sequence defined in the signer info doesn't match the account's actual sequence
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:169
+
+***
+
+#### ZeroBlobSize
+
+> **ZeroBlobSize**: `11124`
+
+cannot use zero blob size
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:261
 
 
 <a name="enumerationsnetworkmd"></a>
@@ -3453,7 +7713,7 @@ Arabica testnet.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:22
+lumina\_node\_wasm.d.ts:340
 
 ***
 
@@ -3465,7 +7725,7 @@ Celestia mainnet.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:18
+lumina\_node\_wasm.d.ts:336
 
 ***
 
@@ -3477,7 +7737,7 @@ Mocha testnet.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:26
+lumina\_node\_wasm.d.ts:344
 
 ***
 
@@ -3489,7 +7749,136 @@ Private local network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:30
+lumina\_node\_wasm.d.ts:348
+
+
+<a name="enumerationssignaturemodemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / SignatureMode
+
+## Enumeration: SignatureMode
+
+### Enumeration Members
+
+#### Multi
+
+> **Multi**: `1`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:352
+
+***
+
+#### Single
+
+> **Single**: `0`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:351
+
+
+<a name="enumerationstxstatusmd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / TxStatus
+
+## Enumeration: TxStatus
+
+Represents state of the transaction in the mempool
+
+### Enumeration Members
+
+#### Committed
+
+> **Committed**: `3`
+
+The transaction was committed into the block.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:373
+
+***
+
+#### Evicted
+
+> **Evicted**: `2`
+
+The transaction was evicted from the mempool.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:369
+
+***
+
+#### Pending
+
+> **Pending**: `1`
+
+The transaction is still pending.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:365
+
+***
+
+#### Unknown
+
+> **Unknown**: `0`
+
+The transaction is not known to the node, it could be never sent.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:361
+
+
+<a name="enumerationsvotetypemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / VoteType
+
+## Enumeration: VoteType
+
+Types of votes
+
+### Enumeration Members
+
+#### Precommit
+
+> **Precommit**: `1`
+
+Precommit
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:386
+
+***
+
+#### Prevote
+
+> **Prevote**: `0`
+
+Prevote
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:382
 
 # Functions
 
@@ -3556,38 +7945,81 @@ lumina\_node\_wasm.d.ts:6
 
 ## Enumerations
 
+- [AttackType](#enumerationsattacktypemd)
+- [CommitVoteType](#enumerationscommitvotetypemd)
+- [ErrorCode](#enumerationserrorcodemd)
 - [Network](#enumerationsnetworkmd)
+- [SignatureMode](#enumerationssignaturemodemd)
+- [TxStatus](#enumerationstxstatusmd)
+- [VoteType](#enumerationsvotetypemd)
 
 ## Classes
 
+- [AbciMessageLog](#classesabcimessagelogmd)
 - [AccAddress](#classesaccaddressmd)
 - [AppVersion](#classesappversionmd)
+- [Attribute](#classesattributemd)
+- [AuthInfo](#classesauthinfomd)
 - [Blob](#classesblobmd)
+- [BlobParams](#classesblobparamsmd)
+- [Block](#classesblockmd)
+- [BlockId](#classesblockidmd)
 - [BlockRange](#classesblockrangemd)
+- [BroadcastMode](#classesbroadcastmodemd)
+- [Coin](#classescoinmd)
+- [Commit](#classescommitmd)
 - [Commitment](#classescommitmentmd)
+- [CommitSig](#classescommitsigmd)
+- [CommitVote](#classescommitvotemd)
+- [ConflictingBlock](#classesconflictingblockmd)
 - [ConnectionCountersSnapshot](#classesconnectioncounterssnapshotmd)
 - [ConsAddress](#classesconsaddressmd)
+- [Data](#classesdatamd)
 - [DataAvailabilityHeader](#classesdataavailabilityheadermd)
+- [DuplicateVoteEvidence](#classesduplicatevoteevidencemd)
+- [Evidence](#classesevidencemd)
 - [ExtendedHeader](#classesextendedheadermd)
+- [Fee](#classesfeemd)
+- [GasInfo](#classesgasinfomd)
+- [GetTxResponse](#classesgettxresponsemd)
+- [GrpcClient](#classesgrpcclientmd)
+- [Header](#classesheadermd)
 - [IntoUnderlyingByteSource](#classesintounderlyingbytesourcemd)
 - [IntoUnderlyingSink](#classesintounderlyingsinkmd)
 - [IntoUnderlyingSource](#classesintounderlyingsourcemd)
+- [JsBitVector](#classesjsbitvectormd)
+- [JsEvent](#classesjseventmd)
+- [JsEventAttribute](#classesjseventattributemd)
+- [JsValidatorInfo](#classesjsvalidatorinfomd)
+- [LightClientAttackEvidence](#classeslightclientattackevidencemd)
+- [ModeInfo](#classesmodeinfomd)
 - [Namespace](#classesnamespacemd)
 - [NetworkInfoSnapshot](#classesnetworkinfosnapshotmd)
 - [NodeClient](#classesnodeclientmd)
 - [NodeConfig](#classesnodeconfigmd)
 - [NodeWorker](#classesnodeworkermd)
+- [PartsHeader](#classespartsheadermd)
 - [PeerTrackerInfoSnapshot](#classespeertrackerinfosnapshotmd)
+- [ProtocolVersion](#classesprotocolversionmd)
 - [SamplingMetadata](#classessamplingmetadatamd)
+- [Signature](#classessignaturemd)
+- [SignedHeader](#classessignedheadermd)
+- [SignerInfo](#classessignerinfomd)
+- [StringEvent](#classesstringeventmd)
 - [SyncingInfoSnapshot](#classessyncinginfosnapshotmd)
+- [Tx](#classestxmd)
+- [TxBody](#classestxbodymd)
 - [TxClient](#classestxclientmd)
+- [TxResponse](#classestxresponsemd)
+- [TxStatusResponse](#classestxstatusresponsemd)
 - [ValAddress](#classesvaladdressmd)
+- [ValidatorSet](#classesvalidatorsetmd)
+- [Vote](#classesvotemd)
 
 ## Interfaces
 
 - [AuthParams](#interfacesauthparamsmd)
 - [BaseAccount](#interfacesbaseaccountmd)
-- [Coin](#interfacescoinmd)
 - [ProtoAny](#interfacesprotoanymd)
 - [PublicKey](#interfacespublickeymd)
 - [SignDoc](#interfacessigndocmd)
@@ -3627,7 +8059,7 @@ Auth module parameters
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:80
+lumina\_node\_wasm.d.ts:437
 
 ***
 
@@ -3637,7 +8069,7 @@ lumina\_node\_wasm.d.ts:80
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:83
+lumina\_node\_wasm.d.ts:440
 
 ***
 
@@ -3647,7 +8079,7 @@ lumina\_node\_wasm.d.ts:83
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:84
+lumina\_node\_wasm.d.ts:441
 
 ***
 
@@ -3657,7 +8089,7 @@ lumina\_node\_wasm.d.ts:84
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:81
+lumina\_node\_wasm.d.ts:438
 
 ***
 
@@ -3667,7 +8099,7 @@ lumina\_node\_wasm.d.ts:81
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:82
+lumina\_node\_wasm.d.ts:439
 
 
 <a name="interfacesbaseaccountmd"></a>
@@ -3690,7 +8122,7 @@ Common data of all account types
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:72
+lumina\_node\_wasm.d.ts:429
 
 ***
 
@@ -3700,7 +8132,7 @@ lumina\_node\_wasm.d.ts:72
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:70
+lumina\_node\_wasm.d.ts:427
 
 ***
 
@@ -3710,7 +8142,7 @@ lumina\_node\_wasm.d.ts:70
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:71
+lumina\_node\_wasm.d.ts:428
 
 ***
 
@@ -3720,40 +8152,7 @@ lumina\_node\_wasm.d.ts:71
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:73
-
-
-<a name="interfacescoinmd"></a>
-
-[**lumina-node-wasm**](#readmemd)
-
-***
-
-[lumina-node-wasm](#globalsmd) / Coin
-
-## Interface: Coin
-
-Coin
-
-### Properties
-
-#### amount
-
-> **amount**: `bigint`
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:94
-
-***
-
-#### denom
-
-> **denom**: `string`
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:93
+lumina\_node\_wasm.d.ts:430
 
 
 <a name="interfacesprotoanymd"></a>
@@ -3776,7 +8175,7 @@ Protobuf Any type
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:120
+lumina\_node\_wasm.d.ts:399
 
 ***
 
@@ -3786,7 +8185,7 @@ lumina\_node\_wasm.d.ts:120
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:121
+lumina\_node\_wasm.d.ts:400
 
 
 <a name="interfacespublickeymd"></a>
@@ -3809,7 +8208,7 @@ Public key
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:62
+lumina\_node\_wasm.d.ts:419
 
 ***
 
@@ -3819,7 +8218,7 @@ lumina\_node\_wasm.d.ts:62
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:63
+lumina\_node\_wasm.d.ts:420
 
 
 <a name="interfacessigndocmd"></a>
@@ -3842,7 +8241,7 @@ A payload to be signed
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:106
+lumina\_node\_wasm.d.ts:453
 
 ***
 
@@ -3852,7 +8251,7 @@ lumina\_node\_wasm.d.ts:106
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:104
+lumina\_node\_wasm.d.ts:451
 
 ***
 
@@ -3862,7 +8261,7 @@ lumina\_node\_wasm.d.ts:104
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:103
+lumina\_node\_wasm.d.ts:450
 
 ***
 
@@ -3872,7 +8271,7 @@ lumina\_node\_wasm.d.ts:103
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:105
+lumina\_node\_wasm.d.ts:452
 
 
 <a name="interfacestxconfigmd"></a>
@@ -3895,7 +8294,7 @@ Transaction config.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:51
+lumina\_node\_wasm.d.ts:475
 
 ***
 
@@ -3905,7 +8304,7 @@ lumina\_node\_wasm.d.ts:51
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:52
+lumina\_node\_wasm.d.ts:476
 
 ***
 
@@ -3915,7 +8314,7 @@ lumina\_node\_wasm.d.ts:52
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:53
+lumina\_node\_wasm.d.ts:477
 
 
 <a name="interfacestxinfomd"></a>
@@ -3938,7 +8337,7 @@ Transaction info
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:43
+lumina\_node\_wasm.d.ts:467
 
 ***
 
@@ -3948,7 +8347,7 @@ lumina\_node\_wasm.d.ts:43
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:44
+lumina\_node\_wasm.d.ts:468
 
 # Type Aliases
 
@@ -3971,7 +8370,7 @@ The `ReadableStreamType` enum.
 
 ### Defined in
 
-lumina\_node\_wasm.d.ts:37
+lumina\_node\_wasm.d.ts:393
 
 
 <a name="type-aliasessignerfnmd"></a>
@@ -3990,4 +8389,4 @@ A function that produces a signature of a payload
 
 ### Defined in
 
-lumina\_node\_wasm.d.ts:112
+lumina\_node\_wasm.d.ts:459

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.9.0",
+            "version": "0.9.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.9.0",
+            "version": "0.9.1",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.13.0...lumina-node-v0.14.0) - 2025-07-18
+
+### Fixed
+
+- *(node)* [**breaking**] Make blockstore only store samples ([#653](https://github.com/eigerco/lumina/pull/653))
+
 ## [0.13.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.12.1...lumina-node-v0.13.0) - 2025-07-02
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.2...celestia-proto-v0.8.0) - 2025-07-18
+
+### Added
+
+- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
+
 ## [0.7.2](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.1...celestia-proto-v0.7.2) - 2025-06-09
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.2...celestia-rpc-v0.11.3) - 2025-07-18
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.11.2](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.1...celestia-rpc-v0.11.2) - 2025-07-02
 
 ### Other

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.12.0...celestia-types-v0.13.0) - 2025-07-18
+
+### Added
+
+- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
+- *(grpc)* Streamline TxClient creation API, add docs with example ([#673](https://github.com/eigerco/lumina/pull/673))
+
 ## [0.12.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.11.2...celestia-types-v0.12.0) - 2025-07-02
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-utils-v0.2.0...lumina-utils-v0.3.0) - 2025-07-18
+
+### Added
+
+- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-utils-v0.1.0...lumina-utils-v0.2.0) - 2025-05-26
 
 ### Fixed

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-utils"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Platform abstraction utilities used across lumina project"


### PR DESCRIPTION



## 🤖 New release

* `celestia-proto`: 0.7.2 -> 0.8.0 (✓ API compatible changes)
* `lumina-utils`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `celestia-types`: 0.12.0 -> 0.13.0 (⚠ API breaking changes)
* `lumina-node`: 0.13.0 -> 0.14.0 (✓ API compatible changes)
* `lumina-cli`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `celestia-grpc`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `lumina-node-uniffi`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `celestia-rpc`: 0.11.2 -> 0.11.3
* `lumina-node-wasm`: 0.9.0 -> 0.9.1

### ⚠ `celestia-types` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum celestia_types::block::uniffi_types::CommitSig, previously in file /tmp/.tmpa0lBw6/celestia-types/src/block.rs:380
  enum celestia_types::uniffi_types::Evidence, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:452

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_types::uniffi_types::ValidatorSet, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:371
  struct celestia_types::uniffi_types::BlockId, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:125
  struct celestia_types::block::uniffi_types::Header, previously in file /tmp/.tmpa0lBw6/celestia-types/src/block.rs:463
  struct celestia_types::block::uniffi_types::SignedHeader, previously in file /tmp/.tmpa0lBw6/celestia-types/src/block.rs:290
  struct celestia_types::uniffi_types::ValidatorInfo, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:328
  struct celestia_types::uniffi_types::AppHash, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:40
  struct celestia_types::uniffi_types::ConflictingBlock, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:411
  struct celestia_types::uniffi_types::BlockHeight, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:580
  struct celestia_types::uniffi_types::Vote, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:250
  struct celestia_types::block::uniffi_types::Commit, previously in file /tmp/.tmpa0lBw6/celestia-types/src/block.rs:320
  struct celestia_types::uniffi_types::Signature, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:211
  struct celestia_types::uniffi_types::PartsHeader, previously in file /tmp/.tmpa0lBw6/celestia-types/src/uniffi_types.rs:98
```

### ⚠ `celestia-grpc` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum celestia_grpc::grpc::Account, previously in file /tmp/.tmpa0lBw6/celestia-grpc/src/grpc/auth.rs:20

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  celestia_grpc::TxClient::new now takes 3 parameters instead of 4, in /tmp/.tmpXoTqBS/lumina/grpc/src/tx.rs:93
  celestia_grpc::TxClient::with_url now takes 3 parameters instead of 4, in /tmp/.tmpXoTqBS/lumina/grpc/src/tx.rs:419

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait celestia_grpc::IntoAny, previously in file /tmp/.tmpa0lBw6/celestia-grpc/src/tx.rs:481
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-proto`

<blockquote>

## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.7.2...celestia-proto-v0.8.0) - 2025-07-18

### Added

- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
</blockquote>

## `lumina-utils`

<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-utils-v0.2.0...lumina-utils-v0.3.0) - 2025-07-18

### Added

- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
</blockquote>

## `celestia-types`

<blockquote>

## [0.13.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.12.0...celestia-types-v0.13.0) - 2025-07-18

### Added

- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
- *(grpc)* Streamline TxClient creation API, add docs with example ([#673](https://github.com/eigerco/lumina/pull/673))
</blockquote>

## `lumina-node`

<blockquote>

## [0.14.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.13.0...lumina-node-v0.14.0) - 2025-07-18

### Fixed

- *(node)* [**breaking**] Make blockstore only store samples ([#653](https://github.com/eigerco/lumina/pull/653))
</blockquote>

## `lumina-cli`

<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.8.0...lumina-cli-v0.9.0) - 2025-07-18

### Added

- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
- *(grpc)* Streamline TxClient creation API, add docs with example ([#673](https://github.com/eigerco/lumina/pull/673))
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.5.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.4.1...celestia-grpc-v0.5.0) - 2025-07-18

### Added

- *(grpc,types,node)* [**breaking**] Wasm grpc client ([#654](https://github.com/eigerco/lumina/pull/654))
- *(grpc)* Streamline TxClient creation API, add docs with example ([#673](https://github.com/eigerco/lumina/pull/673))
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.2.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.2.0...lumina-node-uniffi-v0.2.1) - 2025-07-18

### Other

- update Cargo.lock dependencies
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.11.3](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.2...celestia-rpc-v0.11.3) - 2025-07-18

### Other

- updated the following local packages: celestia-types
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.9.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.9.0...lumina-node-wasm-v0.9.1) - 2025-07-18

### Other

- updated the following local packages: lumina-utils, celestia-types, lumina-node, celestia-grpc, celestia-rpc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).