### PR TITLE
feat: add multi-account TX service and refactor tx client

### DIFF
--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -653,11 +653,6 @@ impl GrpcClient {
         self.inner.account.as_ref().ok_or(Error::MissingSigner)
     }
 
-    pub(crate) fn signer(&self) -> Result<(VerifyingKey, BoxedDocSigner)> {
-        let account = self.account()?;
-        Ok((account.pubkey, account.signer.clone()))
-    }
-
     async fn lock_account(&self, context: &Context) -> Result<AccountGuard<'_>> {
         let account = self.account()?;
 

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 pub mod grpc;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 mod js_client;
+mod multi_account_tx;
 pub mod signer;
 #[cfg(test)]
 mod test_utils;
@@ -23,8 +24,9 @@ pub use crate::boxed::BoxedTransport;
 pub use crate::builder::{Endpoint, GrpcClientBuilder};
 pub use crate::client::GrpcClient;
 pub use crate::error::{Error, GrpcClientBuilderError, Result};
+pub use crate::multi_account_tx::{MultiAccountTxService, MultiAccountTxServiceConfig};
 pub use crate::signer::{AccountSigner, DocSigner};
-pub use crate::tx::{SignDoc, TxConfig, TxInfo};
+pub use crate::tx::{BroadcastedTx, SignDoc, SubmittedTx, TxConfig, TxInfo};
 /// Warning: [`TransactionService`] is experimental and not recommended for use yet.
 pub use crate::tx_client_impl::{ConfirmHandle, TransactionService, TxServiceConfig};
 pub use crate::tx_client_v2::{NodeId, TxHandle, TxRequest};

--- a/grpc/src/multi_account_tx.rs
+++ b/grpc/src/multi_account_tx.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use celestia_types::any::IntoProtobufAny;
+use celestia_types::blob::Blob;
+use celestia_types::state::AccAddress;
+use tokio::sync::RwLock;
+
+use crate::grpc::TxStatusResponse;
+use crate::signer::AccountSigner;
+use crate::tx_client_impl::{ConfirmHandle, TransactionService, TxConfirmInfo, TxServiceConfig};
+use crate::tx_client_v2::{NodeId, TxRequest};
+use crate::{Error, GrpcClient, Result, TxConfig};
+
+const DEFAULT_MAX_STATUS_BATCH: usize = 16;
+const DEFAULT_QUEUE_CAPACITY: usize = 128;
+
+/// Configuration for [`MultiAccountTxService`].
+pub struct MultiAccountTxServiceConfig {
+    /// List of nodes (id, client) for transaction submission and confirmation.
+    pub nodes: Vec<(NodeId, GrpcClient)>,
+    /// Initial set of account signers; one worker is spawned per signer.
+    pub signers: Vec<AccountSigner>,
+    /// Interval between confirmation polling attempts.
+    pub confirm_interval: Duration,
+    /// Maximum number of transactions queried in a single status batch.
+    pub max_status_batch: usize,
+    /// Capacity of the per-account pending transaction queue.
+    pub queue_capacity: usize,
+}
+
+impl MultiAccountTxServiceConfig {
+    /// Create a config with defaults and the given nodes and signers.
+    pub fn new(nodes: Vec<(NodeId, GrpcClient)>, signers: Vec<AccountSigner>) -> Self {
+        Self {
+            nodes,
+            signers,
+            confirm_interval: Duration::from_millis(TxConfig::default().confirmation_interval_ms),
+            max_status_batch: DEFAULT_MAX_STATUS_BATCH,
+            queue_capacity: DEFAULT_QUEUE_CAPACITY,
+        }
+    }
+}
+
+/// A multi-account transaction service that manages one [`TransactionService`]
+/// worker per account, sharing the same gRPC connection pool.
+#[derive(Clone)]
+pub struct MultiAccountTxService {
+    inner: Arc<MultiAccountTxServiceInner>,
+}
+
+struct MultiAccountTxServiceInner {
+    services: RwLock<HashMap<AccAddress, TransactionService>>,
+    nodes: Vec<(NodeId, GrpcClient)>,
+    confirm_interval: Duration,
+    max_status_batch: usize,
+    queue_capacity: usize,
+}
+
+impl MultiAccountTxService {
+    /// Create a new service from config, spawning a worker per initial signer.
+    pub async fn new(config: MultiAccountTxServiceConfig) -> Result<Self> {
+        let mut services = HashMap::with_capacity(config.signers.len());
+        for signer in config.signers {
+            let address = signer.address();
+            let tx_service = TransactionService::new(TxServiceConfig {
+                nodes: config.nodes.clone(),
+                signer,
+                confirm_interval: config.confirm_interval,
+                max_status_batch: config.max_status_batch,
+                queue_capacity: config.queue_capacity,
+            })
+            .await?;
+            services.insert(address, tx_service);
+        }
+
+        Ok(Self {
+            inner: Arc::new(MultiAccountTxServiceInner {
+                services: RwLock::new(services),
+                nodes: config.nodes,
+                confirm_interval: config.confirm_interval,
+                max_status_batch: config.max_status_batch,
+                queue_capacity: config.queue_capacity,
+            }),
+        })
+    }
+
+    /// Add a new account dynamically (spawns its own worker).
+    pub async fn add_account(&self, signer: AccountSigner) -> Result<()> {
+        let address = signer.address();
+        let tx_service = TransactionService::new(TxServiceConfig {
+            nodes: self.inner.nodes.clone(),
+            signer,
+            confirm_interval: self.inner.confirm_interval,
+            max_status_batch: self.inner.max_status_batch,
+            queue_capacity: self.inner.queue_capacity,
+        })
+        .await?;
+
+        self.inner
+            .services
+            .write()
+            .await
+            .insert(address, tx_service);
+        Ok(())
+    }
+
+    /// Submit a [`TxRequest`] for a specific account.
+    ///
+    /// The worker is automatically restarted if it has stopped.
+    pub async fn submit(
+        &self,
+        account: &AccAddress,
+        request: TxRequest,
+    ) -> Result<ConfirmHandle<TxConfirmInfo, TxStatusResponse>> {
+        let service = self.get_service(account).await?;
+        service.submit_restart(request).await
+    }
+
+    /// Submit blobs for a specific account.
+    pub async fn submit_blobs(
+        &self,
+        account: &AccAddress,
+        blobs: Vec<Blob>,
+        cfg: TxConfig,
+    ) -> Result<ConfirmHandle<TxConfirmInfo, TxStatusResponse>> {
+        self.submit(account, TxRequest::blobs(blobs, cfg)).await
+    }
+
+    /// Submit a single cosmos message for a specific account.
+    pub async fn submit_message(
+        &self,
+        account: &AccAddress,
+        msg: impl IntoProtobufAny,
+        cfg: TxConfig,
+    ) -> Result<ConfirmHandle<TxConfirmInfo, TxStatusResponse>> {
+        self.submit(account, TxRequest::message(msg, cfg)).await
+    }
+
+    async fn get_service(&self, account: &AccAddress) -> Result<TransactionService> {
+        self.inner
+            .services
+            .read()
+            .await
+            .get(account)
+            .cloned()
+            .ok_or_else(|| Error::UnknownAccount(*account))
+    }
+}

--- a/grpc/src/tx_client_impl.rs
+++ b/grpc/src/tx_client_impl.rs
@@ -16,7 +16,7 @@ use celestia_types::state::RawTxBody;
 use celestia_types::state::auth::BaseAccount;
 
 use crate::grpc::{BroadcastMode, GasEstimate, TxStatus as GrpcTxStatus, TxStatusResponse};
-use crate::signer::sign_tx;
+use crate::signer::{AccountSigner, sign_tx};
 
 use crate::tx_client_v2::{
     ConfirmResult, NodeId, RejectionReason, SigningError, SigningFailure, StopError, SubmitError,
@@ -54,7 +54,10 @@ impl ConfirmHandle<TxConfirmInfo, TxStatusResponse> {
 /// Warning: [`TransactionService`] is experimental and not recommended for use yet.
 pub struct TxServiceConfig {
     /// List of nodes (id, client) to submit and confirm transactions through.
+    /// These clients are used for transport only (queries, broadcasting).
     pub nodes: Vec<(NodeId, GrpcClient)>,
+    /// The account signer used for signing transactions.
+    pub signer: AccountSigner,
     /// Interval between confirmation polling attempts.
     pub confirm_interval: Duration,
     /// Maximum number of transactions to query in a single status batch.
@@ -64,10 +67,11 @@ pub struct TxServiceConfig {
 }
 
 impl TxServiceConfig {
-    /// Create a new config with defaults and the given node list.
-    pub fn new(nodes: Vec<(NodeId, GrpcClient)>) -> Self {
+    /// Create a new config with defaults and the given node list and signer.
+    pub fn new(nodes: Vec<(NodeId, GrpcClient)>, signer: AccountSigner) -> Self {
         Self {
             nodes,
+            signer,
             confirm_interval: Duration::from_millis(TxConfig::default().confirmation_interval_ms),
             max_status_batch: DEFAULT_MAX_STATUS_BATCH,
             queue_capacity: DEFAULT_QUEUE_CAPACITY,
@@ -91,6 +95,7 @@ struct TransactionServiceInner {
     worker: Mutex<Option<WorkerHandle>>,
     clients: HashMap<NodeId, GrpcClient>,
     primary_client: GrpcClient,
+    signer: AccountSigner,
     account: BaseAccount,
     confirm_interval: Duration,
     max_status_batch: usize,
@@ -120,7 +125,8 @@ impl TransactionService {
             ));
         };
         let client = client.clone();
-        let address = client.get_account_address().ok_or(Error::MissingSigner)?;
+        let signer = config.signer;
+        let address = signer.address();
         let account = client.get_account(&address).await?;
         let account = BaseAccount::from(account);
 
@@ -129,6 +135,7 @@ impl TransactionService {
             account.clone(),
             &clients,
             client.clone(),
+            &signer,
             config.confirm_interval,
             config.max_status_batch,
             config.queue_capacity,
@@ -141,6 +148,7 @@ impl TransactionService {
                 worker: Mutex::new(Some(worker_handle)),
                 clients,
                 primary_client: client,
+                signer,
                 account,
                 confirm_interval: config.confirm_interval,
                 max_status_batch: config.max_status_batch,
@@ -201,6 +209,7 @@ impl TransactionService {
             self.inner.account.clone(),
             &self.inner.clients,
             self.inner.primary_client.clone(),
+            &self.inner.signer,
             self.inner.confirm_interval,
             self.inner.max_status_batch,
             self.inner.queue_capacity,
@@ -218,6 +227,7 @@ impl TransactionService {
         account: BaseAccount,
         clients: &HashMap<NodeId, GrpcClient>,
         primary_client: GrpcClient,
+        account_signer: &AccountSigner,
         confirm_interval: Duration,
         max_status_batch: usize,
         queue_capacity: usize,
@@ -225,7 +235,9 @@ impl TransactionService {
         TxSubmitter<Hash, TxConfirmInfo, TxStatusResponse, Arc<Error>, TxRequest>,
         WorkerHandle,
     )> {
-        let next_sequence = current_sequence(&primary_client).await?;
+        let address = account_signer.address();
+        let next_account = primary_client.get_account(&address).await?;
+        let next_sequence = next_account.sequence;
         let confirmed_sequence = next_sequence.checked_sub(1);
         let nodes = clients
             .iter()
@@ -236,6 +248,7 @@ impl TransactionService {
                         node_id: node_id.clone(),
                         client: client.clone(),
                         account: account.clone(),
+                        account_signer: account_signer.clone(),
                     }),
                 )
             })
@@ -264,6 +277,7 @@ struct NodeClient {
     node_id: NodeId,
     client: GrpcClient,
     account: BaseAccount,
+    account_signer: AccountSigner,
 }
 
 #[async_trait]
@@ -351,7 +365,9 @@ impl TxServer for NodeClient {
     }
 
     async fn current_sequence(&self) -> Result<u64> {
-        current_sequence(&self.client).await
+        let address = self.account_signer.address();
+        let account = self.client.get_account(&address).await?;
+        Ok(account.sequence)
     }
 
     async fn simulate_and_sign(
@@ -362,19 +378,27 @@ impl TxServer for NodeClient {
         Transaction<Self::TxId, Self::ConfirmInfo, Self::ConfirmResponse, Self::SubmitError>,
         SigningFailure<Self::SubmitError>,
     > {
-        sign_with_client(self.account.clone(), &self.client, req.as_ref(), sequence)
-            .await
-            .map_err(map_signing_failure)
+        sign_with_client(
+            self.account.clone(),
+            &self.client,
+            &self.account_signer,
+            req.as_ref(),
+            sequence,
+        )
+        .await
+        .map_err(map_signing_failure)
     }
 }
 
 async fn sign_with_client(
     mut account: BaseAccount,
     client: &GrpcClient,
+    account_signer: &AccountSigner,
     request: &TxRequest,
     sequence: u64,
 ) -> Result<Transaction<Hash, TxConfirmInfo, TxStatusResponse, Arc<Error>>> {
-    let (pubkey, signer) = client.signer()?;
+    let pubkey = &account_signer.pubkey;
+    let signer = &account_signer.signer;
     account.sequence = sequence;
 
     let chain_id = client.chain_id().await?;
@@ -390,7 +414,14 @@ async fn sign_with_client(
             };
             (tx_body, Some(blobs))
         }
-        TxPayload::Tx(body) => (body.clone(), None),
+        TxPayload::Message(any) => {
+            let tx_body = RawTxBody {
+                messages: vec![any.clone()],
+                memo: cfg.memo.clone().unwrap_or_default(),
+                ..RawTxBody::default()
+            };
+            (tx_body, None)
+        }
     };
 
     let (gas_limit, gas_price) = match cfg.gas_limit {
@@ -406,8 +437,8 @@ async fn sign_with_client(
                 tx_body.clone(),
                 chain_id.clone(),
                 &account,
-                &pubkey,
-                &signer,
+                pubkey,
+                signer,
                 0,
                 1,
             )
@@ -421,10 +452,7 @@ async fn sign_with_client(
     };
     let fee = (gas_limit as f64 * gas_price).ceil() as u64;
 
-    let tx = sign_tx(
-        tx_body, chain_id, &account, &pubkey, &signer, gas_limit, fee,
-    )
-    .await?;
+    let tx = sign_tx(tx_body, chain_id, &account, pubkey, signer, gas_limit, fee).await?;
     let bytes = match blobs {
         Some(blobs) => {
             let blob_tx = RawBlobTx {
@@ -512,12 +540,6 @@ fn map_status_response(
         GrpcTxStatus::Pending => Ok(TxStatus::new(TxStatusKind::Pending, original_response)),
         GrpcTxStatus::Unknown => Ok(TxStatus::new(TxStatusKind::Unknown, original_response)),
     }
-}
-
-async fn current_sequence(client: &GrpcClient) -> Result<u64> {
-    let address = client.get_account_address().ok_or(Error::MissingSigner)?;
-    let account = client.get_account(&address).await?;
-    Ok(account.sequence)
 }
 
 fn map_submit_error(code: ErrorCode, message: &str) -> SubmitError {
@@ -653,16 +675,18 @@ mod tests {
     async fn submit_with_worker_and_confirm() {
         let (_lock, _client) = new_tx_client().await;
         let account = load_account();
+        let signer = AccountSigner::from_keypair(account.signing_key);
         let client = GrpcClient::builder()
             .url(CELESTIA_GRPC_URL)
-            .signer_keypair(account.signing_key)
             .build()
             .unwrap();
 
-        let service =
-            TransactionService::new(TxServiceConfig::new(vec![(Arc::from("default"), client)]))
-                .await
-                .unwrap();
+        let service = TransactionService::new(TxServiceConfig::new(
+            vec![(Arc::from("default"), client)],
+            signer,
+        ))
+        .await
+        .unwrap();
         let handle = service
             .submit(TxRequest::blobs(
                 vec![random_blob(10..=1000)],

--- a/grpc/src/tx_client_v2/mod.rs
+++ b/grpc/src/tx_client_v2/mod.rs
@@ -129,8 +129,8 @@ impl<T> TxIdT for T where T: Clone + std::fmt::Debug {}
 pub enum TxPayload {
     /// Pay-for-blobs transaction.
     Blobs(Vec<celestia_types::Blob>),
-    /// Raw Cosmos transaction body with arbitrary messages.
-    Tx(celestia_types::state::RawTxBody),
+    /// A single cosmos message (e.g. MsgPayForFibre, MsgSend).
+    Message(tendermint_proto::google::protobuf::Any),
 }
 
 /// A transaction request combining payload and configuration.
@@ -261,10 +261,10 @@ where
 }
 
 impl TxRequest {
-    /// Create a request for a raw transaction body.
-    pub fn tx(body: celestia_types::state::RawTxBody, cfg: TxConfig) -> Self {
+    /// Create a request for a single cosmos message.
+    pub fn message(msg: impl celestia_types::any::IntoProtobufAny, cfg: TxConfig) -> Self {
         Self {
-            tx: TxPayload::Tx(body),
+            tx: TxPayload::Message(msg.into_any()),
             cfg,
         }
     }

--- a/grpc/src/tx_client_v2/node_manager.rs
+++ b/grpc/src/tx_client_v2/node_manager.rs
@@ -970,7 +970,7 @@ fn process_status_batch<S: TxServer>(
         .into_iter()
         .filter_map(|(tx_id, status)| txs.get_by_id(&tx_id).map(|tx| (tx.sequence, status)))
         .collect::<Vec<_>>();
-    collected.sort_by(|first, second| first.0.cmp(&second.0));
+    collected.sort_by_key(|first| first.0);
     if collected.is_empty() {
         return effects;
     }

--- a/grpc/src/tx_client_v2/node_manager.rs
+++ b/grpc/src/tx_client_v2/node_manager.rs
@@ -451,14 +451,7 @@ impl<S: TxServer> NodeManager<S> {
                     SubmitError::SequenceMismatch { expected } => {
                         let stop_error: StopErrorFor<S> =
                             StopError::SubmitError(failure.original_error.clone());
-                        on_sequence_mismatch::<S>(
-                            node,
-                            sequence,
-                            expected,
-                            stop_error,
-                            txs,
-                            Some(self.delay),
-                        );
+                        on_sequence_mismatch::<S>(node, sequence, expected, stop_error, txs);
                     }
                     SubmitError::MempoolIsFull | SubmitError::NetworkError => {
                         node.shared_mut().submit_delay = Some(self.delay);
@@ -906,7 +899,6 @@ fn on_sequence_mismatch<S: TxServer>(
     expected: u64,
     stop_error: StopErrorFor<S>,
     txs: &NodeBuffer<S>,
-    delay: Option<Duration>,
 ) {
     let mut recover_target = None;
     let mut stop_seq = None;
@@ -921,7 +913,7 @@ fn on_sequence_mismatch<S: TxServer>(
         return;
     }
     // if our sequence is less than expected, we need to confirm
-    // that the transaction with higher sequence nubmer is transaction
+    // that the transaction with higher sequence number is transaction
     // made by our client and not from outside the system
     if sequence < expected {
         let target = expected.saturating_sub(1);
@@ -931,10 +923,6 @@ fn on_sequence_mismatch<S: TxServer>(
             return;
         };
         if tx.id.is_none() {
-            if let Some(value) = delay {
-                node.shared_mut().submit_delay = Some(value);
-                return;
-            }
             let stop_seq = stop_seq_from_last_good(shared.last_submitted, shared.last_confirmed);
             node.apply_stop_error(stop_seq, stop_error);
             return;
@@ -982,7 +970,7 @@ fn process_status_batch<S: TxServer>(
         .into_iter()
         .filter_map(|(tx_id, status)| txs.get_by_id(&tx_id).map(|tx| (tx.sequence, status)))
         .collect::<Vec<_>>();
-    collected.sort_by_key(|first| first.0);
+    collected.sort_by(|first, second| first.0.cmp(&second.0));
     if collected.is_empty() {
         return effects;
     }
@@ -1073,7 +1061,7 @@ fn process_status_batch<S: TxServer>(
         }
     }
     if let Some((sequence, expected, stop_error)) = seq_mismatch {
-        on_sequence_mismatch::<S>(node, sequence, expected, stop_error, txs, None);
+        on_sequence_mismatch::<S>(node, sequence, expected, stop_error, txs);
     }
     if let Some((sequence, status)) = fatal {
         node.apply_stop_error(sequence, StopError::ConfirmError(status));
@@ -1387,7 +1375,7 @@ mod tests {
     }
 
     #[test]
-    fn sequence_mismatch_missing_id_resubmits_with_delay() {
+    fn sequence_mismatch_missing_id_stops_node() {
         let node_id: NodeId = Arc::from("node-1");
         let mut manager = NodeManager::<DummyServer>::new(vec![node_id.clone()], Some(0));
         let mut txs = TestBuffer::new(Some(0));
@@ -1406,10 +1394,10 @@ mod tests {
             &txs,
         );
 
-        let NodeState::Active(state) = manager.nodes.get(&node_id).unwrap() else {
-            panic!("node should be active");
-        };
-        assert!(state.shared.submit_delay.is_some());
+        assert!(matches!(
+            manager.nodes.get(&node_id).unwrap(),
+            NodeState::Stopped(_)
+        ));
     }
 
     #[test]

--- a/grpc/src/tx_client_v2/tests.rs
+++ b/grpc/src/tx_client_v2/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use async_trait::async_trait;
-use celestia_types::state::RawTxBody;
 use prost::Message;
 use std::collections::VecDeque;
 use std::sync::Once;
@@ -791,13 +790,13 @@ impl Harness {
         oneshot::Receiver<Result<TestTxId>>,
         oneshot::Receiver<TestConfirmResult>,
     ) {
-        let body = RawTxBody {
-            memo: format!("test-bytes:{:?}", bytes),
-            ..RawTxBody::default()
+        let any = tendermint_proto::google::protobuf::Any {
+            type_url: "test".to_string(),
+            value: bytes,
         };
         let handle = self
             .manager
-            .add_tx(TxRequest::tx(body, TxConfig::default()))
+            .add_tx(TxRequest::message(any, TxConfig::default()))
             .await
             .expect("add tx");
         (handle.signed, handle.submitted, handle.confirmed)
@@ -824,7 +823,7 @@ async fn test_eviction() {
                         ..
                     } => {
                         let bytes = match &request.as_ref().tx {
-                            TxPayload::Tx(body) => body.encode_to_vec(),
+                            TxPayload::Message(any) => any.encode_to_vec(),
                             TxPayload::Blobs(_) => Vec::new(),
                         };
                         ActionResult {
@@ -1015,7 +1014,7 @@ async fn test_recovering() {
                         ..
                     } => {
                         let bytes = match &request.as_ref().tx {
-                            TxPayload::Tx(body) => body.encode_to_vec(),
+                            TxPayload::Message(any) => any.encode_to_vec(),
                             TxPayload::Blobs(_) => Vec::new(),
                         };
                         ActionResult {


### PR DESCRIPTION
 ## Summary
- Enables PFF submission in an asynchronous thread
- Introduces `MultiAccountTxService` for managing transactions across multiple signer accounts
- Refactors the existing TX client to remove delayed resubmission logic and decouple from the single-signer model
- Updates `NodeManager` to start uploads immediately

## Test plan
- [ ] Existing tx_client_v2 tests pass
- [ ] Integration test `submit_with_worker_and_confirm` passes with new signer flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)