### PR TITLE
chore!: Fix typos, grammar in comments, types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Supported features:
 - Backward and forward Data Availability Sampling
 - Native and browser persistent storage
 - Streaming events happening on the node
-- Native, wasm and uniffi libraries, embed the node anywhere
+- Native, Wasm and UniFFI libraries, embed the node anywhere
 - Integration tests with Go implementation
 
 ## Installing the node
@@ -123,7 +123,7 @@ For security reasons, browsers only allow WebTransport to be used in [Secure Con
 ## Running Go Celestia node for integration
 
 Follow [this guide](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
-to authorize yourself in github's container registry.
+to authorize yourself in GitHub's container registry.
 
 Starting a Celestia network with single validator and some DA nodes
 ```bash
@@ -167,7 +167,7 @@ cargo test
 
 ## Frontend
 
-Check out the front end at [eigerco/lumina-front](https://github.com/eigerco/lumina-front)
+Check out the frontend at [eigerco/lumina-front](https://github.com/eigerco/lumina-front)
 
 ## About Eiger
 

--- a/node/src/daser.rs
+++ b/node/src/daser.rs
@@ -165,7 +165,7 @@ impl Daser {
 
     /// Stop the worker.
     pub(crate) fn stop(&self) {
-        // Singal the Worker to stop.
+        // Signal the Worker to stop.
         self.cancellation_token.cancel();
     }
 
@@ -426,7 +426,7 @@ where
     }
 
     async fn schedule_next_sample_block(&mut self) -> Result<bool> {
-        // Schedule the most recent un-sampled block.
+        // Schedule the most recent unsampled block.
         let header = loop {
             let Some(height) = self.queue.pop_head() else {
                 return Ok(false);
@@ -496,7 +496,7 @@ where
         let event_pub = self.event_pub.clone();
         let sampling_window = self.sampling_window;
 
-        // Schedule retrival of the CIDs. This will be run later on in the `select!` loop.
+        // Schedule retrieval of the CIDs. This will be run later on in the `select!` loop.
         let fut = async move {
             let now = Instant::now();
 
@@ -939,7 +939,7 @@ mod tests {
         // Concurrency limit
         let concurrency_limit = 10;
         // Additional concurrency limit for heads.
-        // In other words concurrency limit becames 15.
+        // In other words concurrency limit becomes 15.
         let additional_headersub_concurrency = 5;
         // Default number of shares that ExtendedHeaderGenerator
         // generates per block.
@@ -974,7 +974,7 @@ mod tests {
         // Concurrency limit reached
         handle.expect_no_cmd().await;
 
-        // However a new head will be allowed because additional limit is applied
+        // However, a new head will be allowed because additional limit is applied
         store.insert(generator.next_many_verified(2)).await.unwrap();
 
         for _ in 0..shares_per_block {
@@ -1001,7 +1001,7 @@ mod tests {
         // Generate 5 more heads
         for _ in 0..additional_headersub_concurrency {
             store.insert(generator.next_many_verified(1)).await.unwrap();
-            // Give some time for Daser to shedule it
+            // Give some time for Daser to schedule it
             sleep(Duration::from_millis(10)).await;
         }
 
@@ -1072,7 +1072,7 @@ mod tests {
         handle.expect_no_cmd().await;
         handle.announce_peer_connected();
 
-        // Blocks that are currently stored are ratelimited, so we shouldn't get any command.
+        // Blocks that are currently stored are rate-limited, so we shouldn't get any command.
         handle.expect_no_cmd().await;
 
         // Any blocks above 1000 are not limited because they are not in prunable area
@@ -1095,10 +1095,10 @@ mod tests {
         )
         .await;
 
-        // Again back to ratelimited
+        // Again back to rate-limited
         handle.expect_no_cmd().await;
 
-        // Now Pruner reports that number of prunable blocks is lower that the threshold
+        // Now Pruner reports that number of prunable blocks is lower than the threshold
         daser
             .update_number_of_prunable_blocks(PRUNER_THRESHOLD - 1)
             .await
@@ -1143,7 +1143,7 @@ mod tests {
         )
         .await;
 
-        // Daser is ratelimited again
+        // Daser is rate-limited again
         handle.expect_no_cmd().await;
     }
 

--- a/node/src/events.rs
+++ b/node/src/events.rs
@@ -485,7 +485,7 @@ fn serialize_system_time<S>(value: &SystemTime, serializer: S) -> Result<S::Ok, 
 where
     S: serde::ser::Serializer,
 {
-    // Javascript expresses time as f64 and in milliseconds.
+    // JavaScript expresses time as f64 and in milliseconds.
     let js_time = value
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("SystemTime is before 1970")

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -402,7 +402,7 @@ where
             .await?;
 
         // We want to immediately remove the sample from blockstore
-        // but **only if** it wasn't chosen for DASing. Otherwise we could
+        // but **only if** it wasn't chosen for DASing. Otherwise, we could
         // accidentally remove samples needed for the block reconstruction.
         //
         // There's a small possibility of permanently storing this sample if

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -2,7 +2,7 @@
 //!
 //! It is a high level integration of various p2p protocols used by Celestia nodes.
 //! Currently supporting:
-//! - libp2p-identitfy
+//! - libp2p-identify
 //! - libp2p-kad
 //! - libp2p-autonat
 //! - libp2p-ping
@@ -112,7 +112,7 @@ pub enum P2pError {
     #[error("Bitswap: {0}")]
     Bitswap(#[from] beetswap::Error),
 
-    /// ProtoBuf message failed to be decoded.
+    /// Protobuf message failed to be decoded.
     #[error("ProtoBuf decoding error: {0}")]
     ProtoDecodeFailed(#[from] tendermint_proto::Error),
 
@@ -326,7 +326,7 @@ impl P2p {
 
     /// Stop the worker.
     pub fn stop(&self) {
-        // Singal the Worker to stop.
+        // Signal the Worker to stop.
         self.cancellation_token.cancel();
     }
 

--- a/node/src/p2p/header_ex/client.rs
+++ b/node/src/p2p/header_ex/client.rs
@@ -375,7 +375,7 @@ where
                     }
                 }
 
-                // Otherwise return the header with the maximum height
+                // Otherwise, return the header with the maximum height
                 let resp = resps.into_iter().next().expect("no responses");
                 TaskResult::Head(Some(Box::new(resp)))
             }
@@ -487,9 +487,9 @@ where
             }
         }
 
-        // If we have pending requests then initialize interval.
+        // If we have requests pending, initialize interval.
         //
-        // We use this mechanism to give some buffer for more requests to
+        // We use this mechanism to give a time buffer for more requests to
         // be accumulated and avoid calling `schedule_pending_requests` on
         // each iteration.
         if self.schedule_pending_interval.is_none() && self.has_pending_requests() {
@@ -1616,7 +1616,7 @@ mod tests {
         handler.on_send_request(HeaderRequest::with_origin(5, 1), tx);
         assert!(handler.has_pending_requests());
 
-        // Try poll without peers
+        // Try to poll without peers
         let ev = poll_client(&mut handler, &mut mock_req, &empty_peer_tracker).await;
         // `SchedulePendingRequests` is generated when there are pending requests.
         // Since we have no peers, the requests are still pending.
@@ -1675,7 +1675,7 @@ mod tests {
         handler.on_send_request(HeaderRequest::head_request(), tx);
         assert!(handler.has_pending_requests());
 
-        // Try poll without peers
+        // Try to poll without peers
         let ev = poll_client(&mut handler, &mut mock_req, &empty_peer_tracker).await;
         assert!(matches!(ev, Event::NeedTrustedPeers));
         assert!(handler.has_pending_requests());

--- a/node/src/p2p/header_ex/server.rs
+++ b/node/src/p2p/header_ex/server.rs
@@ -418,7 +418,7 @@ mod tests {
         )
     }
 
-    // helper which waits for result over the test channel, while continously polling the handler.
+    // helper which waits for result over the test channel, while continuously polling the handler.
     async fn poll_handler_for_result<S>(
         handler: &mut HeaderExServerHandler<S, TestResponseSender>,
         response_sender: &mut TestResponseSender,

--- a/node/src/p2p/shwap.rs
+++ b/node/src/p2p/shwap.rs
@@ -92,7 +92,7 @@ pub(crate) fn convert_cid<const S: usize>(cid: &CidGeneric<S>) -> Result<Cid> {
     )))
 }
 
-/// extracts the `container` part from shwaps `Block` wrapper if the cid matches expected one
+/// Extracts the `container` part from shwap's `Block` wrapper if its CID matches the expected one
 pub(crate) fn get_block_container(expected_cid: &Cid, block: &[u8]) -> Result<Vec<u8>> {
     let block = Block::decode(block)?;
     let block_cid = Cid::read_bytes(block.cid.as_slice())?;

--- a/node/src/p2p/swarm.rs
+++ b/node/src/p2p/swarm.rs
@@ -42,7 +42,7 @@ mod imp {
         //
         // Similarly, if node is started when there's no Internet connection,
         // it won't use the DNS servers offered when Internet connectivity
-        // is restored. Instead we per-define globally-accessible public DNS servers.
+        // is restored. Instead, we per-define globally-accessible public DNS servers.
         let dns_config = dns::ResolverConfig::cloudflare();
 
         let noise_config =
@@ -122,7 +122,7 @@ mod imp {
     async fn read_tls_key(path: impl AsRef<Path>) -> Result<PrivateKeyDer<'static>, P2pError> {
         let path = path.as_ref();
 
-        // TODO: read key in a preallocated memory and zero it after use
+        // TODO: read key in a pre-allocated memory and zero it after use
         let data = fs::read(&path)
             .await
             .map_err(|e| P2pError::TlsInit(format!("{}: {e}", path.display())))?;

--- a/node/src/peer_tracker.rs
+++ b/node/src/peer_tracker.rs
@@ -215,7 +215,7 @@ impl PeerTracker {
     ///
     /// Tag allows having different reasons for protection without interfering with one another.
     ///
-    /// Returns `true` if peer changes from unprotected state to protected.
+    /// Returns `true` if the peer changes state from unprotected to protected.
     pub(crate) fn protect(&mut self, peer_id: &PeerId, tag: u32) -> bool {
         let peer = self
             .peers
@@ -235,7 +235,7 @@ impl PeerTracker {
     ///
     /// Tag allows having different reasons for protection without interfering with one another.
     ///
-    /// Returns `true` if peer changes from protected state to unprotected.
+    /// Returns `true` if the peer changes state from protected to unprotected.
     pub(crate) fn unprotect(&mut self, peer_id: &PeerId, tag: u32) -> bool {
         let Some(peer) = self.peers.get_mut(peer_id) else {
             return false;
@@ -589,7 +589,7 @@ mod tests {
         assert!(!tracker.unprotect(&peer_id, 0));
         assert_eq!(tracker.protected_len(0), 0);
 
-        // Now state changed from unprotected to protected
+        // Now the state changes from unprotected to protected
         assert!(!tracker.is_protected_with_tag(&peer_id, 0));
         assert!(tracker.protect(&peer_id, 0));
         assert!(tracker.is_protected(&peer_id));

--- a/node/src/pruner.rs
+++ b/node/src/pruner.rs
@@ -96,7 +96,7 @@ impl Pruner {
 
     /// Stop the worker.
     pub(crate) fn stop(&self) {
-        // Singal the Worker to stop.
+        // Signal the Worker to stop.
         self.cancellation_token.cancel();
     }
 
@@ -141,7 +141,7 @@ struct Cache {
 
     /// Cached `BlockInfo`.
     block_info: HashMap<u64, BlockInfo>,
-    /// Blocks that we need need to keep their `BlockInfo`.
+    /// Blocks that we need to keep their `BlockInfo`.
     keep_block_info: HashSet<u64>,
 }
 

--- a/node/src/store.rs
+++ b/node/src/store.rs
@@ -138,16 +138,16 @@ pub trait Store: Send + Sync + Debug {
     /// Insert a range of headers into the store.
     ///
     /// New insertion should pass all the constraints in [`BlockRanges::check_insertion_constraints`],
-    /// additionaly it should be [`ExtendedHeader::verify`]ed against neighbor headers.
+    /// additionally it should be [`ExtendedHeader::verify`]ed against neighbour headers.
     async fn insert<R>(&self, headers: R) -> Result<()>
     where
         R: TryInto<VerifiedExtendedHeaders> + Send,
         <R as TryInto<VerifiedExtendedHeaders>>::Error: Display;
 
-    /// Returns a list of header ranges currenty held in store.
+    /// Returns a list of header ranges currently held in store.
     async fn get_stored_header_ranges(&self) -> Result<BlockRanges>;
 
-    /// Returns a list of blocks that were sampled and their header is currenty held in store.
+    /// Returns a list of blocks that were sampled and their header is currently held in store.
     async fn get_sampled_ranges(&self) -> Result<BlockRanges>;
 
     /// Returns a list of headers that were pruned until now.
@@ -207,8 +207,8 @@ pub enum StoreInsertionError {
     NeighborsVerificationFailed(String),
 
     /// Store constraints are not met.
-    #[error("Contraints not met: {0}")]
-    ContraintsNotMet(BlockRangesError),
+    #[error("Constraints not met: {0}")]
+    ConstraintsNotMet(BlockRangesError),
 
     // TODO: Same hash for two different heights is not really possible
     // and `ExtendedHeader::validate` would return an error.
@@ -557,7 +557,7 @@ mod tests {
         s.insert(header101.clone()).await.unwrap();
 
         let error = match s.insert(header101).await {
-            Err(StoreError::InsertionFailed(StoreInsertionError::ContraintsNotMet(e))) => e,
+            Err(StoreError::InsertionFailed(StoreInsertionError::ConstraintsNotMet(e))) => e,
             res => panic!("Invalid result: {res:?}"),
         };
 
@@ -585,7 +585,7 @@ mod tests {
         let header30 = generator.next_of(&header29);
 
         let error = match s.insert(header30).await {
-            Err(StoreError::InsertionFailed(StoreInsertionError::ContraintsNotMet(e))) => e,
+            Err(StoreError::InsertionFailed(StoreInsertionError::ConstraintsNotMet(e))) => e,
             res => panic!("Invalid result: {res:?}"),
         };
         assert_eq!(error, BlockRangesError::BlockRangeOverlap(30..=30, 30..=30));

--- a/node/src/store/in_memory_store.rs
+++ b/node/src/store/in_memory_store.rs
@@ -193,7 +193,7 @@ impl InMemoryStoreInner {
         let (prev_exists, next_exists) = self
             .header_ranges
             .check_insertion_constraints(&headers_range)
-            .map_err(StoreInsertionError::ContraintsNotMet)?;
+            .map_err(StoreInsertionError::ConstraintsNotMet)?;
 
         // header range is already internally verified against itself in `P2p::get_unverified_header_ranges`
         self.verify_against_neighbours(prev_exists.then_some(head), next_exists.then_some(tail))?;

--- a/node/src/store/indexed_db_store.rs
+++ b/node/src/store/indexed_db_store.rs
@@ -24,10 +24,10 @@ use crate::store::utils::VerifiedExtendedHeaders;
 use crate::store::{Result, SamplingMetadata, Store, StoreError, StoreInsertionError};
 use crate::utils::{NamedLock, NamedLockError};
 
-/// indexeddb version, needs to be incremented on every schema schange
+/// IndexedDB version, needs to be incremented on every schema change
 const DB_VERSION: u32 = 5;
 
-// Data stores (SQL table analogue) used in IndexedDb
+// Data stores (SQL table analogue) used in IndexedDB
 const HEADER_STORE_NAME: &str = "headers";
 const SAMPLING_STORE_NAME: &str = "sampling";
 const RANGES_STORE_NAME: &str = "ranges";
@@ -585,7 +585,7 @@ async fn verify_against_neighbours(
 }
 
 /// Get schema version from the db, or perform a heuristic to try to determine
-/// version used (for verisons <4).
+/// version used (for versions <4).
 async fn detect_schema_version(db: &Rexie) -> Result<Option<u32>> {
     let tx = db.transaction(
         &[HEADER_STORE_NAME, RANGES_STORE_NAME, SCHEMA_STORE_NAME],
@@ -706,7 +706,7 @@ async fn insert_tx_op(
     let headers_range = head.height().value()..=tail.height().value();
     let (prev_exists, next_exists) = header_ranges
         .check_insertion_constraints(&headers_range)
-        .map_err(StoreInsertionError::ContraintsNotMet)?;
+        .map_err(StoreInsertionError::ConstraintsNotMet)?;
 
     // header range is already internally verified against itself in `P2p::get_unverified_header_ranges`
     verify_against_neighbours(
@@ -921,13 +921,13 @@ async fn migrate_v4_to_v5(db: &Rexie) -> Result<()> {
     let schema_store = tx.store(SCHEMA_STORE_NAME)?;
     let ranges_store = tx.store(RANGES_STORE_NAME)?;
 
-    // There are two chages in v5:
+    // There are two changes in v5:
     //
     // * Removal of `SamplingStatus` in `SamplingMetadata`
     // * Rename of sampled ranges database key
     //
     // For the first one we don't need to take any actions because it will
-    // be ingored by the deserializer.
+    // be ignored by the deserializer.
     let sampled_ranges = get_ranges(&ranges_store, v4::SAMPLED_RANGES_KEY).await?;
     set_ranges(&ranges_store, SAMPLED_RANGES_KEY, &sampled_ranges).await?;
     ranges_store
@@ -1121,9 +1121,9 @@ pub mod tests {
 
         const PREVIOUS_DB_VERSION: u32 = 1;
 
-        // this fn sets upt the store manually with v1 schema (original, ExtendedHeader only),
-        // and fills it with `hs` headers. It is a caller responsibility to make sure provided
-        // headers are correct and in order.
+        // Set up the store manually with v1 schema (original, ExtendedHeader only), and fill
+        // it with `hs` headers. It is a caller responsibility to make sure provided headers
+        // are correct and in order.
         async fn init_store(name: &str, hs: Vec<ExtendedHeader>) {
             let rexie = Rexie::builder(name)
                 .version(PREVIOUS_DB_VERSION)
@@ -1226,7 +1226,7 @@ pub mod tests {
         async fn migration_test() {
             let store_name = new_indexed_db_store_name().await;
 
-            // Prepare store
+            // Prepare the store
             init_store(&store_name).await;
 
             // Migrate and check

--- a/node/src/store/redb_store.rs
+++ b/node/src/store/redb_store.rs
@@ -69,7 +69,7 @@ impl RedbStore {
         RedbStore::new(Arc::new(db)).await
     }
 
-    /// Open an in memory [`redb`] store.
+    /// Open an in-memory [`redb`] store.
     pub async fn in_memory() -> Result<Self> {
         let db = Database::builder()
             .create_with_backend(redb::backends::InMemoryBackend::new())
@@ -176,7 +176,7 @@ impl RedbStore {
 
     /// Execute a write transaction.
     ///
-    /// If closure returns an error the transaction is aborted, otherwise commited.
+    /// If closure returns an error the transaction is aborted, otherwise committed.
     async fn write_tx<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&mut WriteTransaction) -> Result<T> + Send + 'static,
@@ -297,7 +297,7 @@ impl RedbStore {
 
             let (prev_exists, next_exists) = header_ranges
                 .check_insertion_constraints(&headers_range)
-                .map_err(StoreInsertionError::ContraintsNotMet)?;
+                .map_err(StoreInsertionError::ConstraintsNotMet)?;
 
             verify_against_neighbours(
                 &headers_table,
@@ -829,13 +829,13 @@ fn migrate_v2_to_v3(
     debug_assert_eq!(version, 2);
     warn!("Migrating DB schema from v2 to v3");
 
-    // There are two chages in v3:
+    // There are two changes in v3:
     //
     // * Removal of `SamplingStatus` in `SamplingMetadata`
     // * Rename of sampled ranges database key
     //
     // For the first one we don't need to take any actions because it will
-    // be ingored by the deserializer.
+    // be ignored by the deserializer.
     let mut ranges_table = tx.open_table(RANGES_TABLE)?;
     let sampled_ranges = get_ranges(&ranges_table, v2::SAMPLED_RANGES_KEY)?;
     set_ranges(&mut ranges_table, SAMPLED_RANGES_KEY, &sampled_ranges)?;

--- a/node/src/store/utils.rs
+++ b/node/src/store/utils.rs
@@ -42,7 +42,7 @@ impl AsRef<[ExtendedHeader]> for VerifiedExtendedHeaders {
     }
 }
 
-/// 1-length hedaer span is internally verified, this is valid
+/// 1-length header span is internally verified, this is valid
 impl From<[ExtendedHeader; 1]> for VerifiedExtendedHeaders {
     fn from(value: [ExtendedHeader; 1]) -> Self {
         Self(value.into())

--- a/node/src/syncer.rs
+++ b/node/src/syncer.rs
@@ -148,7 +148,7 @@ where
 
     /// Stop the worker.
     pub(crate) fn stop(&self) {
-        // Singal the Worker to stop.
+        // Signal the Worker to stop.
         self.cancellation_token.cancel();
     }
 
@@ -962,7 +962,7 @@ mod tests {
         p2p_mock.announce_new_head(headers.last().unwrap().clone());
         assert_syncing(&syncer, &store, &[1..=2017], 3001).await;
 
-        // Syncer continues syncing forwads (batch 2)
+        // Syncer continues syncing forwards (batch 2)
         handle_session_batch(&mut p2p_mock, &headers, 2018..=2529, true).await;
         assert_syncing(&syncer, &store, &[1..=2529], 3001).await;
 
@@ -1005,7 +1005,7 @@ mod tests {
         syncer.trigger_fetch_next_batch().await.unwrap();
         p2p_mock.expect_no_cmd().await;
 
-        // After marking the 1st and more than of the 2nd batch, syncer
+        // After marking the 1st and more than of the 2nd batch, Syncer
         // will finally request the 3rd batch.
         for height in 1250..=2048 {
             // Simulate Daser
@@ -1153,7 +1153,7 @@ mod tests {
         // Announce a trusted peer.
         p2p_mock.announce_trusted_peer_connected();
 
-        // Now syncer will send request for HEAD.
+        // Now Syncer will send request for HEAD.
         let (height, amount, respond_to) = p2p_mock.expect_header_request_for_height_cmd().await;
         assert_eq!(height, 0);
         assert_eq!(amount, 1);
@@ -1210,7 +1210,7 @@ mod tests {
         // Announce a trusted peer.
         p2p_mock.announce_trusted_peer_connected();
 
-        // Now syncer will send request for HEAD.
+        // Now Syncer will send request for HEAD.
         let (height, amount, respond_to) = p2p_mock.expect_header_request_for_height_cmd().await;
         assert_eq!(height, 0);
         assert_eq!(amount, 1);
@@ -1254,7 +1254,7 @@ mod tests {
         // Syncer requests missing headers again
         handle_session_batch(&mut p2p_mock, &headers, 1..=19, true).await;
 
-        // With a correct resposne, syncer should update the store
+        // With a correct response, Syncer should update the store
         assert_syncing(&syncer, &store, &[1..=20], 20).await;
     }
 
@@ -1275,7 +1275,7 @@ mod tests {
         // Syncer requests missing headers again
         handle_session_batch(&mut p2p_mock, &headers, 1..=19, true).await;
 
-        // With a correct resposne, syncer should update the store
+        // With a correct response, Syncer should update the store
         assert_syncing(&syncer, &store, &[1..=20], 20).await;
     }
 
@@ -1536,7 +1536,7 @@ mod tests {
             // if we have to do more requests than our concurrency limit anyway
             max_requests
         } else {
-            // otherwise we can handle batch fully concurrent
+            // otherwise, we can handle batch fully concurrent
             header_session::MAX_CONCURRENT_REQS.min(min_requests)
         }
     }


### PR DESCRIPTION
Notably, fix `StoreInsertionError::ConstraintsNotMet` spelling