### PR TITLE
chore: Fix clippy::manual-is-multiple-of on new rust version

### DIFF
--- a/types/src/blob/commitment.rs
+++ b/types/src/blob/commitment.rs
@@ -309,7 +309,7 @@ fn subtree_width(share_count: u64, subtree_root_threshold: u64) -> u64 {
     let mut s = share_count / subtree_root_threshold;
 
     // round up if the width is not an exact multiple of the threshold
-    if share_count % subtree_root_threshold != 0 {
+    if !share_count.is_multiple_of(subtree_root_threshold) {
         s += 1;
     }
 


### PR DESCRIPTION
```
error: manual implementation of `.is_multiple_of()`
Error:    --> types/src/blob/commitment.rs:312:8
    |
312 |     if share_count % subtree_root_threshold != 0 {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!share_count.is_multiple_of(subtree_root_threshold)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
    = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_multiple_of)]`
```