### PR TITLE
Move to singular `Blob::new` constructor

### DIFF
--- a/rpc/tests/share.rs
+++ b/rpc/tests/share.rs
@@ -33,7 +33,7 @@ async fn get_shares_by_namespace() {
     let blobs: Vec<_> = (0..4)
         .map(|_| {
             let data = random_bytes(1024);
-            Blob::new(namespace, data.clone(), AppVersion::V2).unwrap()
+            Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap()
         })
         .collect();
 
@@ -74,7 +74,7 @@ async fn get_shares_range() {
     let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
-    let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
+    let blob = Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap();
     let commitment = blob.commitment;
 
     let submitted_height = blob_submit(&client, &[blob]).await.unwrap();
@@ -126,7 +126,7 @@ async fn get_shares_range_ignores_parity() {
 
     let namespace = random_ns();
     let data = random_bytes(100);
-    let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
+    let blob = Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap();
     let submitted_height = blob_submit(&client, &[blob]).await.unwrap();
 
     let header = client.header_get_by_height(submitted_height).await.unwrap();
@@ -159,7 +159,7 @@ async fn get_shares_by_namespace_wrong_ns() {
     let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
-    let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
+    let blob = Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap();
 
     let submitted_height = blob_submit(&client, &[blob]).await.unwrap();
 
@@ -200,7 +200,7 @@ async fn get_shares_by_namespace_wrong_ns_out_of_range() {
     let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
-    let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
+    let blob = Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap();
 
     let submitted_height = blob_submit(&client, &[blob]).await.unwrap();
 
@@ -226,7 +226,7 @@ async fn get_shares_by_namespace_wrong_roots() {
     let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
-    let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
+    let blob = Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap();
 
     blob_submit(&client, &[blob]).await.unwrap();
 
@@ -245,7 +245,7 @@ async fn get_eds() {
     let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = vec![1, 2, 3, 4];
-    let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
+    let blob = Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap();
 
     let submitted_height = blob_submit(&client, &[blob]).await.unwrap();
 
@@ -266,7 +266,7 @@ async fn get_shares_by_row() {
     let client = new_test_client(AuthLevel::Skip).await.unwrap();
     let namespace = random_ns();
     let data = random_bytes(1024);
-    let blob = Blob::new(namespace, data.clone(), AppVersion::V2).unwrap();
+    let blob = Blob::new(namespace, data.clone(), None, AppVersion::V2).unwrap();
     let commitment = blob.commitment;
 
     let submitted_height = blob_submit(&client, &[blob]).await.unwrap();

--- a/types/src/blob.rs
+++ b/types/src/blob.rs
@@ -95,7 +95,7 @@ impl Blob {
     ///     }"#},
     /// );
     /// ```
-    pub fn new(namespace: Namespace, data: Vec<u8>, app_version: AppVersion) -> Result<Blob> {
+    pub fn new(namespace: Namespace, data: Vec<u8>, app_version: AppVersion, signer: Option<AppVersion>) -> Result<Blob> {
         let share_version = appconsts::SHARE_VERSION_ZERO;
         let commitment =
             Commitment::from_blob(namespace, &data[..], share_version, None, app_version)?;
@@ -106,7 +106,7 @@ impl Blob {
             share_version,
             commitment,
             index: None,
-            signer: None,
+            signer,
         })
     }
 

--- a/types/src/blob.rs
+++ b/types/src/blob.rs
@@ -68,11 +68,16 @@ pub struct BlobParams {
 }
 
 impl Blob {
-    /// Create a new blob with the given data within the [`Namespace`].
+    /// Create a new blob with the given data within the [`Namespace`], with optional signer.
+    ///
+    /// # Notes
+    ///
+    /// If present onchain, `signer` was verified by consensus node on blob submission.
     ///
     /// # Errors
     ///
     /// This function propagates any error from the [`Commitment`] creation.
+    /// To use `signer = Some(address)`, [`AppVersion`] must be at least [`AppVersion::V3`].
     ///
     /// # Example
     ///
@@ -80,11 +85,11 @@ impl Blob {
     /// use celestia_types::{AppVersion, Blob, nmt::Namespace};
     ///
     /// let my_namespace = Namespace::new_v0(&[1, 2, 3, 4, 5]).expect("Invalid namespace");
-    /// let blob = Blob::new(my_namespace, b"some data to store on blockchain".to_vec(), AppVersion::V2)
+    /// let blob_unsigned = Blob::new(my_namespace, b"some data to store on blockchain".to_vec(), AppVersion::V2, None)
     ///     .expect("Failed to create a blob");
     ///
     /// assert_eq!(
-    ///     &serde_json::to_string_pretty(&blob).unwrap(),
+    ///     &serde_json::to_string_pretty(&blob_unsigned).unwrap(),
     ///     indoc::indoc! {r#"{
     ///       "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQIDBAU=",
     ///       "data": "c29tZSBkYXRhIHRvIHN0b3JlIG9uIGJsb2NrY2hhaW4=",
@@ -94,47 +99,41 @@ impl Blob {
     ///       "signer": null
     ///     }"#},
     /// );
+    ///
+    /// let signer = AccAddress::from_str("Yjc3XldhbdYke5i8aSlggYxCCLE=")?;
+    /// let blob_signed = Blob::new(my_namespace, b"some data to store on blockchain".to_vec(), AppVersion::V5, Some(signer))
+    ///     .expect("Failed to create a signed blob");
+    ///
+    /// assert_eq!(
+    ///     &serde_json::to_string_pretty(&blob_signed).unwrap(),
+    ///     indoc::indoc! {r#"{
+    ///       "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQIDBAU=",
+    ///       "data": "c29tZSBkYXRhIHRvIHN0b3JlIG9uIGJsb2NrY2hhaW4=",
+    ///       "share_version": 0,
+    ///       "commitment": "m0A4feU6Fqd5Zy9td3M7lntG8A3PKqe6YdugmAsWz28=",
+    ///       "index": -1,
+    ///       "signer": "Yjc3XldhbdYke5i8aSlggYxCCLE="
+    ///     }"#},
+    /// );
     /// ```
-    pub fn new(namespace: Namespace, data: Vec<u8>, app_version: AppVersion, signer: Option<AppVersion>) -> Result<Blob> {
-        let share_version = appconsts::SHARE_VERSION_ZERO;
-        let commitment =
-            Commitment::from_blob(namespace, &data[..], share_version, None, app_version)?;
-
-        Ok(Blob {
-            namespace,
-            data,
-            share_version,
-            commitment,
-            index: None,
-            signer,
-        })
-    }
-
-    /// Create a new blob with the given data within the [`Namespace`] and with given signer.
-    ///
-    /// # Notes
-    ///
-    /// `signer` is verified by consensus node when blob gets submitted.
-    ///
-    /// # Errors
-    ///
-    /// This function propagates any error from the [`Commitment`] creation. Also [`AppVersion`]
-    /// must be at least [`AppVersion::V3`].
-    pub fn new_with_signer(
+    pub fn new(
         namespace: Namespace,
         data: Vec<u8>,
-        signer: AccAddress,
+        signer: Option<AccAddress>,
         app_version: AppVersion,
     ) -> Result<Blob> {
-        let signer = Some(signer);
-        let share_version = appconsts::SHARE_VERSION_ONE;
-        let commitment = Commitment::from_blob(
-            namespace,
-            &data[..],
-            share_version,
-            signer.as_ref(),
-            app_version,
-        )?;
+        let mut share_version = appconsts::SHARE_VERSION_ZERO;
+
+        if signer.is_some() {
+            let app_version = app_version.as_u64();
+            if app_version < 3 {
+                return Err(Error::UnsupportedAppVersion(app_version));
+            }
+            share_version = appconsts::SHARE_VERSION_ONE;
+        }
+
+        let commitment =
+            Commitment::from_blob(namespace, &data[..], share_version, None, app_version)?;
 
         Ok(Blob {
             namespace,
@@ -357,11 +356,11 @@ impl Blob {
         data.truncate(blob_len as usize);
 
         if share_version == appconsts::SHARE_VERSION_ZERO {
-            Self::new(namespace, data, app_version)
+            Self::new(namespace, data, None, app_version)
         } else if share_version == appconsts::SHARE_VERSION_ONE {
             // shouldn't happen as we have user namespace, seq start, and share v1
             let signer = signer.ok_or(Error::MissingSigner)?;
-            Self::new_with_signer(namespace, data, signer, app_version)
+            Self::new(namespace, data, Some(signer), app_version)
         } else {
             Err(Error::UnsupportedShareVersion(share_version))
         }
@@ -466,7 +465,7 @@ impl Blob {
         app_version: AppVersion,
     ) -> UniffiResult<Self> {
         let namespace = Arc::unwrap_or_clone(namespace);
-        Ok(Blob::new(namespace, data, app_version)?)
+        Ok(Blob::new(namespace, data, None, app_version)?)
     }
 
     /// Create a new blob with the given data within the [`Namespace`] and with given signer.
@@ -483,7 +482,7 @@ impl Blob {
         app_version: AppVersion,
     ) -> UniffiResult<Blob> {
         let namespace = Arc::unwrap_or_clone(namespace);
-        Ok(Blob::new_with_signer(namespace, data, signer, app_version)?)
+        Ok(Blob::new(namespace, data, Some(signer), app_version)?)
     }
 
     /// A [`Namespace`] the [`Blob`] belongs to.
@@ -809,7 +808,7 @@ mod tests {
             let len = rand::random::<usize>() % (1024 * 1024) + 1;
             let data = random_bytes(len);
             let ns = Namespace::const_v0(rand::random());
-            let blob = Blob::new(ns, data, AppVersion::V2).unwrap();
+            let blob = Blob::new(ns, data, None, AppVersion::V2).unwrap();
 
             let shares = blob.to_shares().unwrap();
             assert_eq!(blob, Blob::reconstruct(&shares, AppVersion::V2).unwrap());
@@ -824,7 +823,7 @@ mod tests {
             let ns = Namespace::const_v0(rand::random());
             let signer = rand::random::<[u8; 20]>().into();
 
-            let blob = Blob::new_with_signer(ns, data, signer, AppVersion::V3).unwrap();
+            let blob = Blob::new(ns, data, Some(signer), AppVersion::V3).unwrap();
             let shares = blob.to_shares().unwrap();
 
             Blob::reconstruct(&shares, AppVersion::V2).unwrap_err();
@@ -845,7 +844,7 @@ mod tests {
         let len = rand::random::<usize>() % (1024 * 1024) + 1;
         let data = random_bytes(len);
         let ns = Namespace::const_v0(rand::random());
-        let mut shares = Blob::new(ns, data, AppVersion::V2)
+        let mut shares = Blob::new(ns, data, None, AppVersion::V2)
             .unwrap()
             .to_shares()
             .unwrap();
@@ -871,7 +870,7 @@ mod tests {
         }) {
             let len = (rand::random::<usize>() % 1023 + 1) * 2;
             let data = random_bytes(len);
-            let shares = Blob::new(ns.unwrap(), data, AppVersion::V2)
+            let shares = Blob::new(ns.unwrap(), data, None, AppVersion::V2)
                 .unwrap()
                 .to_shares()
                 .unwrap();
@@ -888,7 +887,7 @@ mod tests {
         let len = rand::random::<usize>() % 1024 * 1024 + 2048;
         let data = random_bytes(len);
         let ns = Namespace::const_v0(rand::random());
-        let shares = Blob::new(ns, data, AppVersion::V2)
+        let shares = Blob::new(ns, data, None, AppVersion::V2)
             .unwrap()
             .to_shares()
             .unwrap();
@@ -905,7 +904,7 @@ mod tests {
         let len = rand::random::<usize>() % (1024 * 1024) + 512;
         let data = random_bytes(len);
         let ns = Namespace::const_v0(rand::random());
-        let mut shares = Blob::new(ns, data, AppVersion::V2)
+        let mut shares = Blob::new(ns, data, None, AppVersion::V2)
             .unwrap()
             .to_shares()
             .unwrap();
@@ -925,7 +924,7 @@ mod tests {
         let data = random_bytes(len);
         let ns = Namespace::const_v0(rand::random());
         let ns2 = Namespace::const_v0(rand::random());
-        let mut shares = Blob::new(ns, data, AppVersion::V2)
+        let mut shares = Blob::new(ns, data, None, AppVersion::V2)
             .unwrap()
             .to_shares()
             .unwrap();
@@ -944,7 +943,7 @@ mod tests {
         let len = rand::random::<usize>() % (1024 * 1024) + 512;
         let data = random_bytes(len);
         let ns = Namespace::const_v0(rand::random());
-        let mut shares = Blob::new(ns, data, AppVersion::V2)
+        let mut shares = Blob::new(ns, data, None, AppVersion::V2)
             .unwrap()
             .to_shares()
             .unwrap();
@@ -965,7 +964,7 @@ mod tests {
                 let len = rand::random::<usize>() % (1024 * 1024) + 512;
                 let data = random_bytes(len);
                 let ns = Namespace::const_v0(rand::random());
-                Blob::new(ns, data, AppVersion::V2).unwrap()
+                Blob::new(ns, data, None, AppVersion::V2).unwrap()
             })
             .collect();
 

--- a/types/src/test_utils.rs
+++ b/types/src/test_utils.rs
@@ -429,7 +429,7 @@ pub fn generate_eds(square_width: usize, app_version: AppVersion) -> ExtendedDat
     // first blob is bigger so that it spans over 2 rows
     let blob_shares = (rand::random::<usize>() % (ods_width - 1)) + ods_width + 1;
     let data = random_bytes(blob_len(blob_shares));
-    let blob = Blob::new(namespaces[0], data, app_version).unwrap();
+    let blob = Blob::new(namespaces[0], data, None, app_version).unwrap();
     shares.extend(blob.to_shares().unwrap().iter().map(Share::to_vec));
 
     // namespace padding
@@ -442,7 +442,7 @@ pub fn generate_eds(square_width: usize, app_version: AppVersion) -> ExtendedDat
     for ns in &namespaces {
         let blob_shares = (rand::random::<usize>() % (ods_width - 1)) + 1;
         let data = random_bytes(blob_len(blob_shares));
-        let blob = Blob::new(*ns, data, app_version).unwrap();
+        let blob = Blob::new(*ns, data, None, app_version).unwrap();
         shares.extend(blob.to_shares().unwrap().iter().map(Share::to_vec));
 
         let padding_ns = if ns != namespaces.last().unwrap() {


### PR DESCRIPTION
### Motivation

In working constructing a `Blob` it's inconvenient to have to make logic to handle if a blob is signed or not, for us it lead to hours of headache trying to troubleshoot why some blobs would work and others would not [example here](https://github.com/celestiaorg/eq-service/pull/110).

To ensure it's not a footgun and make less boilerplate for users of `Blob`, this PR makes a singular interface to construct with `Blob::new`.

## What's included

- Removes `Blob::new_with_signer`
- Add optional `signer` to `Blob::new`

---

Note for maintainers: I am sure there was some reason to split it into two constructors... maybe because this is a type braking change and requires action from all users? Happy to have this closed if it's not aligned with goals, or continue to polish as needed.