### PR TITLE
chore: release v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "blockstore",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "prost",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3474,7 +3474,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-cli"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blockstore",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "rsema1d"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,22 +16,22 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "2.0.0"
 edition = "2024"
 
 [workspace.dependencies]
 beetswap = "0.5"
 blockstore = "0.8"
 leopard-codec = "0.2"
-lumina-node = { version = "=1.0.0", path = "node" }
-lumina-node-wasm = { version = "=1.0.0", path = "node-wasm" }
-lumina-utils = { version = "=1.0.0", path = "utils" }
-celestia-client = { version = "=1.0.0", path = "client" }
-celestia-proto = { version = "=1.0.0", path = "proto" }
-celestia-grpc = { version = "=1.0.0", path = "grpc", default-features = false }
-celestia-grpc-macros = { version = "=1.0.0", path = "grpc/grpc-macros" }
-celestia-rpc = { version = "=1.0.0", path = "rpc", default-features = false }
-celestia-types = { version = "=1.0.0", path = "types", default-features = false }
+lumina-node = { version = "=2.0.0", path = "node" }
+lumina-node-wasm = { version = "=2.0.0", path = "node-wasm" }
+lumina-utils = { version = "=2.0.0", path = "utils" }
+celestia-client = { version = "=2.0.0", path = "client" }
+celestia-proto = { version = "=2.0.0", path = "proto" }
+celestia-grpc = { version = "=2.0.0", path = "grpc", default-features = false }
+celestia-grpc-macros = { version = "=2.0.0", path = "grpc/grpc-macros" }
+celestia-rpc = { version = "=2.0.0", path = "rpc", default-features = false }
+celestia-types = { version = "=2.0.0", path = "types", default-features = false }
 
 anyhow = "1.0.40"
 async-stream = "0.3.5"

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0...celestia-grpc-v2.0.0) - 2026-04-15
+
+### Added
+
+- add fibre gRPC service client and account signer ([#958](https://github.com/celestiaorg/lumina/pull/958))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0-rc.2...celestia-grpc-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-uniffi-v1.0.0...lumina-node-uniffi-v2.0.0) - 2026-04-15
+
+### Other
+
+- [**breaking**] remove iOS, Android, and uniffi binding CI jobs ([#960](https://github.com/celestiaorg/lumina/pull/960))
+
 ### Deprecated
 
 - iOS/Android CI jobs, release automation, and binary artifact builds have been removed ([#960](https://github.com/celestiaorg/lumina/pull/960)). The builds will be removed in future versions.

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Celestia <contact@celestia.org>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0...celestia-proto-v2.0.0) - 2026-04-15
+
+### Added
+
+- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0-rc.2...celestia-proto-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/rsema1d/CHANGELOG.md
+++ b/rsema1d/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0...rsema1d-v2.0.0) - 2026-04-15
+
+### Added
+
+- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0-rc.2...rsema1d-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0...celestia-types-v2.0.0) - 2026-04-15
+
+### Added
+
+- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0-rc.2...celestia-types-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-utils-v1.0.0...lumina-utils-v2.0.0) - 2026-04-15
+
+### Added
+
+- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
+
 ## [1.0.0-rc.2](https://github.com/celestiaorg/lumina/compare/lumina-utils-v0.5.2...lumina-utils-v1.0.0-rc.2) - 2026-02-25
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `celestia-proto`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
* `lumina-utils`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
* `celestia-types`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
* `celestia-rpc`: 1.0.0 -> 2.0.0
* `lumina-node`: 1.0.0 -> 2.0.0
* `lumina-cli`: 1.0.0 -> 2.0.0
* `celestia-grpc-macros`: 1.0.0 -> 2.0.0
* `celestia-grpc`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
* `celestia-client`: 1.0.0 -> 2.0.0
* `lumina-node-wasm`: 1.0.0 -> 2.0.0
* `lumina-node-uniffi`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
* `rsema1d`: 1.0.0 -> 2.0.0 (✓ API compatible changes)

### ⚠ `celestia-proto` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod celestia_proto::proto::blob::v2, previously in file /tmp/.tmpd5G8lp/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-default-1ab12504c7ecc599/target/debug/build/celestia-proto-8bebece5170dfa39/out/mod.rs:126

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_proto::proto::blob::v2::BlobTx, previously in file /tmp/.tmpd5G8lp/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-default-1ab12504c7ecc599/target/debug/build/celestia-proto-8bebece5170dfa39/out/proto.blob.v2.rs:40
  struct celestia_proto::proto::blob::v2::BlobProto, previously in file /tmp/.tmpd5G8lp/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-default-1ab12504c7ecc599/target/debug/build/celestia-proto-8bebece5170dfa39/out/proto.blob.v2.rs:8
  struct celestia_proto::proto::blob::v2::IndexWrapper, previously in file /tmp/.tmpd5G8lp/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-default-1ab12504c7ecc599/target/debug/build/celestia-proto-8bebece5170dfa39/out/proto.blob.v2.rs:61
```

### ⚠ `celestia-grpc` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:UnknownAccount in /tmp/.tmpQ57lEE/lumina/grpc/src/error.rs:112
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-proto`

<blockquote>

## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0...celestia-proto-v2.0.0) - 2026-04-15

### Added

- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))
</blockquote>

## `lumina-utils`

<blockquote>

## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-utils-v1.0.0...lumina-utils-v2.0.0) - 2026-04-15

### Added

- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
</blockquote>

## `celestia-types`

<blockquote>

## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0...celestia-types-v2.0.0) - 2026-04-15

### Added

- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))
</blockquote>

## `celestia-rpc`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-rpc-v1.0.0-rc.2...celestia-rpc-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `lumina-node`

<blockquote>

## [1.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0-rc.3...lumina-node-v1.0.0) - 2026-04-03

### Added

- prepare for v8 release ([#949](https://github.com/celestiaorg/lumina/pull/949))

### Other

- release v1.0.0-rc.4 ([#950](https://github.com/celestiaorg/lumina/pull/950))
</blockquote>

## `lumina-cli`

<blockquote>

## [1.0.0](https://github.com/celestiaorg/lumina/compare/lumina-cli-v1.0.0-rc.4...lumina-cli-v1.0.0) - 2026-04-03

### Other

- update Cargo.lock dependencies
</blockquote>

## `celestia-grpc-macros`

<blockquote>

## [1.0.0-rc.2](https://github.com/celestiaorg/lumina/compare/celestia-grpc-macros-v0.7.0...celestia-grpc-macros-v1.0.0-rc.2) - 2026-02-25

### Added

- simplified/unified release process ([#928](https://github.com/celestiaorg/lumina/pull/928))
</blockquote>

## `celestia-grpc`

<blockquote>

## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0...celestia-grpc-v2.0.0) - 2026-04-15

### Added

- add fibre gRPC service client and account signer ([#958](https://github.com/celestiaorg/lumina/pull/958))
</blockquote>

## `celestia-client`

<blockquote>

## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0-rc.2...celestia-client-v1.0.0-rc.3) - 2026-03-19

### Added

- [**breaking**] remove app version ([#940](https://github.com/celestiaorg/lumina/pull/940))
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [1.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-wasm-v1.0.0-rc.3...lumina-node-wasm-v1.0.0) - 2026-04-03

### Other

- release v1.0.0-rc.4 ([#950](https://github.com/celestiaorg/lumina/pull/950))
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-uniffi-v1.0.0...lumina-node-uniffi-v2.0.0) - 2026-04-15

### Other

- [**breaking**] remove iOS, Android, and uniffi binding CI jobs ([#960](https://github.com/celestiaorg/lumina/pull/960))

### Deprecated

- iOS/Android CI jobs, release automation, and binary artifact builds have been removed ([#960](https://github.com/celestiaorg/lumina/pull/960)). The builds will be removed in future versions.
</blockquote>

## `rsema1d`

<blockquote>

## [2.0.0](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0...rsema1d-v2.0.0) - 2026-04-15

### Added

- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).