### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-stream",
  "celestia-grpc",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytes",
  "prost",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ members = ["cli", "client", "grpc", "node", "node-wasm", "node-uniffi", "proto",
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.15.0", path = "node" }
-lumina-node-wasm = { version = "0.10.1", path = "node-wasm" }
+lumina-node = { version = "0.15.1", path = "node" }
+lumina-node-wasm = { version = "0.10.2", path = "node-wasm" }
 lumina-utils = { version = "0.3.0", path = "utils" }
-celestia-client = { version = "0.1.0", path = "client" }
-celestia-proto = { version = "0.9.0", path = "proto" }
-celestia-grpc = { version = "0.6.0", path = "grpc" }
-celestia-rpc = { version = "0.12.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.14.0", path = "types", default-features = false }
+celestia-client = { version = "0.1.1", path = "client" }
+celestia-proto = { version = "0.9.1", path = "proto" }
+celestia-grpc = { version = "0.6.1", path = "grpc" }
+celestia-rpc = { version = "0.12.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.14.1", path = "types", default-features = false }
 tendermint = { version = "0.40.4", default-features = false }
 tendermint-proto = "0.40.4"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.9.1...lumina-cli-v0.9.2) - 2025-08-19
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-rpc, lumina-node
+
 ## [0.9.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.9.0...lumina-cli-v0.9.1) - 2025-08-13
 
 ### Fixed

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.0...celestia-client-v0.1.1) - 2025-08-19
+
+### Other
+
+- updated the following local packages: celestia-proto, celestia-types, celestia-types, celestia-rpc, celestia-rpc, celestia-grpc, celestia-grpc
+
 ## [0.1.0](https://github.com/eigerco/lumina/releases/tag/celestia-client-v0.1.0) - 2025-08-13
 
 ### Added

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia client combining RPC and gRPC functionality."

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.0...celestia-grpc-v0.6.1) - 2025-08-19
+
+### Other
+
+- updated the following local packages: celestia-proto, celestia-types, celestia-rpc, celestia-rpc
+
 ## [0.6.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.5.0...celestia-grpc-v0.6.0) - 2025-08-13
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.1...lumina-node-uniffi-v0.3.2) - 2025-08-19
+
+### Other
+
+- updated the following local packages: celestia-proto, celestia-types, lumina-node, celestia-grpc
+
 ## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.0...lumina-node-uniffi-v0.3.1) - 2025-08-13
 
 ### Other

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.1...lumina-node-wasm-v0.10.2) - 2025-08-19
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-rpc, lumina-node, celestia-grpc
+
 ## [0.10.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.0...lumina-node-wasm-v0.10.1) - 2025-08-13
 
 ### Fixed

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.15.0...lumina-node-v0.15.1) - 2025-08-19
+
+### Other
+
+- updated the following local packages: celestia-proto, celestia-types, celestia-types, celestia-types, celestia-rpc
+
 ## [0.15.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.14.0...lumina-node-v0.15.0) - 2025-08-13
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.9.0...celestia-proto-v0.9.1) - 2025-08-19
+
+### Fixed
+
+- *(proto,types)* fix binary serialization of maybe_quoted ([#724](https://github.com/eigerco/lumina/pull/724))
+
 ## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.8.0...celestia-proto-v0.9.0) - 2025-08-13
 
 ### Added

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.12.0...celestia-rpc-v0.12.1) - 2025-08-19
+
+### Other
+
+- updated the following local packages: celestia-proto, celestia-types
+
 ## [0.12.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.11.3...celestia-rpc-v0.12.0) - 2025-08-13
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.14.0...celestia-types-v0.14.1) - 2025-08-19
+
+### Fixed
+
+- *(proto,types)* fix binary serialization of maybe_quoted ([#724](https://github.com/eigerco/lumina/pull/724))
+
 ## [0.14.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.13.0...celestia-types-v0.14.0) - 2025-08-13
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION



## 🤖 New release

* `celestia-proto`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `celestia-types`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `celestia-rpc`: 0.12.0 -> 0.12.1
* `lumina-node`: 0.15.0 -> 0.15.1
* `lumina-cli`: 0.9.1 -> 0.9.2
* `celestia-grpc`: 0.6.0 -> 0.6.1
* `celestia-client`: 0.1.0 -> 0.1.1
* `lumina-node-wasm`: 0.10.1 -> 0.10.2
* `lumina-node-uniffi`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-proto`

<blockquote>

## [0.9.1](https://github.com/eigerco/lumina/compare/celestia-proto-v0.9.0...celestia-proto-v0.9.1) - 2025-08-19

### Fixed

- *(proto,types)* fix binary serialization of maybe_quoted ([#724](https://github.com/eigerco/lumina/pull/724))
</blockquote>

## `celestia-types`

<blockquote>

## [0.14.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.14.0...celestia-types-v0.14.1) - 2025-08-19

### Fixed

- *(proto,types)* fix binary serialization of maybe_quoted ([#724](https://github.com/eigerco/lumina/pull/724))
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.12.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.12.0...celestia-rpc-v0.12.1) - 2025-08-19

### Other

- updated the following local packages: celestia-proto, celestia-types
</blockquote>

## `lumina-node`

<blockquote>

## [0.15.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.15.0...lumina-node-v0.15.1) - 2025-08-19

### Other

- updated the following local packages: celestia-proto, celestia-types, celestia-types, celestia-types, celestia-rpc
</blockquote>

## `lumina-cli`

<blockquote>

## [0.9.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.9.1...lumina-cli-v0.9.2) - 2025-08-19

### Other

- updated the following local packages: celestia-types, celestia-rpc, lumina-node
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.6.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.0...celestia-grpc-v0.6.1) - 2025-08-19

### Other

- updated the following local packages: celestia-proto, celestia-types, celestia-rpc, celestia-rpc
</blockquote>

## `celestia-client`

<blockquote>

## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.0...celestia-client-v0.1.1) - 2025-08-19

### Other

- updated the following local packages: celestia-proto, celestia-types, celestia-types, celestia-rpc, celestia-rpc, celestia-grpc, celestia-grpc
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.10.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.1...lumina-node-wasm-v0.10.2) - 2025-08-19

### Other

- updated the following local packages: celestia-types, celestia-rpc, lumina-node, celestia-grpc
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.3.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.1...lumina-node-uniffi-v0.3.2) - 2025-08-19

### Other

- updated the following local packages: celestia-proto, celestia-types, lumina-node, celestia-grpc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).