### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-stream",
  "celestia-grpc",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ members = ["cli", "client", "grpc", "node", "node-wasm", "node-uniffi", "proto",
 [workspace.dependencies]
 blockstore = "0.7.1"
 lumina-node = { version = "0.15.1", path = "node" }
-lumina-node-wasm = { version = "0.10.2", path = "node-wasm" }
+lumina-node-wasm = { version = "0.10.3", path = "node-wasm" }
 lumina-utils = { version = "0.3.0", path = "utils" }
-celestia-client = { version = "0.1.1", path = "client" }
+celestia-client = { version = "0.1.2", path = "client" }
 celestia-proto = { version = "0.9.1", path = "proto" }
-celestia-grpc = { version = "0.6.1", path = "grpc" }
+celestia-grpc = { version = "0.7.0", path = "grpc" }
 celestia-rpc = { version = "0.12.1", path = "rpc", default-features = false }
 celestia-types = { version = "0.14.1", path = "types", default-features = false }
 tendermint = { version = "0.40.4", default-features = false }

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.1...celestia-client-v0.1.2) - 2025-09-03
+
+### Added
+
+- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.0...celestia-client-v0.1.1) - 2025-08-19
 
 ### Other

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia client combining RPC and gRPC functionality."

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.1...celestia-grpc-v0.7.0) - 2025-09-03
+
+### Added
+
+- *(grpc)* [**breaking**] expose whole node config instead just gas price ([#732](https://github.com/eigerco/lumina/pull/732))
+- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
+
 ## [0.6.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.0...celestia-grpc-v0.6.1) - 2025-08-19
 
 ### Other

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"
@@ -22,7 +22,7 @@ categories = [
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-celestia-grpc-macros = { version = "0.3.0", path = "grpc-macros" }
+celestia-grpc-macros = { version = "0.3.1", path = "grpc-macros" }
 celestia-proto = { workspace = true, features = ["tonic"] }
 celestia-types.workspace = true
 prost.workspace = true

--- a/grpc/grpc-macros/CHANGELOG.md
+++ b/grpc/grpc-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.3.0...celestia-grpc-macros-v0.3.1) - 2025-09-03
+
+### Added
+
+- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.2.1...celestia-grpc-macros-v0.3.0) - 2025-07-29
 
 ### Added

--- a/grpc/grpc-macros/Cargo.toml
+++ b/grpc/grpc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Helper crate for grpc_method macro for creating gRPC client, used by celestia-grpc"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.2...lumina-node-uniffi-v0.3.3) - 2025-09-03
+
+### Other
+
+- updated the following local packages: celestia-grpc
+
 ## [0.3.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.1...lumina-node-uniffi-v0.3.2) - 2025-08-19
 
 ### Other

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.2...lumina-node-wasm-v0.10.3) - 2025-09-03
+
+### Other
+
+- updated the following local packages: celestia-grpc
+
 ## [0.10.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.1...lumina-node-wasm-v0.10.2) - 2025-08-19
 
 ### Other

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"


### PR DESCRIPTION



## 🤖 New release

* `celestia-grpc-macros`: 0.3.0 -> 0.3.1
* `celestia-grpc`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `celestia-client`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `lumina-node-wasm`: 0.10.2 -> 0.10.3
* `lumina-node-uniffi`: 0.3.2 -> 0.3.3

### ⚠ `celestia-grpc` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  TxClient::get_min_gas_price, previously in file /tmp/.tmp399uCl/celestia-grpc/src/tx.rs:212
  GrpcClient::get_min_gas_price, previously in file /tmp/.tmp399uCl/celestia-grpc/src/grpc.rs:180
  GrpcClient::get_min_gas_price, previously in file /tmp/.tmp399uCl/celestia-grpc/src/grpc.rs:180

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait celestia_grpc::DocSigner gained Sync in file /tmp/.tmppzOs5e/lumina/grpc/src/tx.rs:462
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-grpc-macros`

<blockquote>

## [0.3.1](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.3.0...celestia-grpc-macros-v0.3.1) - 2025-09-03

### Added

- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.1...celestia-grpc-v0.7.0) - 2025-09-03

### Added

- *(grpc)* [**breaking**] expose whole node config instead just gas price ([#732](https://github.com/eigerco/lumina/pull/732))
- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
</blockquote>

## `celestia-client`

<blockquote>

## [0.1.2](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.1...celestia-client-v0.1.2) - 2025-09-03

### Added

- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.10.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.2...lumina-node-wasm-v0.10.3) - 2025-09-03

### Other

- updated the following local packages: celestia-grpc
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.3.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.2...lumina-node-uniffi-v0.3.3) - 2025-09-03

### Other

- updated the following local packages: celestia-grpc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).