### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "blockstore",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3265,7 +3265,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ members = [
 beetswap = "0.5"
 blockstore = "0.8"
 leopard-codec = "0.2"
-lumina-node = { version = "0.16.0", path = "node" }
-lumina-node-wasm = { version = "0.11.0", path = "node-wasm" }
+lumina-node = { version = "0.17.0", path = "node" }
+lumina-node-wasm = { version = "0.11.1", path = "node-wasm" }
 lumina-utils = { version = "0.4.0", path = "utils" }
-celestia-client = { version = "0.2.0", path = "client" }
+celestia-client = { version = "0.3.0", path = "client" }
 celestia-proto = { version = "0.10.0", path = "proto" }
-celestia-grpc = { version = "0.8.0", path = "grpc", default-features = false }
+celestia-grpc = { version = "0.9.0", path = "grpc", default-features = false }
 celestia-grpc-macros = { version = "0.4.0", path = "grpc/grpc-macros" }
-celestia-rpc = { version = "0.14.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.16.0", path = "types", default-features = false }
+celestia-rpc = { version = "0.14.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.17.0", path = "types", default-features = false }
 
 anyhow = "1.0.40"
 async-trait = "0.1.80"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.10.0...lumina-cli-v0.10.1) - 2025-10-07
+
+### Other
+
+- updated the following local packages: celestia-types, lumina-node, celestia-rpc
+
 ## [0.10.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.9.3...lumina-cli-v0.10.0) - 2025-09-25
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-client-v0.2.0...celestia-client-v0.3.0) - 2025-10-07
+
+### Fixed
+
+- *(client)* [**breaking**] use AsyncGrpcCall also in BlobApi::submit ([#760](https://github.com/eigerco/lumina/pull/760))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/celestia-client-v0.1.2...celestia-client-v0.2.0) - 2025-09-25
 
 ### Added

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-client"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia client combining RPC and gRPC functionality."

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.8.0...celestia-grpc-v0.9.0) - 2025-10-07
+
+### Fixed
+
+- *(types,grpc)* [**breaking**] Address::from_account_verifying_key spelling #764
+
 ## [0.8.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.7.0...celestia-grpc-v0.8.0) - 2025-09-25
 
 ### Added

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-grpc"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for interacting with Celestia validator nodes gRPC"

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.4.0...lumina-node-uniffi-v0.4.1) - 2025-10-07
+
+### Other
+
+- updated the following local packages: celestia-types, lumina-node, celestia-grpc
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.3.3...lumina-node-uniffi-v0.4.0) - 2025-09-25
 
 ### Added

--- a/node-uniffi/Cargo.toml
+++ b/node-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-uniffi"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mobile bindings for Lumina node"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.11.0...lumina-node-wasm-v0.11.1) - 2025-10-07
+
+### Other
+
+- updated the following local packages: celestia-types, lumina-node, celestia-grpc, celestia-rpc
+
 ## [0.11.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.10.3...lumina-node-wasm-v0.11.0) - 2025-09-25
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "0.11.0",
+            "version": "0.11.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "0.11.0",
+            "version": "0.11.1",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.16.0...lumina-node-v0.17.0) - 2025-10-07
+
+### Added
+
+- *(node)* [**breaking**] Implement peer discovery based on node type ([#761](https://github.com/eigerco/lumina/pull/761))
+
 ## [0.16.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.15.2...lumina-node-v0.16.0) - 2025-09-25
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.14.0...celestia-rpc-v0.14.1) - 2025-10-07
+
+### Other
+
+- updated the following local packages: celestia-types
+
 ## [0.14.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.13.0...celestia-rpc-v0.14.0) - 2025-09-25
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.16.0...celestia-types-v0.17.0) - 2025-10-07
+
+### Fixed
+
+- *(types,grpc)* [**breaking**] Address::from_account_verifying_key spelling #764
+
 ## [0.16.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.15.0...celestia-types-v0.16.0) - 2025-09-25
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION



## 🤖 New release

* `celestia-types`: 0.16.0 -> 0.17.0 (⚠ API breaking changes)
* `lumina-node`: 0.16.0 -> 0.17.0 (⚠ API breaking changes)
* `celestia-grpc`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `celestia-client`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `celestia-rpc`: 0.14.0 -> 0.14.1
* `lumina-cli`: 0.10.0 -> 0.10.1
* `lumina-node-wasm`: 0.11.0 -> 0.11.1
* `lumina-node-uniffi`: 0.4.0 -> 0.4.1

### ⚠ `celestia-types` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  Address::from_account_veryfing_key, previously in file /tmp/.tmpso3XOG/celestia-types/src/state/address.rs:74
  Address::from_validator_veryfing_key, previously in file /tmp/.tmpso3XOG/celestia-types/src/state/address.rs:79
  Address::from_consensus_veryfing_key, previously in file /tmp/.tmpso3XOG/celestia-types/src/state/address.rs:84
```

### ⚠ `lumina-node` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PeerTrackerInfo.num_connected_full_nodes in /tmp/.tmplyczEy/lumina/node/src/peer_tracker.rs:42
  field PeerTrackerInfo.num_connected_archival_nodes in /tmp/.tmplyczEy/lumina/node/src/peer_tracker.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-types`

<blockquote>

## [0.17.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.16.0...celestia-types-v0.17.0) - 2025-10-07

### Fixed

- *(types,grpc)* [**breaking**] Address::from_account_verifying_key spelling #764
</blockquote>

## `lumina-node`

<blockquote>

## [0.17.0](https://github.com/eigerco/lumina/compare/lumina-node-v0.16.0...lumina-node-v0.17.0) - 2025-10-07

### Added

- *(node)* [**breaking**] Implement peer discovery based on node type ([#761](https://github.com/eigerco/lumina/pull/761))
</blockquote>

## `celestia-grpc`

<blockquote>

## [0.9.0](https://github.com/eigerco/lumina/compare/celestia-grpc-v0.8.0...celestia-grpc-v0.9.0) - 2025-10-07

### Fixed

- *(types,grpc)* [**breaking**] Address::from_account_verifying_key spelling #764
</blockquote>

## `celestia-client`

<blockquote>

## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-client-v0.2.0...celestia-client-v0.3.0) - 2025-10-07

### Fixed

- *(client)* [**breaking**] use AsyncGrpcCall also in BlobApi::submit ([#760](https://github.com/eigerco/lumina/pull/760))
</blockquote>

## `celestia-rpc`

<blockquote>

## [0.14.1](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.14.0...celestia-rpc-v0.14.1) - 2025-10-07

### Other

- updated the following local packages: celestia-types
</blockquote>

## `lumina-cli`

<blockquote>

## [0.10.1](https://github.com/eigerco/lumina/compare/lumina-cli-v0.10.0...lumina-cli-v0.10.1) - 2025-10-07

### Other

- updated the following local packages: celestia-types, lumina-node, celestia-rpc
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [0.11.1](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.11.0...lumina-node-wasm-v0.11.1) - 2025-10-07

### Other

- updated the following local packages: celestia-types, lumina-node, celestia-grpc, celestia-rpc
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [0.4.1](https://github.com/eigerco/lumina/compare/lumina-node-uniffi-v0.4.0...lumina-node-uniffi-v0.4.1) - 2025-10-07

### Other

- updated the following local packages: celestia-types, lumina-node, celestia-grpc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).