### PR TITLE
feat: add fibre gRPC service client and account signer

### DIFF
--- a/grpc/src/boxed.rs
+++ b/grpc/src/boxed.rs
@@ -39,16 +39,25 @@ type BoxedError = Box<dyn StdError + Sync + Send + 'static>;
 type BoxedResponseFuture =
     Pin<Box<dyn ConditionalSendFuture<Output = Result<BoxedResponse, BoxedError>> + 'static>>;
 
-pub(crate) struct BoxedTransport {
+/// A type-erased gRPC transport that works on both native and wasm32.
+///
+/// On native, wraps a `tonic::transport::Channel`.
+/// On wasm32, wraps a `tonic_web_wasm_client::Client`.
+///
+/// Implements `Service<http::Request<TonicBody>>` so it can be passed directly
+/// to tonic-generated clients.
+pub struct BoxedTransport {
     inner: Box<dyn AbstractTransport + Send + Sync>,
     pub(crate) metadata: Arc<TransportMetadata>,
 }
 
-pub(crate) struct BoxedBody {
+/// Opaque response body type used by [`BoxedTransport`].
+pub struct BoxedBody {
     inner: Box<dyn AbstractBody + Unpin + Send + 'static>,
 }
 
-pub(crate) trait ConditionalSendFuture: Future + CondSend {}
+/// A future that is conditionally `Send` (via [`CondSend`]).
+pub trait ConditionalSendFuture: Future + CondSend {}
 
 trait AbstractBody {
     fn poll_frame_inner(

--- a/grpc/src/builder.rs
+++ b/grpc/src/builder.rs
@@ -15,11 +15,9 @@ use zeroize::Zeroizing;
 use crate::boxed::{BoxedTransport, TransportMetadata, boxed};
 use crate::client::AccountState;
 use crate::grpc::Context;
-use crate::signer::BoxedDocSigner;
+use crate::signer::{AccountSigner, BoxedDocSigner};
 use crate::utils::CondSend;
 use crate::{DocSigner, GrpcClient, GrpcClientBuilderError};
-
-use imp::build_transport;
 
 /// A URL endpoint with per-endpoint configuration.
 ///
@@ -252,6 +250,12 @@ impl GrpcClientBuilder {
         self.pubkey_and_signer(pubkey, signer)
     }
 
+    /// Add signer from an existing [`AccountSigner`].
+    pub fn account_signer(mut self, signer: AccountSigner) -> GrpcClientBuilder {
+        self.signer_kind = Some(SignerKind::Signer((signer.pubkey, signer.signer)));
+        self
+    }
+
     /// Set signer from a raw private key.
     pub fn private_key(mut self, bytes: &[u8]) -> GrpcClientBuilder {
         self.signer_kind = Some(SignerKind::PrivKeyBytes(Zeroizing::new(bytes.to_vec())));
@@ -291,7 +295,7 @@ impl GrpcClientBuilder {
                     let (url, endpoint_context) = endpoint.into_parts()?;
                     let mut context = base_context.clone();
                     context.extend(&endpoint_context);
-                    build_transport(url, context)
+                    imp::build_transport(url, context)
                 }
                 TransportEntry::BoxedTransport(mut transport) => {
                     let mut context = base_context.clone();

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -14,12 +14,22 @@ use celestia_grpc_macros::grpc_method;
 use celestia_proto::celestia::blob::v1::query_client::QueryClient as BlobQueryClient;
 use celestia_proto::celestia::core::v1::gas_estimation::gas_estimator_client::GasEstimatorClient;
 use celestia_proto::celestia::core::v1::tx::tx_client::TxClient as TxStatusClient;
+use celestia_proto::celestia::fibre::v1::fibre_client::FibreClient as FibreServiceClient;
+use celestia_proto::celestia::fibre::v1::{
+    DownloadShardResponse, UploadShardRequest, UploadShardResponse,
+};
+use celestia_proto::celestia::valaddr::v1::query_client::QueryClient as ValaddrQueryClient;
+use celestia_proto::celestia::valaddr::v1::{
+    QueryAllFibreProvidersResponse, QueryFibreProviderInfoResponse,
+};
 use celestia_proto::cosmos::auth::v1beta1::query_client::QueryClient as AuthQueryClient;
 use celestia_proto::cosmos::bank::v1beta1::query_client::QueryClient as BankQueryClient;
 use celestia_proto::cosmos::base::node::v1beta1::service_client::ServiceClient as ConfigServiceClient;
 use celestia_proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient as TendermintServiceClient;
 use celestia_proto::cosmos::staking::v1beta1::query_client::QueryClient as StakingQueryClient;
 use celestia_proto::cosmos::tx::v1beta1::service_client::ServiceClient as TxServiceClient;
+use celestia_proto::tendermint_celestia_mods::rpc::grpc::ValidatorSetResponse;
+use celestia_proto::tendermint_celestia_mods::rpc::grpc::block_api_client::BlockApiClient as FibreBlockApiClient;
 use celestia_types::blob::{BlobParams, MsgPayForBlobs, RawBlobTx, RawMsgPayForBlobs};
 use celestia_types::block::Block;
 use celestia_types::consts::appconsts;
@@ -280,6 +290,31 @@ impl GrpcClient {
         priority: TxPriority,
         tx_bytes: Vec<u8>,
     ) -> AsyncGrpcCall<GasEstimate>;
+
+    // fibre: consensus queries
+
+    /// Get fibre validator set at the given height (0 = latest).
+    #[grpc_method(FibreBlockApiClient::validator_set)]
+    fn get_fibre_validator_set(&self, height: i64) -> AsyncGrpcCall<ValidatorSetResponse>;
+
+    /// Get all fibre providers registered on-chain.
+    #[grpc_method(ValaddrQueryClient::all_fibre_providers)]
+    fn get_all_fibre_providers(&self) -> AsyncGrpcCall<QueryAllFibreProvidersResponse>;
+
+    /// Get fibre provider info for a single validator by bech32 consensus address.
+    #[grpc_method(ValaddrQueryClient::fibre_provider_info)]
+    fn get_fibre_provider_info(
+        &self,
+        address: String,
+    ) -> AsyncGrpcCall<QueryFibreProviderInfoResponse>;
+
+    /// Upload a shard to a validator.
+    #[grpc_method(FibreServiceClient::upload_shard)]
+    fn upload_shard(&self, request: UploadShardRequest) -> AsyncGrpcCall<UploadShardResponse>;
+
+    /// Download a shard from a validator.
+    #[grpc_method(FibreServiceClient::download_shard)]
+    fn download_shard(&self, blob_id: Vec<u8>) -> AsyncGrpcCall<DownloadShardResponse>;
 
     /// Submit given message to celestia network.
     ///

--- a/grpc/src/error.rs
+++ b/grpc/src/error.rs
@@ -1,4 +1,5 @@
 use celestia_types::hash::Hash;
+use celestia_types::state::AccAddress;
 use celestia_types::state::ErrorCode;
 use k256::ecdsa::signature::Error as SignatureError;
 use tonic::Status;
@@ -105,6 +106,10 @@ pub enum Error {
     /// Invalid parameter provided
     #[error("Invalid BroadcastedTx parameter provided: {0}")]
     InvalidBroadcastedTx(String),
+
+    /// No account registered for the given address
+    #[error("Unknown account: {0}")]
+    UnknownAccount(AccAddress),
 }
 
 /// Representation of all the errors that can occur when building [`GrpcClient`] using

--- a/grpc/src/grpc.rs
+++ b/grpc/src/grpc.rs
@@ -30,6 +30,8 @@ mod celestia_tx;
 mod blob;
 // cosmos.tx
 mod cosmos_tx;
+// fibre (BlockAPI + valaddr)
+mod fibre;
 
 pub use crate::grpc::celestia_tx::{TxStatus, TxStatusBatchResponse, TxStatusResponse};
 pub use crate::grpc::cosmos_tx::{BroadcastMode, GetTxResponse};

--- a/grpc/src/grpc/fibre.rs
+++ b/grpc/src/grpc/fibre.rs
@@ -1,0 +1,79 @@
+use celestia_proto::celestia::fibre::v1::{
+    DownloadShardRequest, DownloadShardResponse, UploadShardRequest, UploadShardResponse,
+};
+use celestia_proto::celestia::valaddr::v1::{
+    QueryAllFibreProvidersRequest, QueryAllFibreProvidersResponse, QueryFibreProviderInfoRequest,
+    QueryFibreProviderInfoResponse,
+};
+use celestia_proto::tendermint_celestia_mods::rpc::grpc::{
+    ValidatorSetRequest, ValidatorSetResponse,
+};
+
+use crate::Result;
+use crate::grpc::{FromGrpcResponse, IntoGrpcParam, make_empty_params};
+
+// BlockAPI — validator set
+
+impl IntoGrpcParam<ValidatorSetRequest> for i64 {
+    fn into_parameter(self) -> ValidatorSetRequest {
+        ValidatorSetRequest { height: self }
+    }
+}
+
+impl FromGrpcResponse<ValidatorSetResponse> for ValidatorSetResponse {
+    fn try_from_response(self) -> Result<ValidatorSetResponse> {
+        Ok(self)
+    }
+}
+
+// Valaddr — all fibre providers
+
+make_empty_params!(QueryAllFibreProvidersRequest);
+
+impl FromGrpcResponse<QueryAllFibreProvidersResponse> for QueryAllFibreProvidersResponse {
+    fn try_from_response(self) -> Result<QueryAllFibreProvidersResponse> {
+        Ok(self)
+    }
+}
+
+// Valaddr — single fibre provider info
+
+impl IntoGrpcParam<QueryFibreProviderInfoRequest> for String {
+    fn into_parameter(self) -> QueryFibreProviderInfoRequest {
+        QueryFibreProviderInfoRequest {
+            validator_consensus_address: self,
+        }
+    }
+}
+
+impl FromGrpcResponse<QueryFibreProviderInfoResponse> for QueryFibreProviderInfoResponse {
+    fn try_from_response(self) -> Result<QueryFibreProviderInfoResponse> {
+        Ok(self)
+    }
+}
+
+// Fibre service — upload/download shards
+
+impl IntoGrpcParam<UploadShardRequest> for UploadShardRequest {
+    fn into_parameter(self) -> UploadShardRequest {
+        self
+    }
+}
+
+impl FromGrpcResponse<UploadShardResponse> for UploadShardResponse {
+    fn try_from_response(self) -> Result<UploadShardResponse> {
+        Ok(self)
+    }
+}
+
+impl IntoGrpcParam<DownloadShardRequest> for Vec<u8> {
+    fn into_parameter(self) -> DownloadShardRequest {
+        DownloadShardRequest { blob_id: self }
+    }
+}
+
+impl FromGrpcResponse<DownloadShardResponse> for DownloadShardResponse {
+    fn try_from_response(self) -> Result<DownloadShardResponse> {
+        Ok(self)
+    }
+}

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -1,7 +1,8 @@
 #![doc = include_str!("../README.md")]
 
 mod abci_proofs;
-pub(crate) mod boxed;
+/// Boxed transport types for type-erased gRPC connections.
+pub mod boxed;
 mod builder;
 mod client;
 mod error;
@@ -16,12 +17,13 @@ mod tx_client_impl;
 pub mod tx_client_v2;
 #[cfg(all(not(target_arch = "wasm32"), feature = "uniffi"))]
 pub mod uniffi_client;
-mod utils;
+pub(crate) mod utils;
 
+pub use crate::boxed::BoxedTransport;
 pub use crate::builder::{Endpoint, GrpcClientBuilder};
 pub use crate::client::GrpcClient;
 pub use crate::error::{Error, GrpcClientBuilderError, Result};
-pub use crate::signer::DocSigner;
+pub use crate::signer::{AccountSigner, DocSigner};
 pub use crate::tx::{SignDoc, TxConfig, TxInfo};
 /// Warning: [`TransactionService`] is experimental and not recommended for use yet.
 pub use crate::tx_client_impl::{ConfirmHandle, TransactionService, TxServiceConfig};

--- a/grpc/src/signer.rs
+++ b/grpc/src/signer.rs
@@ -16,6 +16,8 @@ use celestia_proto::cosmos::crypto::secp256k1;
 use celestia_types::state::auth::BaseAccount;
 use celestia_types::state::{AuthInfo, Fee, ModeInfo, RawTx, RawTxBody, SignerInfo, Sum};
 
+use celestia_types::state::AccAddress;
+
 use crate::Result;
 
 /// ECDSA/secp256k1 signature used for signing transactions
@@ -84,6 +86,68 @@ where
 impl fmt::Debug for BoxedDocSigner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("BoxedDocSigner { .. }")
+    }
+}
+
+/// A signer bundling a verifying key and a signing implementation.
+///
+/// This type decouples signing from the gRPC transport layer, allowing a single
+/// [`GrpcClient`](crate::GrpcClient) connection to be shared without carrying account state.
+#[derive(Clone)]
+pub struct AccountSigner {
+    pub(crate) pubkey: VerifyingKey,
+    pub(crate) signer: BoxedDocSigner,
+}
+
+impl AccountSigner {
+    /// Create a new `AccountSigner` from a verifying key and a signer implementation.
+    pub fn new(pubkey: VerifyingKey, signer: impl DocSigner + 'static) -> Self {
+        Self {
+            pubkey,
+            signer: BoxedDocSigner::new(signer),
+        }
+    }
+
+    /// Create a new `AccountSigner` from a keypair that implements both signing and key extraction.
+    pub fn from_keypair(
+        signer: impl DocSigner + signature::Keypair<VerifyingKey = VerifyingKey> + 'static,
+    ) -> Self {
+        let pubkey = signer.verifying_key();
+        Self::new(pubkey, signer)
+    }
+
+    /// Create a new `AccountSigner` from raw private key bytes.
+    pub fn from_private_key(bytes: &[u8]) -> std::result::Result<Self, k256::ecdsa::Error> {
+        let signing_key = k256::ecdsa::SigningKey::from_slice(bytes)?;
+        let pubkey = *signing_key.verifying_key();
+        Ok(Self {
+            pubkey,
+            signer: BoxedDocSigner::new(signing_key),
+        })
+    }
+
+    /// Create a new `AccountSigner` from a hex-encoded private key.
+    pub fn from_private_key_hex(hex_str: &str) -> std::result::Result<Self, k256::ecdsa::Error> {
+        let bytes = hex::decode(hex_str.trim()).map_err(|_| k256::ecdsa::Error::new())?;
+        Self::from_private_key(&bytes)
+    }
+
+    /// Get a reference to the verifying key.
+    pub fn verifying_key(&self) -> &VerifyingKey {
+        &self.pubkey
+    }
+
+    /// Get the account address derived from the verifying key.
+    pub fn address(&self) -> AccAddress {
+        AccAddress::from(self.pubkey)
+    }
+}
+
+impl fmt::Debug for AccountSigner {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("AccountSigner")
+            .field("address", &self.address())
+            .finish_non_exhaustive()
     }
 }
 

--- a/grpc/src/utils.rs
+++ b/grpc/src/utils.rs
@@ -1,17 +1,3 @@
 //! Utilities for conditionally adding `Send` and `Sync` constraints.
 
-/// A conditionally compiled trait indirection for `Send` bounds.
-/// This target makes it require `Send`.
-#[cfg(not(target_arch = "wasm32"))]
-pub trait CondSend: Send {}
-
-/// A conditionally compiled trait indirection for `Send` bounds.
-/// This target makes it not require any marker traits.
-#[cfg(target_arch = "wasm32")]
-pub trait CondSend {}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<S> CondSend for S where S: Send {}
-
-#[cfg(target_arch = "wasm32")]
-impl<S> CondSend for S {}
+pub use lumina_utils::cond_send::CondSend;


### PR DESCRIPTION
## Summary
- Add fibre gRPC service client wrapper (`grpc/fibre.rs`) with upload/download shard methods and consensus queries (validator set, fibre providers)
- Introduce `AccountSigner` abstraction in `grpc/signer.rs` decoupling signing from gRPC transport
- Make `BoxedTransport` and `CondSend` public for use by downstream crates
- Update builder to accept `AccountSigner` directly

## Test plan
- [ ] `cargo build -p celestia-grpc` compiles
- [ ] `cargo build -p celestia-grpc --features tonic` compiles
- [ ] `cargo test -p celestia-grpc` passes
- [ ] Existing workspace tests pass

Part of the fibre PR split — Batch 2 (PR 3/10)