### PR TITLE
fix(proto,types): fix binary serialization of maybe_quoted

### DIFF
--- a/proto/src/serializers/maybe_quoted.rs
+++ b/proto/src/serializers/maybe_quoted.rs
@@ -1,40 +1,17 @@
 //! A [`from_str`] serializer that additionally allows deserializing `T` using its own [`Deserialize`] impl.
 //!
+//! Binary serializers will only use the [`from_str`].
+//!
 //! [`from_str`]: crate::serializers::from_str
 
 use std::fmt::Display;
 use std::str::FromStr;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer};
 
 use crate::serializers::cow_str::CowStr;
 
-#[derive(Serialize, Deserialize)]
-#[serde(untagged)]
-enum MaybeQuoted<'a, T> {
-    Direct(T),
-    #[serde(borrow)]
-    Quoted(CowStr<'a>),
-}
-
-#[derive(Serialize, Deserialize)]
-enum MaybeQuotedTagged<T> {
-    Direct(T),
-    Quoted(String),
-}
-
-/// Serialize from T into string
-pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: Serialize + Display,
-{
-    if serializer.is_human_readable() {
-        value.to_string().serialize(serializer)
-    } else {
-        MaybeQuotedTagged::<T>::Quoted(value.to_string()).serialize(serializer)
-    }
-}
+pub use crate::serializers::from_str::serialize;
 
 /// Deserialize T directly or from string
 pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
@@ -43,15 +20,20 @@ where
     T: Deserialize<'de> + FromStr,
     <T as FromStr>::Err: Display,
 {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum MaybeQuoted<'a, T> {
+        Direct(T),
+        #[serde(borrow)]
+        Quoted(CowStr<'a>),
+    }
+
     if deserializer.is_human_readable() {
         match MaybeQuoted::deserialize(deserializer)? {
             MaybeQuoted::Direct(t) => Ok(t),
             MaybeQuoted::Quoted(s) => s.parse().map_err(serde::de::Error::custom),
         }
     } else {
-        match MaybeQuotedTagged::deserialize(deserializer)? {
-            MaybeQuotedTagged::Direct(t) => Ok(t),
-            MaybeQuotedTagged::Quoted(s) => s.parse().map_err(serde::de::Error::custom),
-        }
+        crate::serializers::from_str::deserialize(deserializer)
     }
 }

--- a/proto/src/serializers/maybe_quoted.rs
+++ b/proto/src/serializers/maybe_quoted.rs
@@ -5,11 +5,36 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::serializers::cow_str::CowStr;
 
-pub use crate::serializers::from_str::serialize;
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum MaybeQuoted<'a, T> {
+    Direct(T),
+    #[serde(borrow)]
+    Quoted(CowStr<'a>),
+}
+
+#[derive(Serialize, Deserialize)]
+enum MaybeQuotedTagged<T> {
+    Direct(T),
+    Quoted(String),
+}
+
+/// Serialize from T into string
+pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize + Display,
+{
+    if serializer.is_human_readable() {
+        value.to_string().serialize(serializer)
+    } else {
+        MaybeQuotedTagged::<T>::Quoted(value.to_string()).serialize(serializer)
+    }
+}
 
 /// Deserialize T directly or from string
 pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
@@ -18,16 +43,15 @@ where
     T: Deserialize<'de> + FromStr,
     <T as FromStr>::Err: Display,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum MaybeQuoted<'a, T> {
-        Direct(T),
-        #[serde(borrow)]
-        Quoted(CowStr<'a>),
-    }
-
-    match MaybeQuoted::deserialize(deserializer)? {
-        MaybeQuoted::Direct(t) => Ok(t),
-        MaybeQuoted::Quoted(s) => s.parse().map_err(serde::de::Error::custom),
+    if deserializer.is_human_readable() {
+        match MaybeQuoted::deserialize(deserializer)? {
+            MaybeQuoted::Direct(t) => Ok(t),
+            MaybeQuoted::Quoted(s) => s.parse().map_err(serde::de::Error::custom),
+        }
+    } else {
+        match MaybeQuotedTagged::deserialize(deserializer)? {
+            MaybeQuotedTagged::Direct(t) => Ok(t),
+            MaybeQuotedTagged::Quoted(s) => s.parse().map_err(serde::de::Error::custom),
+        }
     }
 }

--- a/types/src/data_availability_header.rs
+++ b/types/src/data_availability_header.rs
@@ -656,6 +656,15 @@ mod tests {
         proof.verify(dah_root).unwrap_err();
     }
 
+    #[test]
+    fn test_serialize_row_proof_with_bincode() {
+        let dah = random_dah(16);
+        let proof = dah.row_proof(0..=1).unwrap();
+        let serialized = bincode::serialize(&proof).unwrap();
+        let deserialized: RowProof = bincode::deserialize(&serialized).unwrap();
+        assert_eq!(proof, deserialized);
+    }
+
     fn random_dah(square_width: u16) -> DataAvailabilityHeader {
         let namespaces: Vec<_> = (0..square_width)
             .map(|n| Namespace::new_v0(&[n as u8]).unwrap())
@@ -675,4 +684,5 @@ mod tests {
 
         DataAvailabilityHeader::new(row_roots, col_roots, AppVersion::V2).unwrap()
     }
+
 }

--- a/types/src/data_availability_header.rs
+++ b/types/src/data_availability_header.rs
@@ -684,5 +684,4 @@ mod tests {
 
         DataAvailabilityHeader::new(row_roots, col_roots, AppVersion::V2).unwrap()
     }
-
 }

--- a/types/src/nmt.rs
+++ b/types/src/nmt.rs
@@ -928,4 +928,12 @@ mod tests {
         assert_eq!(hash.max_namespace(), *Namespace::new_v0(&[9]).unwrap());
         assert_eq!(hash.hash(), [0xFF; 32]);
     }
+
+    #[test]
+    fn test_serialize_namespace_with_bincode() {
+        let ns = Namespace::new_v0(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).unwrap();
+        let serialized = bincode::serialize(&ns).unwrap();
+        let deserialized: Namespace = bincode::deserialize(&serialized).unwrap();
+        assert_eq!(ns, deserialized);
+    }
 }

--- a/types/src/nmt/namespace_proof.rs
+++ b/types/src/nmt/namespace_proof.rs
@@ -226,3 +226,4 @@ mod tests {
         assert_eq!(proof, deserialized);
     }
 }
+

--- a/types/src/nmt/namespace_proof.rs
+++ b/types/src/nmt/namespace_proof.rs
@@ -226,4 +226,3 @@ mod tests {
         assert_eq!(proof, deserialized);
     }
 }
-

--- a/types/src/nmt/namespace_proof.rs
+++ b/types/src/nmt/namespace_proof.rs
@@ -206,3 +206,23 @@ impl From<NamespaceProof> for RawNmtProof {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_namespace_proof_with_bincode() {
+        let nmt_proof = NmtNamespaceProof::PresenceProof {
+            proof: NmtProof {
+                siblings: vec![],
+                range: 0..1,
+            },
+            ignore_max_ns: false,
+        };
+        let proof = NamespaceProof::from(nmt_proof);
+        let serialized = bincode::serialize(&proof).unwrap();
+        let deserialized: NamespaceProof = bincode::deserialize(&serialized).unwrap();
+        assert_eq!(proof, deserialized);
+    }
+}


### PR DESCRIPTION
With v0.15.0, we encountered a broken serializers / deserializers for `RowProof`.

This PR add tests to ensure it doesn't happen again.

Still in draft because I haven't fixed it yet