### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-stream",
  "celestia-grpc",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ members = ["cli", "client", "grpc", "node", "node-wasm", "node-uniffi", "proto",
 
 [workspace.dependencies]
 blockstore = "0.7.1"
-lumina-node = { version = "0.15.1", path = "node" }
-lumina-node-wasm = { version = "0.10.2", path = "node-wasm" }
+lumina-node = { version = "0.15.2", path = "node" }
+lumina-node-wasm = { version = "0.10.3", path = "node-wasm" }
 lumina-utils = { version = "0.3.0", path = "utils" }
-celestia-client = { version = "0.1.1", path = "client" }
+celestia-client = { version = "0.1.2", path = "client" }
 celestia-proto = { version = "0.9.1", path = "proto" }
-celestia-grpc = { version = "0.6.1", path = "grpc" }
-celestia-rpc = { version = "0.12.1", path = "rpc", default-features = false }
-celestia-types = { version = "0.14.1", path = "types", default-features = false }
+celestia-grpc = { version = "0.7.0", path = "grpc" }
+celestia-rpc = { version = "0.13.0", path = "rpc", default-features = false }
+celestia-types = { version = "0.15.0", path = "types", default-features = false }
 tendermint = { version = "0.40.4", default-features = false }
 tendermint-proto = "0.40.4"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/eigerco/lumina/compare/lumina-cli-v0.9.2...lumina-cli-v0.9.3) - 2025-09-08
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-rpc, lumina-node
+
 ## [0.9.2](https://github.com/eigerco/lumina/compare/lumina-cli-v0.9.1...lumina-cli-v0.9.2) - 2025-08-19
 
 ### Other

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.1...celestia-client-v0.1.2) - 2025-09-08
+
+### Added
+
+- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
+
+### Other
+
+- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
+
 ## [0.1.1](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.0...celestia-client-v0.1.1) - 2025-08-19
 
 ### Other

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia client combining RPC and gRPC functionality."

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.1...celestia-grpc-v0.7.0) - 2025-09-08
+
+### Added
+
+- *(types)* [**breaking**] Add support for app v6 ([#733](https://github.com/eigerco/lumina/pull/733))
+- *(grpc)* remove retries on insufficient fee and gas multiplier ([#731](https://github.com/eigerco/lumina/pull/731))
+- *(grpc)* [**breaking**] expose whole node config instead just gas price ([#732](https://github.com/eigerco/lumina/pull/732))
+- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
+
+### Other
+
+- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
+
 ## [0.6.1](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.0...celestia-grpc-v0.6.1) - 2025-08-19
 
 ### Other

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"
@@ -22,7 +22,7 @@ categories = [
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-celestia-grpc-macros = { version = "0.3.0", path = "grpc-macros" }
+celestia-grpc-macros = { version = "0.3.1", path = "grpc-macros" }
 celestia-proto = { workspace = true, features = ["tonic"] }
 celestia-types.workspace = true
 prost.workspace = true

--- a/grpc/grpc-macros/CHANGELOG.md
+++ b/grpc/grpc-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.3.0...celestia-grpc-macros-v0.3.1) - 2025-09-08
+
+### Added
+
+- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.2.1...celestia-grpc-macros-v0.3.0) - 2025-07-29
 
 ### Added

--- a/grpc/grpc-macros/Cargo.toml
+++ b/grpc/grpc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Helper crate for grpc_method macro for creating gRPC client, used by celestia-grpc"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.2...lumina-node-uniffi-v0.3.3) - 2025-09-08
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-grpc, lumina-node
+
 ## [0.3.2](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.1...lumina-node-uniffi-v0.3.2) - 2025-08-19
 
 ### Other

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.2...lumina-node-wasm-v0.10.3) - 2025-09-08
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-rpc, celestia-grpc, lumina-node
+
 ## [0.10.2](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.1...lumina-node-wasm-v0.10.2) - 2025-08-19
 
 ### Other

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -420,6 +420,18 @@ App v5
 
 lumina\_node\_wasm.d.ts:634
 
+***
+
+#### V6
+
+> `readonly` `static` **V6**: [`AppVersion`](#classesappversionmd)
+
+App v6
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:638
+
 ### Methods
 
 #### free()
@@ -472,7 +484,7 @@ strings instead of raw bytes.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:643
+lumina\_node\_wasm.d.ts:647
 
 ***
 
@@ -482,7 +494,7 @@ lumina\_node\_wasm.d.ts:643
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:644
+lumina\_node\_wasm.d.ts:648
 
 ### Methods
 
@@ -496,7 +508,7 @@ lumina\_node\_wasm.d.ts:644
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:642
+lumina\_node\_wasm.d.ts:646
 
 
 <a name="classesauthinfomd"></a>
@@ -525,7 +537,7 @@ verification of the signers. This can be estimated via simulation.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:667
+lumina\_node\_wasm.d.ts:671
 
 ***
 
@@ -541,7 +553,7 @@ which pays the [`Fee`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:659
+lumina\_node\_wasm.d.ts:663
 
 ### Methods
 
@@ -555,7 +567,7 @@ lumina\_node\_wasm.d.ts:659
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:651
+lumina\_node\_wasm.d.ts:655
 
 
 <a name="classesblobmd"></a>
@@ -598,7 +610,7 @@ Create a new blob with the given data within the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:685
+lumina\_node\_wasm.d.ts:689
 
 ### Properties
 
@@ -610,7 +622,7 @@ A [`Commitment`] computed from the [`Blob`]s data.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:705
+lumina\_node\_wasm.d.ts:709
 
 ***
 
@@ -622,7 +634,7 @@ Data stored within the [`Blob`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:697
+lumina\_node\_wasm.d.ts:701
 
 ***
 
@@ -634,7 +646,7 @@ A [`Namespace`] the [`Blob`] belongs to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:693
+lumina\_node\_wasm.d.ts:697
 
 ***
 
@@ -646,7 +658,7 @@ Version indicating the format in which [`Share`]s should be created from this [`
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:701
+lumina\_node\_wasm.d.ts:705
 
 ### Accessors
 
@@ -680,7 +692,7 @@ Index of the blob's first share in the EDS. Only set for blobs retrieved from ch
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:709
+lumina\_node\_wasm.d.ts:713
 
 ***
 
@@ -718,7 +730,7 @@ Must be present in `share_version 1` and absent otherwise.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:719
+lumina\_node\_wasm.d.ts:723
 
 ### Methods
 
@@ -734,7 +746,7 @@ Clone a blob creating a new deep copy of it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:689
+lumina\_node\_wasm.d.ts:693
 
 ***
 
@@ -748,7 +760,7 @@ lumina\_node\_wasm.d.ts:689
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:681
+lumina\_node\_wasm.d.ts:685
 
 ***
 
@@ -764,7 +776,7 @@ lumina\_node\_wasm.d.ts:681
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:676
+lumina\_node\_wasm.d.ts:680
 
 ***
 
@@ -780,7 +792,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:680
+lumina\_node\_wasm.d.ts:684
 
 
 <a name="classesblobparamsmd"></a>
@@ -805,7 +817,7 @@ Gas cost per blob byte
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:744
+lumina\_node\_wasm.d.ts:748
 
 ***
 
@@ -817,7 +829,7 @@ Max square size
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:748
+lumina\_node\_wasm.d.ts:752
 
 ### Methods
 
@@ -831,7 +843,7 @@ lumina\_node\_wasm.d.ts:748
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:740
+lumina\_node\_wasm.d.ts:744
 
 ***
 
@@ -847,7 +859,7 @@ lumina\_node\_wasm.d.ts:740
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:735
+lumina\_node\_wasm.d.ts:739
 
 ***
 
@@ -863,7 +875,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:739
+lumina\_node\_wasm.d.ts:743
 
 
 <a name="classesblockmd"></a>
@@ -893,7 +905,7 @@ Transaction data
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:765
+lumina\_node\_wasm.d.ts:769
 
 ***
 
@@ -905,7 +917,7 @@ Evidence of malfeasance
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:773
+lumina\_node\_wasm.d.ts:777
 
 ***
 
@@ -917,7 +929,7 @@ Block header
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:769
+lumina\_node\_wasm.d.ts:773
 
 ***
 
@@ -929,7 +941,7 @@ Last commit, should be `None` for the initial block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:777
+lumina\_node\_wasm.d.ts:781
 
 ### Methods
 
@@ -943,7 +955,7 @@ lumina\_node\_wasm.d.ts:777
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:761
+lumina\_node\_wasm.d.ts:765
 
 
 <a name="classesblockidmd"></a>
@@ -968,7 +980,7 @@ The block’s main hash is the Merkle root of all the fields in the block header
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:788
+lumina\_node\_wasm.d.ts:792
 
 ***
 
@@ -992,7 +1004,7 @@ This does not translate to Rust, but we can indicate this in the domain type.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:804
+lumina\_node\_wasm.d.ts:808
 
 ### Methods
 
@@ -1006,7 +1018,7 @@ lumina\_node\_wasm.d.ts:804
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:784
+lumina\_node\_wasm.d.ts:788
 
 
 <a name="classesblockrangemd"></a>
@@ -1031,7 +1043,7 @@ Last block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:827
+lumina\_node\_wasm.d.ts:831
 
 ***
 
@@ -1043,7 +1055,7 @@ First block height in range
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:823
+lumina\_node\_wasm.d.ts:827
 
 ### Methods
 
@@ -1057,7 +1069,7 @@ lumina\_node\_wasm.d.ts:823
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:819
+lumina\_node\_wasm.d.ts:823
 
 ***
 
@@ -1073,7 +1085,7 @@ lumina\_node\_wasm.d.ts:819
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:814
+lumina\_node\_wasm.d.ts:818
 
 ***
 
@@ -1089,7 +1101,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:818
+lumina\_node\_wasm.d.ts:822
 
 
 <a name="classesbroadcastmodemd"></a>
@@ -1115,7 +1127,7 @@ immediately.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:853
+lumina\_node\_wasm.d.ts:857
 
 ***
 
@@ -1128,7 +1140,7 @@ DEPRECATED: use `BroadcastMode` `Sync` instead,
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:843
+lumina\_node\_wasm.d.ts:847
 
 ***
 
@@ -1141,7 +1153,7 @@ a CheckTx execution response only.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:848
+lumina\_node\_wasm.d.ts:852
 
 ***
 
@@ -1153,7 +1165,7 @@ zero-value for mode ordering
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:838
+lumina\_node\_wasm.d.ts:842
 
 ### Methods
 
@@ -1167,7 +1179,7 @@ lumina\_node\_wasm.d.ts:838
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:834
+lumina\_node\_wasm.d.ts:838
 
 
 <a name="classescoinmd"></a>
@@ -1214,7 +1226,7 @@ lumina\_node\_wasm.d.ts:457
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:860
+lumina\_node\_wasm.d.ts:864
 
 
 <a name="classescommitmd"></a>
@@ -1240,7 +1252,7 @@ Block ID
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:880
+lumina\_node\_wasm.d.ts:884
 
 ***
 
@@ -1252,7 +1264,7 @@ Block height
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:872
+lumina\_node\_wasm.d.ts:876
 
 ***
 
@@ -1264,7 +1276,7 @@ Round
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:876
+lumina\_node\_wasm.d.ts:880
 
 ***
 
@@ -1276,7 +1288,7 @@ Signatures
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:884
+lumina\_node\_wasm.d.ts:888
 
 ### Methods
 
@@ -1290,7 +1302,7 @@ lumina\_node\_wasm.d.ts:884
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:868
+lumina\_node\_wasm.d.ts:872
 
 
 <a name="classescommitsigmd"></a>
@@ -1316,7 +1328,7 @@ vote type of a validator
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:896
+lumina\_node\_wasm.d.ts:900
 
 ### Accessors
 
@@ -1350,7 +1362,7 @@ vote, if received
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:900
+lumina\_node\_wasm.d.ts:904
 
 ### Methods
 
@@ -1364,7 +1376,7 @@ lumina\_node\_wasm.d.ts:900
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:892
+lumina\_node\_wasm.d.ts:896
 
 
 <a name="classescommitvotemd"></a>
@@ -1389,7 +1401,7 @@ Timestamp
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:919
+lumina\_node\_wasm.d.ts:923
 
 ***
 
@@ -1401,7 +1413,7 @@ Address of the voting validator
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:915
+lumina\_node\_wasm.d.ts:919
 
 ### Accessors
 
@@ -1435,7 +1447,7 @@ Signature
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:923
+lumina\_node\_wasm.d.ts:927
 
 ### Methods
 
@@ -1449,7 +1461,7 @@ lumina\_node\_wasm.d.ts:923
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:911
+lumina\_node\_wasm.d.ts:915
 
 
 <a name="classescommitmentmd"></a>
@@ -1510,7 +1522,7 @@ read more about that in the [`share commitment rules`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:977
+lumina\_node\_wasm.d.ts:981
 
 ***
 
@@ -1526,7 +1538,7 @@ Hash of the commitment
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:981
+lumina\_node\_wasm.d.ts:985
 
 ***
 
@@ -1542,7 +1554,7 @@ lumina\_node\_wasm.d.ts:981
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:972
+lumina\_node\_wasm.d.ts:976
 
 ***
 
@@ -1558,7 +1570,104 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:976
+lumina\_node\_wasm.d.ts:980
+
+
+<a name="classesconfigresponsemd"></a>
+
+[**lumina-node-wasm**](#readmemd)
+
+***
+
+[lumina-node-wasm](#globalsmd) / ConfigResponse
+
+## Class: ConfigResponse
+
+Response holding consensus node configuration.
+
+### Properties
+
+#### halt\_height
+
+> **halt\_height**: `bigint`
+
+A height at which the node should stop advancing state.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1012
+
+***
+
+#### pruning\_interval
+
+> **pruning\_interval**: `bigint`
+
+Amount of blocks used as an interval to trigger prunning.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1008
+
+***
+
+#### pruning\_keep\_recent
+
+> **pruning\_keep\_recent**: `bigint`
+
+How many recent blocks are stored by the node.
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:1004
+
+### Accessors
+
+#### minimum\_gas\_price
+
+##### Get Signature
+
+> **get** **minimum\_gas\_price**(): `number`
+
+Minimum gas price for the node to accept tx. Value is in `utia` denom.
+
+###### Returns
+
+`number`
+
+##### Set Signature
+
+> **set** **minimum\_gas\_price**(`value`): `void`
+
+Minimum gas price for the node to accept tx. Value is in `utia` denom.
+
+###### Parameters
+
+####### value
+
+`number`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:996
+
+### Methods
+
+#### free()
+
+> **free**(): `void`
+
+##### Returns
+
+`void`
+
+##### Defined in
+
+lumina\_node\_wasm.d.ts:992
 
 
 <a name="classesconflictingblockmd"></a>
@@ -1583,7 +1692,7 @@ Signed header
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:992
+lumina\_node\_wasm.d.ts:1023
 
 ***
 
@@ -1595,7 +1704,7 @@ Validator set
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:996
+lumina\_node\_wasm.d.ts:1027
 
 ### Methods
 
@@ -1609,7 +1718,7 @@ lumina\_node\_wasm.d.ts:996
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:988
+lumina\_node\_wasm.d.ts:1019
 
 
 <a name="classesconnectioncounterssnapshotmd"></a>
@@ -1632,7 +1741,7 @@ The total number of connections, both pending and established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1012
+lumina\_node\_wasm.d.ts:1043
 
 ***
 
@@ -1644,7 +1753,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1028
+lumina\_node\_wasm.d.ts:1059
 
 ***
 
@@ -1656,7 +1765,7 @@ The number of established incoming connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1032
+lumina\_node\_wasm.d.ts:1063
 
 ***
 
@@ -1668,7 +1777,7 @@ The number of established outgoing connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1036
+lumina\_node\_wasm.d.ts:1067
 
 ***
 
@@ -1680,7 +1789,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1016
+lumina\_node\_wasm.d.ts:1047
 
 ***
 
@@ -1692,7 +1801,7 @@ The total number of pending connections, both incoming and outgoing.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1020
+lumina\_node\_wasm.d.ts:1051
 
 ***
 
@@ -1704,7 +1813,7 @@ The number of outgoing connections being established.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1024
+lumina\_node\_wasm.d.ts:1055
 
 ### Methods
 
@@ -1718,7 +1827,7 @@ lumina\_node\_wasm.d.ts:1024
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1008
+lumina\_node\_wasm.d.ts:1039
 
 ***
 
@@ -1734,7 +1843,7 @@ lumina\_node\_wasm.d.ts:1008
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1003
+lumina\_node\_wasm.d.ts:1034
 
 ***
 
@@ -1750,7 +1859,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1007
+lumina\_node\_wasm.d.ts:1038
 
 
 <a name="classesconsaddressmd"></a>
@@ -1777,7 +1886,7 @@ Address of a consensus node.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1051
+lumina\_node\_wasm.d.ts:1082
 
 ***
 
@@ -1793,7 +1902,7 @@ lumina\_node\_wasm.d.ts:1051
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1046
+lumina\_node\_wasm.d.ts:1077
 
 ***
 
@@ -1809,7 +1918,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1050
+lumina\_node\_wasm.d.ts:1081
 
 
 <a name="classesdatamd"></a>
@@ -1838,7 +1947,7 @@ to as the "data root".
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1070
+lumina\_node\_wasm.d.ts:1101
 
 ***
 
@@ -1850,7 +1959,7 @@ Square width of original data square.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1064
+lumina\_node\_wasm.d.ts:1095
 
 ***
 
@@ -1862,7 +1971,7 @@ Transactions
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1074
+lumina\_node\_wasm.d.ts:1105
 
 ### Methods
 
@@ -1876,7 +1985,7 @@ lumina\_node\_wasm.d.ts:1074
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1060
+lumina\_node\_wasm.d.ts:1091
 
 
 <a name="classesdataavailabilityheadermd"></a>
@@ -1944,7 +2053,7 @@ Get the a root of the column with the given index.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1138
+lumina\_node\_wasm.d.ts:1169
 
 ***
 
@@ -1960,7 +2069,7 @@ Merkle roots of the [`ExtendedDataSquare`] columns.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1130
+lumina\_node\_wasm.d.ts:1161
 
 ***
 
@@ -1974,7 +2083,7 @@ lumina\_node\_wasm.d.ts:1130
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1122
+lumina\_node\_wasm.d.ts:1153
 
 ***
 
@@ -1992,7 +2101,7 @@ This is the data commitment for the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1144
+lumina\_node\_wasm.d.ts:1175
 
 ***
 
@@ -2014,7 +2123,7 @@ Get a root of the row with the given index.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1134
+lumina\_node\_wasm.d.ts:1165
 
 ***
 
@@ -2030,7 +2139,7 @@ Merkle roots of the [`ExtendedDataSquare`] rows.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1126
+lumina\_node\_wasm.d.ts:1157
 
 ***
 
@@ -2046,7 +2155,7 @@ Get the size of the [`ExtendedDataSquare`] for which this header was built.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1148
+lumina\_node\_wasm.d.ts:1179
 
 ***
 
@@ -2062,7 +2171,7 @@ lumina\_node\_wasm.d.ts:1148
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1117
+lumina\_node\_wasm.d.ts:1148
 
 ***
 
@@ -2078,7 +2187,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1121
+lumina\_node\_wasm.d.ts:1152
 
 
 <a name="classesduplicatevoteevidencemd"></a>
@@ -2103,7 +2212,7 @@ Timestamp
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1175
+lumina\_node\_wasm.d.ts:1206
 
 ***
 
@@ -2115,7 +2224,7 @@ Total voting power
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1167
+lumina\_node\_wasm.d.ts:1198
 
 ***
 
@@ -2127,7 +2236,7 @@ Validator power
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1171
+lumina\_node\_wasm.d.ts:1202
 
 ***
 
@@ -2139,7 +2248,7 @@ Vote A
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1159
+lumina\_node\_wasm.d.ts:1190
 
 ***
 
@@ -2151,7 +2260,7 @@ Vote B
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1163
+lumina\_node\_wasm.d.ts:1194
 
 ### Methods
 
@@ -2165,7 +2274,7 @@ lumina\_node\_wasm.d.ts:1163
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1155
+lumina\_node\_wasm.d.ts:1186
 
 
 <a name="classesevidencemd"></a>
@@ -2192,7 +2301,7 @@ Evidence of malfeasance by validators (i.e. signing conflicting votes or light c
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1182
+lumina\_node\_wasm.d.ts:1213
 
 
 <a name="classesextendedheadermd"></a>
@@ -2243,7 +2352,7 @@ Commit metadata and signatures from validators committing the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1313
+lumina\_node\_wasm.d.ts:1344
 
 ***
 
@@ -2255,7 +2364,7 @@ Header of the block data availability.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1305
+lumina\_node\_wasm.d.ts:1336
 
 ***
 
@@ -2267,7 +2376,7 @@ Tendermint block header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1309
+lumina\_node\_wasm.d.ts:1340
 
 ***
 
@@ -2279,7 +2388,7 @@ Information about the set of validators commiting the block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1317
+lumina\_node\_wasm.d.ts:1348
 
 ### Methods
 
@@ -2295,7 +2404,7 @@ Clone a header producing a deep copy of it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1227
+lumina\_node\_wasm.d.ts:1258
 
 ***
 
@@ -2309,7 +2418,7 @@ lumina\_node\_wasm.d.ts:1227
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1223
+lumina\_node\_wasm.d.ts:1254
 
 ***
 
@@ -2325,7 +2434,7 @@ Get the block hash.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1239
+lumina\_node\_wasm.d.ts:1270
 
 ***
 
@@ -2341,7 +2450,7 @@ Get the block height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1231
+lumina\_node\_wasm.d.ts:1262
 
 ***
 
@@ -2357,7 +2466,7 @@ Get the hash of the previous header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1243
+lumina\_node\_wasm.d.ts:1274
 
 ***
 
@@ -2373,7 +2482,7 @@ Get the block time.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1235
+lumina\_node\_wasm.d.ts:1266
 
 ***
 
@@ -2389,7 +2498,7 @@ lumina\_node\_wasm.d.ts:1235
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1218
+lumina\_node\_wasm.d.ts:1249
 
 ***
 
@@ -2405,7 +2514,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1222
+lumina\_node\_wasm.d.ts:1253
 
 ***
 
@@ -2421,7 +2530,7 @@ Decode protobuf encoded header and then validate it.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1247
+lumina\_node\_wasm.d.ts:1278
 
 ***
 
@@ -2449,7 +2558,7 @@ This function will also return an error if untrusted headers and `self` don't fo
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1257
+lumina\_node\_wasm.d.ts:1288
 
 ***
 
@@ -2489,7 +2598,7 @@ This function will also return an error if untrusted headers and `self` don't fo
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1301
+lumina\_node\_wasm.d.ts:1332
 
 ***
 
@@ -2529,7 +2638,7 @@ to each other.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1279
+lumina\_node\_wasm.d.ts:1310
 
 
 <a name="classesfeemd"></a>
@@ -2556,7 +2665,7 @@ amount is the amount of coins to be paid as a fee
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1330
+lumina\_node\_wasm.d.ts:1361
 
 ***
 
@@ -2569,7 +2678,7 @@ before an out of gas error occurs
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1335
+lumina\_node\_wasm.d.ts:1366
 
 ***
 
@@ -2583,7 +2692,7 @@ not support fee grants, this will fail
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1347
+lumina\_node\_wasm.d.ts:1378
 
 ***
 
@@ -2597,7 +2706,7 @@ setting this field does *not* change the ordering of required signers for the tr
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1341
+lumina\_node\_wasm.d.ts:1372
 
 ### Methods
 
@@ -2611,7 +2720,7 @@ lumina\_node\_wasm.d.ts:1341
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1326
+lumina\_node\_wasm.d.ts:1357
 
 
 <a name="classesgasestimatemd"></a>
@@ -2636,7 +2745,7 @@ Gas price estimated based on last 5 blocks
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1358
+lumina\_node\_wasm.d.ts:1389
 
 ***
 
@@ -2648,7 +2757,7 @@ Simulated transaction gas usage
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1362
+lumina\_node\_wasm.d.ts:1393
 
 ### Methods
 
@@ -2662,7 +2771,7 @@ lumina\_node\_wasm.d.ts:1362
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1354
+lumina\_node\_wasm.d.ts:1385
 
 
 <a name="classesgasinfomd"></a>
@@ -2687,7 +2796,7 @@ GasUsed is the amount of gas actually consumed.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1377
+lumina\_node\_wasm.d.ts:1408
 
 ***
 
@@ -2699,7 +2808,7 @@ GasWanted is the maximum units of work we allow this tx to perform.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1373
+lumina\_node\_wasm.d.ts:1404
 
 ### Methods
 
@@ -2713,7 +2822,7 @@ lumina\_node\_wasm.d.ts:1373
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1369
+lumina\_node\_wasm.d.ts:1400
 
 
 <a name="classesgettxresponsemd"></a>
@@ -2738,7 +2847,7 @@ Response Transaction
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1388
+lumina\_node\_wasm.d.ts:1419
 
 ***
 
@@ -2750,7 +2859,7 @@ TxResponse to a Query
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1392
+lumina\_node\_wasm.d.ts:1423
 
 ### Methods
 
@@ -2764,7 +2873,7 @@ lumina\_node\_wasm.d.ts:1392
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1384
+lumina\_node\_wasm.d.ts:1415
 
 
 <a name="classesgrpcclientmd"></a>
@@ -2811,7 +2920,7 @@ Issue a direct ABCI query to the application
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1456
+lumina\_node\_wasm.d.ts:1487
 
 ***
 
@@ -2837,7 +2946,7 @@ Broadcast prepared and serialised transaction
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1460
+lumina\_node\_wasm.d.ts:1491
 
 ***
 
@@ -2851,7 +2960,7 @@ lumina\_node\_wasm.d.ts:1460
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1399
+lumina\_node\_wasm.d.ts:1430
 
 ***
 
@@ -2873,7 +2982,7 @@ Get account
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1411
+lumina\_node\_wasm.d.ts:1442
 
 ***
 
@@ -2889,7 +2998,7 @@ Get accounts
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1415
+lumina\_node\_wasm.d.ts:1446
 
 ***
 
@@ -2911,7 +3020,7 @@ Get balance of all coins
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1432
+lumina\_node\_wasm.d.ts:1463
 
 ***
 
@@ -2927,7 +3036,7 @@ Get auth params
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1407
+lumina\_node\_wasm.d.ts:1438
 
 ***
 
@@ -2953,7 +3062,7 @@ Get balance of coins with given denom
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1428
+lumina\_node\_wasm.d.ts:1459
 
 ***
 
@@ -2969,7 +3078,7 @@ Get blob params
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1472
+lumina\_node\_wasm.d.ts:1503
 
 ***
 
@@ -2991,7 +3100,7 @@ Get block by height
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1452
+lumina\_node\_wasm.d.ts:1483
 
 ***
 
@@ -3007,23 +3116,23 @@ Get latest block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1448
+lumina\_node\_wasm.d.ts:1479
 
 ***
 
-#### get\_min\_gas\_price()
+#### get\_node\_config()
 
-> **get\_min\_gas\_price**(): `Promise`\<`number`\>
+> **get\_node\_config**(): `Promise`\<[`ConfigResponse`](#classesconfigresponsemd)\>
 
-Get Minimum Gas price
+Get node configuration
 
 ##### Returns
 
-`Promise`\<`number`\>
+`Promise`\<[`ConfigResponse`](#classesconfigresponsemd)\>
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1444
+lumina\_node\_wasm.d.ts:1475
 
 ***
 
@@ -3045,7 +3154,7 @@ Get balance of all spendable coins
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1436
+lumina\_node\_wasm.d.ts:1467
 
 ***
 
@@ -3061,7 +3170,7 @@ Get total supply
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1440
+lumina\_node\_wasm.d.ts:1471
 
 ***
 
@@ -3083,7 +3192,7 @@ Get Tx
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1464
+lumina\_node\_wasm.d.ts:1495
 
 ***
 
@@ -3114,7 +3223,7 @@ app hash is the result of applying the previous block's transaction list.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1424
+lumina\_node\_wasm.d.ts:1455
 
 ***
 
@@ -3136,7 +3245,7 @@ Simulate prepared and serialised transaction, returning simulated gas usage
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1468
+lumina\_node\_wasm.d.ts:1499
 
 ***
 
@@ -3158,7 +3267,7 @@ Get status of the transaction
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1476
+lumina\_node\_wasm.d.ts:1507
 
 ***
 
@@ -3180,7 +3289,7 @@ Create a new client connected with the given `url`
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1403
+lumina\_node\_wasm.d.ts:1434
 
 
 <a name="classesheadermd"></a>
@@ -3207,7 +3316,7 @@ State after txs from the previous block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1541
+lumina\_node\_wasm.d.ts:1572
 
 ***
 
@@ -3219,7 +3328,7 @@ Chain ID
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1493
+lumina\_node\_wasm.d.ts:1524
 
 ***
 
@@ -3231,7 +3340,7 @@ Consensus params for the current block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1537
+lumina\_node\_wasm.d.ts:1568
 
 ***
 
@@ -3243,7 +3352,7 @@ Current block height
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1497
+lumina\_node\_wasm.d.ts:1528
 
 ***
 
@@ -3255,7 +3364,7 @@ Validators for the next block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1533
+lumina\_node\_wasm.d.ts:1564
 
 ***
 
@@ -3267,7 +3376,7 @@ Original proposer of the block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1561
+lumina\_node\_wasm.d.ts:1592
 
 ***
 
@@ -3279,7 +3388,7 @@ Current timestamp encoded as rfc3339
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1501
+lumina\_node\_wasm.d.ts:1532
 
 ***
 
@@ -3291,7 +3400,7 @@ Validators for the current block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1529
+lumina\_node\_wasm.d.ts:1560
 
 ***
 
@@ -3303,7 +3412,7 @@ Header version
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1489
+lumina\_node\_wasm.d.ts:1520
 
 ### Accessors
 
@@ -3337,7 +3446,7 @@ Merkle root of transaction hashes
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1521
+lumina\_node\_wasm.d.ts:1552
 
 ***
 
@@ -3371,7 +3480,7 @@ Hash of evidence included in the block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1553
+lumina\_node\_wasm.d.ts:1584
 
 ***
 
@@ -3405,7 +3514,7 @@ Previous block info
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1505
+lumina\_node\_wasm.d.ts:1536
 
 ***
 
@@ -3439,7 +3548,7 @@ Commit from validators from the last block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1513
+lumina\_node\_wasm.d.ts:1544
 
 ***
 
@@ -3473,7 +3582,7 @@ Root hash of all results from the txs from the previous block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1545
+lumina\_node\_wasm.d.ts:1576
 
 ### Methods
 
@@ -3487,7 +3596,7 @@ lumina\_node\_wasm.d.ts:1545
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1485
+lumina\_node\_wasm.d.ts:1516
 
 
 <a name="classesintounderlyingbytesourcemd"></a>
@@ -3508,7 +3617,7 @@ lumina\_node\_wasm.d.ts:1485
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1570
+lumina\_node\_wasm.d.ts:1601
 
 ***
 
@@ -3518,7 +3627,7 @@ lumina\_node\_wasm.d.ts:1570
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1569
+lumina\_node\_wasm.d.ts:1600
 
 ### Methods
 
@@ -3532,7 +3641,7 @@ lumina\_node\_wasm.d.ts:1569
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1568
+lumina\_node\_wasm.d.ts:1599
 
 ***
 
@@ -3546,7 +3655,7 @@ lumina\_node\_wasm.d.ts:1568
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1565
+lumina\_node\_wasm.d.ts:1596
 
 ***
 
@@ -3566,7 +3675,7 @@ lumina\_node\_wasm.d.ts:1565
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1567
+lumina\_node\_wasm.d.ts:1598
 
 ***
 
@@ -3586,7 +3695,7 @@ lumina\_node\_wasm.d.ts:1567
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1566
+lumina\_node\_wasm.d.ts:1597
 
 
 <a name="classesintounderlyingsinkmd"></a>
@@ -3617,7 +3726,7 @@ lumina\_node\_wasm.d.ts:1566
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1577
+lumina\_node\_wasm.d.ts:1608
 
 ***
 
@@ -3631,7 +3740,7 @@ lumina\_node\_wasm.d.ts:1577
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1576
+lumina\_node\_wasm.d.ts:1607
 
 ***
 
@@ -3645,7 +3754,7 @@ lumina\_node\_wasm.d.ts:1576
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1574
+lumina\_node\_wasm.d.ts:1605
 
 ***
 
@@ -3665,7 +3774,7 @@ lumina\_node\_wasm.d.ts:1574
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1575
+lumina\_node\_wasm.d.ts:1606
 
 
 <a name="classesintounderlyingsourcemd"></a>
@@ -3690,7 +3799,7 @@ lumina\_node\_wasm.d.ts:1575
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1583
+lumina\_node\_wasm.d.ts:1614
 
 ***
 
@@ -3704,7 +3813,7 @@ lumina\_node\_wasm.d.ts:1583
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1581
+lumina\_node\_wasm.d.ts:1612
 
 ***
 
@@ -3724,7 +3833,7 @@ lumina\_node\_wasm.d.ts:1581
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1582
+lumina\_node\_wasm.d.ts:1613
 
 
 <a name="classesjsbitvectormd"></a>
@@ -3747,7 +3856,7 @@ Array of bits
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1591
+lumina\_node\_wasm.d.ts:1622
 
 ### Methods
 
@@ -3761,7 +3870,7 @@ lumina\_node\_wasm.d.ts:1591
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1590
+lumina\_node\_wasm.d.ts:1621
 
 
 <a name="classesjseventmd"></a>
@@ -3786,7 +3895,7 @@ Later, transactions may be queried using these events.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1602
+lumina\_node\_wasm.d.ts:1633
 
 ***
 
@@ -3796,7 +3905,7 @@ lumina\_node\_wasm.d.ts:1602
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1601
+lumina\_node\_wasm.d.ts:1632
 
 ### Methods
 
@@ -3810,7 +3919,7 @@ lumina\_node\_wasm.d.ts:1601
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1600
+lumina\_node\_wasm.d.ts:1631
 
 
 <a name="classesjseventattributemd"></a>
@@ -3831,7 +3940,7 @@ lumina\_node\_wasm.d.ts:1600
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1609
+lumina\_node\_wasm.d.ts:1640
 
 ***
 
@@ -3841,7 +3950,7 @@ lumina\_node\_wasm.d.ts:1609
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1607
+lumina\_node\_wasm.d.ts:1638
 
 ***
 
@@ -3851,7 +3960,7 @@ lumina\_node\_wasm.d.ts:1607
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1608
+lumina\_node\_wasm.d.ts:1639
 
 ### Methods
 
@@ -3865,7 +3974,7 @@ lumina\_node\_wasm.d.ts:1608
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1606
+lumina\_node\_wasm.d.ts:1637
 
 
 <a name="classesjsvalidatorinfomd"></a>
@@ -3890,7 +3999,7 @@ Validator account address
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1620
+lumina\_node\_wasm.d.ts:1651
 
 ***
 
@@ -3902,7 +4011,7 @@ Validator voting power
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1628
+lumina\_node\_wasm.d.ts:1659
 
 ***
 
@@ -3914,7 +4023,7 @@ Validator proposer priority
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1640
+lumina\_node\_wasm.d.ts:1671
 
 ***
 
@@ -3926,7 +4035,7 @@ Validator public key
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1624
+lumina\_node\_wasm.d.ts:1655
 
 ### Accessors
 
@@ -3960,7 +4069,7 @@ Validator name
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1632
+lumina\_node\_wasm.d.ts:1663
 
 ### Methods
 
@@ -3974,7 +4083,7 @@ lumina\_node\_wasm.d.ts:1632
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1616
+lumina\_node\_wasm.d.ts:1647
 
 
 <a name="classeslightclientattackevidencemd"></a>
@@ -3999,7 +4108,7 @@ Byzantine validators
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1659
+lumina\_node\_wasm.d.ts:1690
 
 ***
 
@@ -4011,7 +4120,7 @@ Common height
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1655
+lumina\_node\_wasm.d.ts:1686
 
 ***
 
@@ -4023,7 +4132,7 @@ Conflicting block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1651
+lumina\_node\_wasm.d.ts:1682
 
 ***
 
@@ -4035,7 +4144,7 @@ Timestamp
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1667
+lumina\_node\_wasm.d.ts:1698
 
 ***
 
@@ -4047,7 +4156,7 @@ Total voting power
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1663
+lumina\_node\_wasm.d.ts:1694
 
 ### Methods
 
@@ -4061,7 +4170,7 @@ lumina\_node\_wasm.d.ts:1663
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1647
+lumina\_node\_wasm.d.ts:1678
 
 
 <a name="classesmodeinfomd"></a>
@@ -4087,7 +4196,7 @@ bitarray specifies which keys within the multisig are signing
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1689
+lumina\_node\_wasm.d.ts:1720
 
 ***
 
@@ -4101,7 +4210,7 @@ future
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1684
+lumina\_node\_wasm.d.ts:1715
 
 ***
 
@@ -4115,7 +4224,7 @@ which could include nested multisig public keys
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1695
+lumina\_node\_wasm.d.ts:1726
 
 ### Methods
 
@@ -4129,7 +4238,7 @@ lumina\_node\_wasm.d.ts:1695
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1674
+lumina\_node\_wasm.d.ts:1705
 
 ***
 
@@ -4145,7 +4254,7 @@ Return signature mode for the stored signature(s)
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1678
+lumina\_node\_wasm.d.ts:1709
 
 
 <a name="classesnamespacemd"></a>
@@ -4188,7 +4297,7 @@ Returns the trailing 28 bytes indicating the id of the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1804
+lumina\_node\_wasm.d.ts:1835
 
 ***
 
@@ -4200,7 +4309,7 @@ Returns the first byte indicating the version of the [`Namespace`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1800
+lumina\_node\_wasm.d.ts:1831
 
 ***
 
@@ -4214,7 +4323,7 @@ Used to indicate the end of the primary reserved group.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1775
+lumina\_node\_wasm.d.ts:1806
 
 ***
 
@@ -4228,7 +4337,7 @@ Used to indicate the beginning of the secondary reserved group.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1781
+lumina\_node\_wasm.d.ts:1812
 
 ***
 
@@ -4240,7 +4349,7 @@ Namespace size in bytes.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1754
+lumina\_node\_wasm.d.ts:1785
 
 ***
 
@@ -4256,7 +4365,7 @@ merkle roots.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1796
+lumina\_node\_wasm.d.ts:1827
 
 ***
 
@@ -4268,7 +4377,7 @@ Primary reserved [`Namespace`] for the compact Shares with MsgPayForBlobs transa
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1762
+lumina\_node\_wasm.d.ts:1793
 
 ***
 
@@ -4283,7 +4392,7 @@ so that user-defined namespaces are correctly aligned in `ExtendedDataSquare`
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1769
+lumina\_node\_wasm.d.ts:1800
 
 ***
 
@@ -4298,7 +4407,7 @@ blobs before the parity data is generated for the `ExtendedDataSquare`.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1788
+lumina\_node\_wasm.d.ts:1819
 
 ***
 
@@ -4310,7 +4419,7 @@ Primary reserved [`Namespace`] for the compact `Share`s with `cosmos SDK` transa
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1758
+lumina\_node\_wasm.d.ts:1789
 
 ### Methods
 
@@ -4326,7 +4435,7 @@ Converts the [`Namespace`] to a byte slice.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1750
+lumina\_node\_wasm.d.ts:1781
 
 ***
 
@@ -4340,7 +4449,7 @@ lumina\_node\_wasm.d.ts:1750
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1728
+lumina\_node\_wasm.d.ts:1759
 
 ***
 
@@ -4356,7 +4465,7 @@ lumina\_node\_wasm.d.ts:1728
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1723
+lumina\_node\_wasm.d.ts:1754
 
 ***
 
@@ -4372,7 +4481,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1727
+lumina\_node\_wasm.d.ts:1758
 
 ***
 
@@ -4400,7 +4509,7 @@ version `0` namespace, check [`newV0`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1746
+lumina\_node\_wasm.d.ts:1777
 
 ***
 
@@ -4425,7 +4534,7 @@ Check [`Namespace::new_v0`] for more details.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1736
+lumina\_node\_wasm.d.ts:1767
 
 
 <a name="classesnetworkinfosnapshotmd"></a>
@@ -4450,7 +4559,7 @@ Gets counters for ongoing network connections.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1827
+lumina\_node\_wasm.d.ts:1858
 
 ***
 
@@ -4462,7 +4571,7 @@ The number of connected peers, i.e. peers with whom at least one established con
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1823
+lumina\_node\_wasm.d.ts:1854
 
 ### Methods
 
@@ -4476,7 +4585,7 @@ lumina\_node\_wasm.d.ts:1823
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1819
+lumina\_node\_wasm.d.ts:1850
 
 ***
 
@@ -4492,7 +4601,7 @@ lumina\_node\_wasm.d.ts:1819
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1814
+lumina\_node\_wasm.d.ts:1845
 
 ***
 
@@ -4508,7 +4617,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1818
+lumina\_node\_wasm.d.ts:1849
 
 
 <a name="classesnodeclientmd"></a>
@@ -4547,7 +4656,7 @@ expected to have `MessagePort`-like interface for sending and receiving messages
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1841
+lumina\_node\_wasm.d.ts:1872
 
 ### Methods
 
@@ -4569,7 +4678,7 @@ Establish a new connection to the existing worker over provided port
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1845
+lumina\_node\_wasm.d.ts:1876
 
 ***
 
@@ -4585,7 +4694,7 @@ Get all the peers that node is connected to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1882
+lumina\_node\_wasm.d.ts:1913
 
 ***
 
@@ -4601,7 +4710,7 @@ Returns a [`BroadcastChannel`] for events generated by [`Node`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1949
+lumina\_node\_wasm.d.ts:1980
 
 ***
 
@@ -4615,7 +4724,7 @@ lumina\_node\_wasm.d.ts:1949
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1836
+lumina\_node\_wasm.d.ts:1867
 
 ***
 
@@ -4637,7 +4746,7 @@ Get a synced header for the block with a given hash.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1925
+lumina\_node\_wasm.d.ts:1956
 
 ***
 
@@ -4659,7 +4768,7 @@ Get a synced header for the block with a given height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1929
+lumina\_node\_wasm.d.ts:1960
 
 ***
 
@@ -4693,7 +4802,7 @@ If range contains a height of a header that is not found in the store.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1941
+lumina\_node\_wasm.d.ts:1972
 
 ***
 
@@ -4709,7 +4818,7 @@ Get the latest locally synced header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1921
+lumina\_node\_wasm.d.ts:1952
 
 ***
 
@@ -4725,7 +4834,7 @@ Get the latest header announced in the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1917
+lumina\_node\_wasm.d.ts:1948
 
 ***
 
@@ -4747,7 +4856,7 @@ Get data sampling metadata of an already sampled height.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1945
+lumina\_node\_wasm.d.ts:1976
 
 ***
 
@@ -4763,7 +4872,7 @@ Check whether Lumina is currently running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1849
+lumina\_node\_wasm.d.ts:1880
 
 ***
 
@@ -4779,7 +4888,7 @@ Get all the multiaddresses on which the node listens.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1878
+lumina\_node\_wasm.d.ts:1909
 
 ***
 
@@ -4795,7 +4904,7 @@ Get node's local peer ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1858
+lumina\_node\_wasm.d.ts:1889
 
 ***
 
@@ -4811,7 +4920,7 @@ Get current network info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1874
+lumina\_node\_wasm.d.ts:1905
 
 ***
 
@@ -4827,7 +4936,7 @@ Get current [`PeerTracker`] info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1862
+lumina\_node\_wasm.d.ts:1893
 
 ***
 
@@ -4858,7 +4967,7 @@ using bitswap protocol.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1909
+lumina\_node\_wasm.d.ts:1940
 
 ***
 
@@ -4880,7 +4989,7 @@ Request a header for the block with a given hash from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1894
+lumina\_node\_wasm.d.ts:1925
 
 ***
 
@@ -4902,7 +5011,7 @@ Request a header for the block with a given height from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1898
+lumina\_node\_wasm.d.ts:1929
 
 ***
 
@@ -4918,7 +5027,7 @@ Request the head header from the network.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1890
+lumina\_node\_wasm.d.ts:1921
 
 ***
 
@@ -4946,7 +5055,7 @@ The headers will be verified with the `from` header.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1904
+lumina\_node\_wasm.d.ts:1935
 
 ***
 
@@ -4972,7 +5081,7 @@ Trust or untrust the peer with a given ID.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1886
+lumina\_node\_wasm.d.ts:1917
 
 ***
 
@@ -4994,7 +5103,7 @@ Start a node with the provided config, if it's not running
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1853
+lumina\_node\_wasm.d.ts:1884
 
 ***
 
@@ -5008,7 +5117,7 @@ lumina\_node\_wasm.d.ts:1853
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1854
+lumina\_node\_wasm.d.ts:1885
 
 ***
 
@@ -5024,7 +5133,7 @@ Get current header syncing info.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1913
+lumina\_node\_wasm.d.ts:1944
 
 ***
 
@@ -5040,7 +5149,7 @@ Wait until the node is connected to at least 1 peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1866
+lumina\_node\_wasm.d.ts:1897
 
 ***
 
@@ -5056,7 +5165,7 @@ Wait until the node is connected to at least 1 trusted peer.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1870
+lumina\_node\_wasm.d.ts:1901
 
 
 <a name="classesnodeconfigmd"></a>
@@ -5081,7 +5190,7 @@ A list of bootstrap peers to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1976
+lumina\_node\_wasm.d.ts:2007
 
 ***
 
@@ -5093,7 +5202,7 @@ A network to connect to.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1972
+lumina\_node\_wasm.d.ts:2003
 
 ***
 
@@ -5107,7 +5216,7 @@ Whether to store data in persistent memory or not.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1982
+lumina\_node\_wasm.d.ts:2013
 
 ### Accessors
 
@@ -5159,7 +5268,7 @@ If this is not set, then default value will apply:
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1995
+lumina\_node\_wasm.d.ts:2026
 
 ### Methods
 
@@ -5173,7 +5282,7 @@ lumina\_node\_wasm.d.ts:1995
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1964
+lumina\_node\_wasm.d.ts:1995
 
 ***
 
@@ -5189,7 +5298,7 @@ lumina\_node\_wasm.d.ts:1964
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1959
+lumina\_node\_wasm.d.ts:1990
 
 ***
 
@@ -5205,7 +5314,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1963
+lumina\_node\_wasm.d.ts:1994
 
 ***
 
@@ -5227,7 +5336,7 @@ Get the configuration with default bootnodes for provided network
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:1968
+lumina\_node\_wasm.d.ts:1999
 
 
 <a name="classesnodeworkermd"></a>
@@ -5263,7 +5372,7 @@ them and sending a response back, as well as accepting new `NodeClient` connecti
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2018
+lumina\_node\_wasm.d.ts:2049
 
 ### Methods
 
@@ -5277,7 +5386,7 @@ lumina\_node\_wasm.d.ts:2018
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2017
+lumina\_node\_wasm.d.ts:2048
 
 ***
 
@@ -5291,7 +5400,7 @@ lumina\_node\_wasm.d.ts:2017
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2019
+lumina\_node\_wasm.d.ts:2050
 
 
 <a name="classespartsheadermd"></a>
@@ -5316,7 +5425,7 @@ Hash of the parts set header
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2034
+lumina\_node\_wasm.d.ts:2065
 
 ***
 
@@ -5328,7 +5437,7 @@ Number of parts in this block
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2030
+lumina\_node\_wasm.d.ts:2061
 
 ### Methods
 
@@ -5342,7 +5451,7 @@ lumina\_node\_wasm.d.ts:2030
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2026
+lumina\_node\_wasm.d.ts:2057
 
 
 <a name="classespeertrackerinfosnapshotmd"></a>
@@ -5367,7 +5476,7 @@ Number of the connected peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2053
+lumina\_node\_wasm.d.ts:2084
 
 ***
 
@@ -5379,7 +5488,7 @@ Number of the connected trusted peers.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2057
+lumina\_node\_wasm.d.ts:2088
 
 ### Methods
 
@@ -5393,7 +5502,7 @@ lumina\_node\_wasm.d.ts:2057
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2049
+lumina\_node\_wasm.d.ts:2080
 
 ***
 
@@ -5409,7 +5518,7 @@ lumina\_node\_wasm.d.ts:2049
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2044
+lumina\_node\_wasm.d.ts:2075
 
 ***
 
@@ -5425,7 +5534,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2048
+lumina\_node\_wasm.d.ts:2079
 
 
 <a name="classesproofopmd"></a>
@@ -5452,7 +5561,7 @@ Note: This type is a duplicate of the ProofOp proto type defined in Tendermint.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2071
+lumina\_node\_wasm.d.ts:2102
 
 ***
 
@@ -5462,7 +5571,7 @@ lumina\_node\_wasm.d.ts:2071
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2070
+lumina\_node\_wasm.d.ts:2101
 
 ***
 
@@ -5472,7 +5581,7 @@ lumina\_node\_wasm.d.ts:2070
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2069
+lumina\_node\_wasm.d.ts:2100
 
 ### Methods
 
@@ -5486,7 +5595,7 @@ lumina\_node\_wasm.d.ts:2069
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2068
+lumina\_node\_wasm.d.ts:2099
 
 
 <a name="classesproofopsmd"></a>
@@ -5511,7 +5620,7 @@ Note: This type is a duplicate of the ProofOps proto type defined in Tendermint.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2081
+lumina\_node\_wasm.d.ts:2112
 
 ### Methods
 
@@ -5525,7 +5634,7 @@ lumina\_node\_wasm.d.ts:2081
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2080
+lumina\_node\_wasm.d.ts:2111
 
 
 <a name="classesprotocolversionmd"></a>
@@ -5550,7 +5659,7 @@ app version
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2096
+lumina\_node\_wasm.d.ts:2127
 
 ***
 
@@ -5562,7 +5671,7 @@ blockchain version
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2092
+lumina\_node\_wasm.d.ts:2123
 
 ### Methods
 
@@ -5576,7 +5685,7 @@ lumina\_node\_wasm.d.ts:2092
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2088
+lumina\_node\_wasm.d.ts:2119
 
 
 <a name="classessamplingmetadatamd"></a>
@@ -5603,7 +5712,7 @@ Return Array of cids
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2109
+lumina\_node\_wasm.d.ts:2140
 
 ### Methods
 
@@ -5617,7 +5726,7 @@ lumina\_node\_wasm.d.ts:2109
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2105
+lumina\_node\_wasm.d.ts:2136
 
 
 <a name="classessignaturemd"></a>
@@ -5640,7 +5749,7 @@ Signature
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2117
+lumina\_node\_wasm.d.ts:2148
 
 ### Methods
 
@@ -5654,7 +5763,7 @@ lumina\_node\_wasm.d.ts:2117
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2116
+lumina\_node\_wasm.d.ts:2147
 
 
 <a name="classessignedheadermd"></a>
@@ -5679,7 +5788,7 @@ Commit containing signatures for the header
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2132
+lumina\_node\_wasm.d.ts:2163
 
 ***
 
@@ -5691,7 +5800,7 @@ Signed block headers
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2128
+lumina\_node\_wasm.d.ts:2159
 
 ### Methods
 
@@ -5705,7 +5814,7 @@ lumina\_node\_wasm.d.ts:2128
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2124
+lumina\_node\_wasm.d.ts:2155
 
 
 <a name="classessignerinfomd"></a>
@@ -5732,7 +5841,7 @@ structure to support nested multisig pubkey's
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2151
+lumina\_node\_wasm.d.ts:2182
 
 ***
 
@@ -5746,7 +5855,7 @@ prevent replay attacks.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2157
+lumina\_node\_wasm.d.ts:2188
 
 ### Methods
 
@@ -5760,7 +5869,7 @@ lumina\_node\_wasm.d.ts:2157
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2140
+lumina\_node\_wasm.d.ts:2171
 
 ***
 
@@ -5778,7 +5887,7 @@ signer address for this position and lookup the public key.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2146
+lumina\_node\_wasm.d.ts:2177
 
 
 <a name="classesstringeventmd"></a>
@@ -5802,7 +5911,7 @@ contain key/value pairs that are strings instead of raw bytes.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2167
+lumina\_node\_wasm.d.ts:2198
 
 ***
 
@@ -5812,7 +5921,7 @@ lumina\_node\_wasm.d.ts:2167
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2166
+lumina\_node\_wasm.d.ts:2197
 
 ### Methods
 
@@ -5826,7 +5935,7 @@ lumina\_node\_wasm.d.ts:2166
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2165
+lumina\_node\_wasm.d.ts:2196
 
 
 <a name="classessyncinginfosnapshotmd"></a>
@@ -5851,7 +5960,7 @@ Ranges of headers that are already synchronised
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2186
+lumina\_node\_wasm.d.ts:2217
 
 ***
 
@@ -5863,7 +5972,7 @@ Syncing target. The latest height seen in the network that was successfully veri
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2190
+lumina\_node\_wasm.d.ts:2221
 
 ### Methods
 
@@ -5877,7 +5986,7 @@ lumina\_node\_wasm.d.ts:2190
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2182
+lumina\_node\_wasm.d.ts:2213
 
 ***
 
@@ -5893,7 +6002,7 @@ lumina\_node\_wasm.d.ts:2182
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2177
+lumina\_node\_wasm.d.ts:2208
 
 ***
 
@@ -5909,7 +6018,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2181
+lumina\_node\_wasm.d.ts:2212
 
 
 <a name="classestxmd"></a>
@@ -5935,7 +6044,7 @@ and [`Fee`].
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2206
+lumina\_node\_wasm.d.ts:2237
 
 ***
 
@@ -5947,7 +6056,7 @@ Processable content of the transaction
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2201
+lumina\_node\_wasm.d.ts:2232
 
 ***
 
@@ -5960,7 +6069,7 @@ allow connecting signature meta information like public key and signing mode by 
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2211
+lumina\_node\_wasm.d.ts:2242
 
 ### Methods
 
@@ -5974,7 +6083,7 @@ lumina\_node\_wasm.d.ts:2211
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2197
+lumina\_node\_wasm.d.ts:2228
 
 
 <a name="classestxbodymd"></a>
@@ -5999,7 +6108,7 @@ lumina\_node\_wasm.d.ts:2197
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2245
+lumina\_node\_wasm.d.ts:2276
 
 ***
 
@@ -6012,7 +6121,7 @@ be processed by the chain
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2250
+lumina\_node\_wasm.d.ts:2281
 
 ### Methods
 
@@ -6030,7 +6139,7 @@ and can't be handled, the transaction will be rejected
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2235
+lumina\_node\_wasm.d.ts:2266
 
 ***
 
@@ -6044,7 +6153,7 @@ lumina\_node\_wasm.d.ts:2235
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2218
+lumina\_node\_wasm.d.ts:2249
 
 ***
 
@@ -6067,7 +6176,7 @@ transaction.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2229
+lumina\_node\_wasm.d.ts:2260
 
 ***
 
@@ -6085,7 +6194,7 @@ and can't be handled, they will be ignored
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2241
+lumina\_node\_wasm.d.ts:2272
 
 
 <a name="classestxclientmd"></a>
@@ -6159,7 +6268,7 @@ const tx_client = await new TxClient("http://127.0.0.1:18080", keys.pubKey, sign
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2291
+lumina\_node\_wasm.d.ts:2322
 
 ### Properties
 
@@ -6171,7 +6280,7 @@ AppVersion of the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2394
+lumina\_node\_wasm.d.ts:2421
 
 ***
 
@@ -6183,7 +6292,7 @@ Chain id of the client
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2390
+lumina\_node\_wasm.d.ts:2417
 
 ### Methods
 
@@ -6197,7 +6306,7 @@ lumina\_node\_wasm.d.ts:2390
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2256
+lumina\_node\_wasm.d.ts:2287
 
 ***
 
@@ -6219,7 +6328,7 @@ Get account
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2366
+lumina\_node\_wasm.d.ts:2393
 
 ***
 
@@ -6235,7 +6344,7 @@ Get accounts
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2370
+lumina\_node\_wasm.d.ts:2397
 
 ***
 
@@ -6257,7 +6366,7 @@ Get balance of all coins
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2378
+lumina\_node\_wasm.d.ts:2405
 
 ***
 
@@ -6273,7 +6382,7 @@ Get auth params
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2362
+lumina\_node\_wasm.d.ts:2389
 
 ***
 
@@ -6299,7 +6408,7 @@ Get balance of coins with given denom
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2374
+lumina\_node\_wasm.d.ts:2401
 
 ***
 
@@ -6325,7 +6434,7 @@ min gas price.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2303
+lumina\_node\_wasm.d.ts:2330
 
 ***
 
@@ -6347,7 +6456,7 @@ Get balance of all spendable coins
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2382
+lumina\_node\_wasm.d.ts:2409
 
 ***
 
@@ -6363,23 +6472,7 @@ Get total supply
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2386
-
-***
-
-#### minGasPrice()
-
-> **minGasPrice**(): `Promise`\<`number`\>
-
-Query for the current minimum gas price
-
-##### Returns
-
-`Promise`\<`number`\>
-
-##### Defined in
-
-lumina\_node\_wasm.d.ts:2295
+lumina\_node\_wasm.d.ts:2413
 
 ***
 
@@ -6430,7 +6523,7 @@ await txClient.submitBlobs(blobs.map(b => b.clone()));
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2332
+lumina\_node\_wasm.d.ts:2359
 
 ***
 
@@ -6478,7 +6571,7 @@ const txInfo = await txClient.submitMessage(sendMsgAny);
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2358
+lumina\_node\_wasm.d.ts:2385
 
 
 <a name="classestxresponsemd"></a>
@@ -6503,7 +6596,7 @@ Response code.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2409
+lumina\_node\_wasm.d.ts:2436
 
 ***
 
@@ -6515,7 +6608,7 @@ Namespace for the Code
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2405
+lumina\_node\_wasm.d.ts:2432
 
 ***
 
@@ -6527,7 +6620,7 @@ Result bytes, if any.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2413
+lumina\_node\_wasm.d.ts:2440
 
 ***
 
@@ -6542,7 +6635,7 @@ additional metadata, emitted only by processing the messages.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2451
+lumina\_node\_wasm.d.ts:2478
 
 ***
 
@@ -6554,7 +6647,7 @@ Amount of gas consumed by transaction.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2434
+lumina\_node\_wasm.d.ts:2461
 
 ***
 
@@ -6566,7 +6659,7 @@ Amount of gas requested for transaction.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2430
+lumina\_node\_wasm.d.ts:2457
 
 ***
 
@@ -6578,7 +6671,7 @@ The block height
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2444
+lumina\_node\_wasm.d.ts:2471
 
 ***
 
@@ -6590,7 +6683,7 @@ Additional information. May be non-deterministic.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2426
+lumina\_node\_wasm.d.ts:2453
 
 ***
 
@@ -6602,7 +6695,7 @@ The output of the application's logger (typed). May be non-deterministic.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2422
+lumina\_node\_wasm.d.ts:2449
 
 ***
 
@@ -6615,7 +6708,7 @@ non-deterministic.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2418
+lumina\_node\_wasm.d.ts:2445
 
 ***
 
@@ -6629,7 +6722,7 @@ it's genesis time.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2440
+lumina\_node\_wasm.d.ts:2467
 
 ### Methods
 
@@ -6643,7 +6736,7 @@ lumina\_node\_wasm.d.ts:2440
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2401
+lumina\_node\_wasm.d.ts:2428
 
 
 <a name="classestxstatusresponsemd"></a>
@@ -6668,7 +6761,7 @@ Error log, if transaction failed.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2472
+lumina\_node\_wasm.d.ts:2499
 
 ***
 
@@ -6682,7 +6775,7 @@ execution code indicates an error.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2468
+lumina\_node\_wasm.d.ts:2495
 
 ***
 
@@ -6694,7 +6787,7 @@ Height of the block in which the transaction was committed.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2480
+lumina\_node\_wasm.d.ts:2507
 
 ***
 
@@ -6706,7 +6799,7 @@ Index of the transaction in block.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2462
+lumina\_node\_wasm.d.ts:2489
 
 ***
 
@@ -6718,7 +6811,7 @@ Status of the transaction.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2476
+lumina\_node\_wasm.d.ts:2503
 
 ### Methods
 
@@ -6732,7 +6825,7 @@ lumina\_node\_wasm.d.ts:2476
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2458
+lumina\_node\_wasm.d.ts:2485
 
 
 <a name="classesvaladdressmd"></a>
@@ -6759,7 +6852,7 @@ Address of a validator.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2495
+lumina\_node\_wasm.d.ts:2522
 
 ***
 
@@ -6775,7 +6868,7 @@ lumina\_node\_wasm.d.ts:2495
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2490
+lumina\_node\_wasm.d.ts:2517
 
 ***
 
@@ -6791,7 +6884,7 @@ Return stringified version of self.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2494
+lumina\_node\_wasm.d.ts:2521
 
 
 <a name="classesvalidatorsetmd"></a>
@@ -6816,7 +6909,7 @@ Total voting power
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2518
+lumina\_node\_wasm.d.ts:2545
 
 ***
 
@@ -6828,7 +6921,7 @@ Validators in the set
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2506
+lumina\_node\_wasm.d.ts:2533
 
 ### Accessors
 
@@ -6862,7 +6955,7 @@ Proposer
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2510
+lumina\_node\_wasm.d.ts:2537
 
 ### Methods
 
@@ -6876,7 +6969,7 @@ lumina\_node\_wasm.d.ts:2510
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2502
+lumina\_node\_wasm.d.ts:2529
 
 
 <a name="classesvotemd"></a>
@@ -6902,7 +6995,7 @@ Vote extension provided by the application. Only valid for precommit messages.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2574
+lumina\_node\_wasm.d.ts:2601
 
 ***
 
@@ -6914,7 +7007,7 @@ Block height
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2534
+lumina\_node\_wasm.d.ts:2561
 
 ***
 
@@ -6926,7 +7019,7 @@ Round
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2538
+lumina\_node\_wasm.d.ts:2565
 
 ***
 
@@ -6938,7 +7031,7 @@ Validator address
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2558
+lumina\_node\_wasm.d.ts:2585
 
 ***
 
@@ -6950,7 +7043,7 @@ Validator index
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2562
+lumina\_node\_wasm.d.ts:2589
 
 ***
 
@@ -6962,7 +7055,7 @@ Type of vote (prevote or precommit)
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2530
+lumina\_node\_wasm.d.ts:2557
 
 ### Accessors
 
@@ -6996,7 +7089,7 @@ Block ID
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2542
+lumina\_node\_wasm.d.ts:2569
 
 ***
 
@@ -7030,7 +7123,7 @@ Vote extension signature by the validator Only valid for precommit messages.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2578
+lumina\_node\_wasm.d.ts:2605
 
 ***
 
@@ -7064,7 +7157,7 @@ Signature
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2566
+lumina\_node\_wasm.d.ts:2593
 
 ***
 
@@ -7098,7 +7191,7 @@ Timestamp
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2550
+lumina\_node\_wasm.d.ts:2577
 
 ### Methods
 
@@ -7112,7 +7205,7 @@ lumina\_node\_wasm.d.ts:2550
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:2526
+lumina\_node\_wasm.d.ts:2553
 
 # Enumerations
 
@@ -8399,6 +8492,7 @@ lumina\_node\_wasm.d.ts:6
 - [Commitment](#classescommitmentmd)
 - [CommitSig](#classescommitsigmd)
 - [CommitVote](#classescommitvotemd)
+- [ConfigResponse](#classesconfigresponsemd)
 - [ConflictingBlock](#classesconflictingblockmd)
 - [ConnectionCountersSnapshot](#classesconnectioncounterssnapshotmd)
 - [ConsAddress](#classesconsaddressmd)
@@ -8672,7 +8766,7 @@ A payload to be signed
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:470
+lumina\_node\_wasm.d.ts:510
 
 ***
 
@@ -8682,7 +8776,7 @@ lumina\_node\_wasm.d.ts:470
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:468
+lumina\_node\_wasm.d.ts:508
 
 ***
 
@@ -8692,7 +8786,7 @@ lumina\_node\_wasm.d.ts:468
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:467
+lumina\_node\_wasm.d.ts:507
 
 ***
 
@@ -8702,7 +8796,7 @@ lumina\_node\_wasm.d.ts:467
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:469
+lumina\_node\_wasm.d.ts:509
 
 
 <a name="interfacestxconfigmd"></a>
@@ -8728,7 +8822,7 @@ query gas estimation service to get estimate gas limit.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:502
+lumina\_node\_wasm.d.ts:485
 
 ***
 
@@ -8741,7 +8835,7 @@ estimation service to get gas price estimate.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:507
+lumina\_node\_wasm.d.ts:490
 
 ***
 
@@ -8753,7 +8847,7 @@ Memo for the transaction
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:511
+lumina\_node\_wasm.d.ts:494
 
 ***
 
@@ -8765,7 +8859,7 @@ Priority of the transaction, used with gas estimation service
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:515
+lumina\_node\_wasm.d.ts:498
 
 
 <a name="interfacestxinfomd"></a>
@@ -8790,7 +8884,7 @@ Hash of the transaction.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:487
+lumina\_node\_wasm.d.ts:470
 
 ***
 
@@ -8802,7 +8896,7 @@ Height at which transaction was submitted.
 
 ##### Defined in
 
-lumina\_node\_wasm.d.ts:491
+lumina\_node\_wasm.d.ts:474
 
 # Type Aliases
 
@@ -8844,4 +8938,4 @@ A function that produces a signature of a payload
 
 ### Defined in
 
-lumina\_node\_wasm.d.ts:476
+lumina\_node\_wasm.d.ts:516

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.10.2",
+            "version": "0.10.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.10.2",
+            "version": "0.10.3",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/eigerco/lumina/compare/lumina-node-v0.15.1...lumina-node-v0.15.2) - 2025-09-08
+
+### Other
+
+- updated the following local packages: celestia-types, celestia-types, celestia-types, celestia-rpc
+
 ## [0.15.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.15.0...lumina-node-v0.15.1) - 2025-08-19
 
 ### Other

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.12.1...celestia-rpc-v0.13.0) - 2025-09-08
+
+### Added
+
+- *(types)* [**breaking**] Add support for app v6 ([#733](https://github.com/eigerco/lumina/pull/733))
+
+### Other
+
+- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
+
 ## [0.12.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.12.0...celestia-rpc-v0.12.1) - 2025-08-19
 
 ### Other

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.14.1...celestia-types-v0.15.0) - 2025-09-08
+
+### Added
+
+- *(types)* [**breaking**] Add support for app v6 ([#733](https://github.com/eigerco/lumina/pull/733))
+
+### Other
+
+- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
+
 ## [0.14.1](https://github.com/eigerco/lumina/compare/celestia-types-v0.14.0...celestia-types-v0.14.1) - 2025-08-19
 
 ### Fixed

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION



## 🤖 New release

* `celestia-types`: 0.14.1 -> 0.15.0 (⚠ API breaking changes)
* `celestia-rpc`: 0.12.1 -> 0.13.0 (✓ API compatible changes)
* `celestia-grpc-macros`: 0.3.0 -> 0.3.1
* `celestia-grpc`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `celestia-client`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `lumina-node`: 0.15.1 -> 0.15.2
* `lumina-cli`: 0.9.2 -> 0.9.3
* `lumina-node-wasm`: 0.10.2 -> 0.10.3
* `lumina-node-uniffi`: 0.3.2 -> 0.3.3

### ⚠ `celestia-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RedelegationEntry.unbonding_id in /tmp/.tmpcbLhNG/lumina/types/src/state/query_delegation.rs:295
  field RedelegationEntry.unbonding_on_hold_ref_count in /tmp/.tmpcbLhNG/lumina/types/src/state/query_delegation.rs:297
  field UnbondingDelegationEntry.unbonding_id in /tmp/.tmpcbLhNG/lumina/types/src/state/query_delegation.rs:146
  field UnbondingDelegationEntry.unbonding_on_hold_ref_count in /tmp/.tmpcbLhNG/lumina/types/src/state/query_delegation.rs:148

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant AppVersion:V6 in /tmp/.tmpcbLhNG/lumina/types/src/consts.rs:160
  variant AppVersion:V6 in /tmp/.tmpcbLhNG/lumina/types/src/consts.rs:160
```

### ⚠ `celestia-grpc` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  TxClient::get_min_gas_price, previously in file /tmp/.tmpad3Izr/celestia-grpc/src/tx.rs:212
  GrpcClient::get_min_gas_price, previously in file /tmp/.tmpad3Izr/celestia-grpc/src/grpc.rs:180
  GrpcClient::get_min_gas_price, previously in file /tmp/.tmpad3Izr/celestia-grpc/src/grpc.rs:180

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait celestia_grpc::DocSigner gained Sync in file /tmp/.tmpcbLhNG/lumina/grpc/src/tx.rs:444
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`

<blockquote>

## [0.15.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.14.1...celestia-types-v0.15.0) - 2025-09-08

### Added

- *(types)* [**breaking**] Add support for app v6 ([#733](https://github.com/eigerco/lumina/pull/733))

### Other

- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.13.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.12.1...celestia-rpc-v0.13.0) - 2025-09-08

### Added

- *(types)* [**breaking**] Add support for app v6 ([#733](https://github.com/eigerco/lumina/pull/733))

### Other

- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
</blockquote>

## `celestia-grpc-macros`

<blockquote>

## [0.3.1](https://github.com/eigerco/lumina/compare/celestia-grpc-macros-v0.3.0...celestia-grpc-macros-v0.3.1) - 2025-09-08

### Added

- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.7.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.6.1...celestia-grpc-v0.7.0) - 2025-09-08

### Added

- *(types)* [**breaking**] Add support for app v6 ([#733](https://github.com/eigerco/lumina/pull/733))
- *(grpc)* remove retries on insufficient fee and gas multiplier ([#731](https://github.com/eigerco/lumina/pull/731))
- *(grpc)* [**breaking**] expose whole node config instead just gas price ([#732](https://github.com/eigerco/lumina/pull/732))
- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))

### Other

- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
</blockquote>

## `celestia-client`

<blockquote>

## [0.1.2](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.1...celestia-client-v0.1.2) - 2025-09-08

### Added

- *(client,grpc)* make sure all returned futures are Send ([#729](https://github.com/eigerco/lumina/pull/729))

### Other

- *(client,grpc,types)* Make all the celestia-client types types Serialisable ([#734](https://github.com/eigerco/lumina/pull/734))
</blockquote>

## `lumina-node`

<blockquote>

## [0.15.2](https://github.com/eigerco/lumina/compare/lumina-node-v0.15.1...lumina-node-v0.15.2) - 2025-09-08

### Other

- updated the following local packages: celestia-types, celestia-types, celestia-types, celestia-rpc
</blockquote>

## `lumina-cli`

<blockquote>

## [0.9.3](https://github.com/eigerco/lumina/compare/lumina-cli-v0.9.2...lumina-cli-v0.9.3) - 2025-09-08

### Other

- updated the following local packages: celestia-types, celestia-rpc, lumina-node
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.10.3](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.2...lumina-node-wasm-v0.10.3) - 2025-09-08

### Other

- updated the following local packages: celestia-types, celestia-rpc, celestia-grpc, lumina-node
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.3.3](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.2...lumina-node-uniffi-v0.3.3) - 2025-09-08

### Other

- updated the following local packages: celestia-types, celestia-grpc, lumina-node
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).