### PR TITLE
chore: release v1.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-stream",
  "blockstore",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "bytes",
  "prost",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3475,7 +3475,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-cli"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "blockstore",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "rsema1d"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "criterion",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,22 +16,22 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 edition = "2024"
 
 [workspace.dependencies]
 beetswap = "0.5"
 blockstore = "0.8"
 leopard-codec = "0.2"
-lumina-node = { version = "=1.0.0-rc.3", path = "node" }
-lumina-node-wasm = { version = "=1.0.0-rc.3", path = "node-wasm" }
-lumina-utils = { version = "=1.0.0-rc.3", path = "utils" }
-celestia-client = { version = "=1.0.0-rc.3", path = "client" }
-celestia-proto = { version = "=1.0.0-rc.3", path = "proto" }
-celestia-grpc = { version = "=1.0.0-rc.3", path = "grpc", default-features = false }
-celestia-grpc-macros = { version = "=1.0.0-rc.3", path = "grpc/grpc-macros" }
-celestia-rpc = { version = "=1.0.0-rc.3", path = "rpc", default-features = false }
-celestia-types = { version = "=1.0.0-rc.3", path = "types", default-features = false }
+lumina-node = { version = "=1.0.0-rc.4", path = "node" }
+lumina-node-wasm = { version = "=1.0.0-rc.4", path = "node-wasm" }
+lumina-utils = { version = "=1.0.0-rc.4", path = "utils" }
+celestia-client = { version = "=1.0.0-rc.4", path = "client" }
+celestia-proto = { version = "=1.0.0-rc.4", path = "proto" }
+celestia-grpc = { version = "=1.0.0-rc.4", path = "grpc", default-features = false }
+celestia-grpc-macros = { version = "=1.0.0-rc.4", path = "grpc/grpc-macros" }
+celestia-rpc = { version = "=1.0.0-rc.4", path = "rpc", default-features = false }
+celestia-types = { version = "=1.0.0-rc.4", path = "types", default-features = false }
 
 anyhow = "1.0.40"
 async-stream = "0.3.5"

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "1.0.0-rc.3",
+    "version": "1.0.0-rc.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "1.0.0-rc.3",
+            "version": "1.0.0-rc.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "1.0.0-rc.3",
+            "version": "1.0.0-rc.4",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Celestia <contact@celestia.org>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "1.0.0-rc.3",
+    "version": "1.0.0-rc.4",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.4](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0-rc.3...lumina-node-v1.0.0-rc.4) - 2026-04-03
+
+### Added
+
+- prepare for v8 release ([#949](https://github.com/celestiaorg/lumina/pull/949))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0-rc.2...lumina-node-v1.0.0-rc.3) - 2026-03-19
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `celestia-proto`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `lumina-utils`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `celestia-types`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `celestia-rpc`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `lumina-node`: 1.0.0-rc.3 -> 1.0.0-rc.4 (✓ API compatible changes)
* `lumina-cli`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `celestia-grpc-macros`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `celestia-grpc`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `celestia-client`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `lumina-node-wasm`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `lumina-node-uniffi`: 1.0.0-rc.3 -> 1.0.0-rc.4
* `rsema1d`: 1.0.0-rc.3 -> 1.0.0-rc.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-proto`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0-rc.2...celestia-proto-v1.0.0-rc.3) - 2026-03-19

### Added

- add tonic-server feature for server generation in tonic build ([#932](https://github.com/celestiaorg/lumina/pull/932))
- update protos from celestia-app ([#931](https://github.com/celestiaorg/lumina/pull/931))
</blockquote>

## `lumina-utils`

<blockquote>

## [1.0.0-rc.2](https://github.com/celestiaorg/lumina/compare/lumina-utils-v0.5.2...lumina-utils-v1.0.0-rc.2) - 2026-02-25

### Added

- simplified/unified release process ([#928](https://github.com/celestiaorg/lumina/pull/928))
</blockquote>

## `celestia-types`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0-rc.2...celestia-types-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `celestia-rpc`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-rpc-v1.0.0-rc.2...celestia-rpc-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `lumina-node`

<blockquote>

## [1.0.0-rc.4](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0-rc.3...lumina-node-v1.0.0-rc.4) - 2026-04-03

### Added

- prepare for v8 release ([#949](https://github.com/celestiaorg/lumina/pull/949))
</blockquote>

## `lumina-cli`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/lumina-cli-v1.0.0-rc.2...lumina-cli-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `celestia-grpc-macros`

<blockquote>

## [1.0.0-rc.2](https://github.com/celestiaorg/lumina/compare/celestia-grpc-macros-v0.7.0...celestia-grpc-macros-v1.0.0-rc.2) - 2026-02-25

### Added

- simplified/unified release process ([#928](https://github.com/celestiaorg/lumina/pull/928))
</blockquote>

## `celestia-grpc`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0-rc.2...celestia-grpc-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `celestia-client`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0-rc.2...celestia-client-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/lumina-node-wasm-v1.0.0-rc.2...lumina-node-wasm-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [1.0.0-rc.2](https://github.com/celestiaorg/lumina/compare/lumina-node-uniffi-v0.5.3...lumina-node-uniffi-v1.0.0-rc.2) - 2026-02-25

### Added

- simplified/unified release process ([#928](https://github.com/celestiaorg/lumina/pull/928))
</blockquote>

## `rsema1d`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0-rc.2...rsema1d-v1.0.0-rc.3) - 2026-03-19

### Added

- update rsema1d import path to celestia-app/v8/pkg/rsema1d ([#937](https://github.com/celestiaorg/lumina/pull/937))
- implement rsema1d ([#933](https://github.com/celestiaorg/lumina/pull/933))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).