### PR TITLE
feat: use plaintext key for validator

### DIFF
--- a/ci/run-validator.sh
+++ b/ci/run-validator.sh
@@ -93,7 +93,7 @@ create_or_import_key() {
   fi
 
   # otherwise, just import it
-  echo "password" | celestia-appd keys import "$node_name" "$key_file" \
+  celestia-appd keys import-hex "$node_name" "$(cat "$plaintext_key_file")" \
     --keyring-backend "test"
 }
 


### PR DESCRIPTION
There exists a bug that prevents `celestia-app` correctly decrypting the encrypted test key (`validator-0.key`) using pre-defined password when running on MacOS in Docker (docker runs amd64 binaries using Rosetta2 translation layer which presumably has some problems when decrypting the key using AVX2 instructions, the problem goes away when we compile using `purego`). 

Easiest fix is to use the `.plaintext-key` which is already in the repo.