### PR TITLE
feat(proto): add tonic-server feature for optional gRPC server stub generation

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -41,5 +41,6 @@ serde_json.workspace = true
 
 [features]
 tonic = ["dep:tonic", "dep:tonic-build"]
+tonic-server = ["tonic"]
 uniffi = ["dep:uniffi"]
 wasm-bindgen  = ["dep:wasm-bindgen"]

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -280,7 +280,7 @@ fn tonic_build(fds: FileDescriptorSet) {
     let mut tonic_config = tonic_build::configure()
         .include_file("mod.rs")
         .build_client(true)
-        .build_server(false)
+        .build_server(cfg!(feature = "tonic-server"))
         .build_transport(false)
         .use_arc_self(true)
         .compile_well_known_types(true)


### PR DESCRIPTION
## Overview

PR #890 added server traits to the `rpc` crate, enabling tools like [localestia](https://github.com/celestiaorg/localestia) to implement JSON-RPC methods (`blob_submit`, `header_get`, etc.) with type-safe, lumina-compatible interfaces. This PR is the natural follow-up at the **gRPC layer**.

Currently, the `tonic` feature in `celestia-proto` generates client stubs only (`build_server(false)`). This is the right default — lumina's primary consumers are light clients that connect to Celestia consensus nodes and never serve gRPC traffic themselves.

However, the same tools that benefit from #890 also need to expose gRPC services. Localestia, for example, must implement the gRPC surface expected by `celestia-node`'s `txclient`: `GetNodeInfo`, `Account`, `BroadcastTx`, `TxStatus`, and `EstimateGasPriceAndUsage`. Without generated server traits, implementing these requires manually writing `tower::Service<http::Request<Body>>` for each service — bypassing tonic's type-safe traits entirely and making it easy to drift from the canonical proto definitions.

This PR adds a `tonic-server` feature that opts into server stub generation:

```toml
celestia-proto = { ..., features = ["tonic-server"] }
```

Enabling the standard tonic server pattern:

```rust
use celestia_proto::cosmos::tx::v1beta1::service_server::{Service, TxServiceServer};

#[tonic::async_trait]
impl Service for MyTxService { ... }
```

## Changes

- `proto/Cargo.toml`: add `tonic-server = ["tonic"]` feature
- `proto/build.rs`: `build_server(false)` → `build_server(cfg!(feature = "tonic-server"))`

## Breaking Changes

None. Existing consumers using the `tonic` feature are unaffected — server generation remains off by default.
