### PR TITLE
chore: set permissions for the 'ci' workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 # Automatically cancels a job if a new commit is pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
 concurrency:
@@ -195,6 +198,7 @@ jobs:
 
   build-ios:
     runs-on: macos-latest
+
     steps:
     - uses: actions/checkout@v4
 
@@ -263,6 +267,7 @@ jobs:
 
   build-android:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v4
 
@@ -303,6 +308,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v4
     - name: Run fmt
@@ -311,6 +317,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v4
 
@@ -337,6 +344,7 @@ jobs:
 
   unused-deps:
     runs-on: ubuntu-latest
+
     name: unused dependencies
     steps:
     - name: Checkout sources
@@ -358,6 +366,7 @@ jobs:
 
   minimal-versions:
     runs-on: ubuntu-latest
+
     name: minimal versions of dependencies
     steps:
     - uses: actions/checkout@v4
@@ -438,6 +447,7 @@ jobs:
 
   required:
     runs-on: ubuntu-latest
+
     name: Required checks
     if: ${{ !cancelled() }}
     needs:


### PR DESCRIPTION
Explicitly request only read permissions to adhere to principle of least privilige