### PR TITLE
[WIP] chore: upgrade getrandom, rand & remove old getrandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
  "celestia-rpc",
  "celestia-types",
  "futures-util",
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "hex",
  "http",
  "http-body",
@@ -814,7 +814,7 @@ dependencies = [
  "celestia-types",
  "dyn-clone",
  "futures",
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "gloo-timers 0.3.0",
  "hex",
  "http",
@@ -884,7 +884,7 @@ dependencies = [
  "celestia-types",
  "dotenvy",
  "futures-util",
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "gloo-net",
  "gloo-timers 0.3.0",
  "http",
@@ -922,7 +922,7 @@ dependencies = [
  "const_format",
  "ed25519-consensus",
  "enum_dispatch",
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "indoc",
  "js-sys",
  "k256",
@@ -1872,21 +1872,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
@@ -2617,7 +2617,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -3482,7 +3482,7 @@ dependencies = [
  "dashmap",
  "either",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "gloo-timers 0.3.0",
  "idb",
  "integer-encoding",
@@ -3693,7 +3693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.59.0",
 ]
 
@@ -4478,7 +4478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -4583,7 +4583,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -5466,7 +5466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.0",
@@ -6152,7 +6152,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6199,15 +6199,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,8 @@ futures-util = "0.3"
 # we don't depend on `getrandom` directly, but it requires additional actions
 # to build for wasm32, thus we need to specify it and enable certain features
 # and set `rustflags` in `.cargo/config.toml`.
-# See <https://docs.rs/getrandom/0.3.3/getrandom/#webassembly-support>
-# libp2p 0.56 has dependency on both rand 0.8.5 and 0.9.2, which means we need both
-getrandom_02 = { package = "getrandom", version = "0.2.10", features = ["js"] }
-getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+# See <https://docs.rs/getrandom/0.3.4/getrandom/#webassembly-support>
+getrandom_03 = { package = "getrandom", version = "0.3.4", features = ["wasm_js"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 hex = "0.4.3"
 http = "1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -47,7 +47,7 @@ tonic = { workspace = true, features = ["transport"] }
 celestia-grpc = { workspace = true, features = ["wasm-bindgen"] }
 celestia-rpc = { workspace = true, features = ["wasm-bindgen"] }
 celestia-types = { workspace = true, features = ["wasm-bindgen"] }
-getrandom_02.workspace = true
+getrandom_03.workspace = true
 tonic-web-wasm-client.workspace = true
 
 [dev-dependencies]

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -57,7 +57,7 @@ tokio = { workspace = true, features = ["time"] }
 tonic = { workspace = true, features = ["transport"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom_02.workspace = true
+getrandom_03.workspace = true
 gloo-timers.workspace = true
 js-sys = { workspace = true, optional = true }
 send_wrapper.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -68,7 +68,7 @@ libp2p = { workspace = true, features = [
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-getrandom_02.workspace = true
+getrandom_03.workspace = true
 rust-embed = { workspace = true, features = ["debug-embed", "include-exclude", "interpolate-folder-path"] }
 wasm-bindgen-test.workspace = true
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -43,7 +43,7 @@ uniffi = { workspace = true, optional = true }
 k256.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom_02.workspace = true
+getrandom_03.workspace = true
 lumina-utils = { workspace = true, features = ["make-object"] }
 
 js-sys = { workspace = true, optional = true }


### PR DESCRIPTION
### Summary of Changes

- All direct uses now point to getrandom 0.3.4 via the getrandom_03 workspace alias, and rand is centralized in the workspace.
- There are no explicit getrandom = "0.2" entries in any Cargo.toml.
- Current tendermint/rand versions still depend on getrandom 0.2; bumping them alone won’t eliminate it.

Resolves #782 