### PR TITLE
feat: add fibre gRPC transport and proto conversion layer

### DIFF
--- a/fibre/Cargo.toml
+++ b/fibre/Cargo.toml
@@ -17,11 +17,16 @@ rsema1d.workspace = true
 
 # Crypto
 k256 = { workspace = true, features = ["ecdsa"] }
+ed25519-dalek = { version = "2.1", features = ["digest"] }
 sha2 = "0.10.8"
 rand.workspace = true
+chacha8rand = "0.1.2"
 
 # Async runtime
 tokio = { workspace = true, features = ["sync", "macros"] }
+tokio-util.workspace = true
+futures.workspace = true
+lumina-utils = { workspace = true, features = ["executor"] }
 
 # gRPC
 tonic = { workspace = true, features = ["codegen"] }
@@ -32,6 +37,11 @@ tendermint-proto.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 hex.workspace = true
+async-trait.workspace = true
+bech32 = "0.11"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tonic = { workspace = true, features = ["transport"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/fibre/src/domain/payment_promise.rs
+++ b/fibre/src/domain/payment_promise.rs
@@ -751,33 +751,8 @@ mod tests {
 
         let original_sign_bytes = promise.sign_bytes().unwrap();
 
-        // Convert to proto and encode (inline conversion to avoid dependency on transport layer)
-        use celestia_proto::cosmos::crypto::secp256k1::PubKey as ProtoPubKey;
-        use tendermint_proto::google::protobuf::Timestamp;
-        let ts_dur = promise
-            .creation_timestamp
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap();
-        let proto_pp = celestia_proto::celestia::fibre::v1::PaymentPromise {
-            chain_id: promise.chain_id.clone(),
-            height: promise.height as i64,
-            namespace: promise.namespace.clone(),
-            blob_size: promise.upload_size,
-            blob_version: promise.blob_version,
-            commitment: promise.commitment.to_vec(),
-            creation_timestamp: Some(Timestamp {
-                seconds: ts_dur.as_secs() as i64,
-                nanos: ts_dur.subsec_nanos() as i32,
-            }),
-            signer_public_key: Some(ProtoPubKey {
-                key: promise
-                    .signer_pubkey
-                    .to_encoded_point(true)
-                    .as_bytes()
-                    .to_vec(),
-            }),
-            signature: promise.signature.clone().unwrap_or_default(),
-        };
+        // Convert to proto and encode
+        let proto_pp = celestia_proto::celestia::fibre::v1::PaymentPromise::from(&promise);
         let proto_bytes = proto_pp.encode_to_vec();
 
         // Print the raw proto bytes for cross-language decoding

--- a/fibre/src/lib.rs
+++ b/fibre/src/lib.rs
@@ -5,16 +5,23 @@
 //! small payment receipt (`MsgPayForFibre`) goes on-chain.
 
 pub mod domain;
+pub mod transport;
 
 pub use domain::config;
 pub use domain::error;
 
-// Compatibility aliases so domain submodules can use `crate::blob`, etc.
-pub(crate) use domain::{blob, blob_header};
+// Compatibility aliases preserve historical crate-local paths so tests and
+// internals don't need broad path rewrites during this refactor.
+pub(crate) use domain::{blob, blob_header, payment_promise};
+pub(crate) use transport::{grpc_validator_client, host_registry, proto_conv, validator_client};
 
+pub use celestia_grpc::Endpoint;
 pub use config::{
     BlobConfig, DEFAULT_PROTOCOL_PARAMS, FibreClientConfig, Fraction, ProtocolParams,
 };
 pub use domain::blob::{Blob, BlobID, Commitment};
 pub use domain::payment_promise::{PaymentPromise, SignedPaymentPromise};
 pub use error::{FibreError, Result};
+pub use transport::grpc_validator_client::GrpcValidatorConnector;
+pub use transport::host_registry::{GrpcHostRegistry, Host, HostRegistry};
+pub use transport::validator_client::{ValidatorConnection, ValidatorConnector};

--- a/fibre/src/transport/grpc_validator_client.rs
+++ b/fibre/src/transport/grpc_validator_client.rs
@@ -1,0 +1,301 @@
+//! Production gRPC transport implementation.
+//!
+//! [`GrpcValidatorConnector`] resolves validator addresses via a
+//! [`HostRegistry`] and caches [`GrpcClient`] connections.
+//! [`GrpcValidatorConnection`] uses [`GrpcClient`] methods to upload
+//! and download shards over the Fibre gRPC service.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use celestia_grpc::GrpcClient;
+
+use crate::blob::BlobID;
+use crate::error::FibreError;
+use crate::host_registry::HostRegistry;
+use crate::payment_promise::PaymentPromise;
+use crate::proto_conv;
+use crate::validator::ValidatorInfo;
+use crate::validator_client::{
+    DownloadResponse, DownloadedRow, UploadResponse, ValidatorConnection, ValidatorConnector,
+};
+
+/// Factory that resolves validator hosts and caches gRPC connections.
+pub struct GrpcValidatorConnector {
+    host_registry: Arc<dyn HostRegistry>,
+    connections: tokio::sync::Mutex<HashMap<[u8; 20], Arc<GrpcValidatorConnection>>>,
+}
+
+impl GrpcValidatorConnector {
+    /// Create a new connector backed by the given host registry.
+    pub fn new(host_registry: Arc<dyn HostRegistry>) -> Self {
+        Self {
+            host_registry,
+            connections: tokio::sync::Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl ValidatorConnector for GrpcValidatorConnector {
+    async fn connect(
+        &self,
+        validator: &ValidatorInfo,
+    ) -> Result<Arc<dyn ValidatorConnection>, FibreError> {
+        // Fast path: check cache under lock.
+        {
+            let cache = self.connections.lock().await;
+            if let Some(conn) = cache.get(&validator.address) {
+                return Ok(conn.clone() as Arc<dyn ValidatorConnection>);
+            }
+        }
+
+        // Cache miss: resolve host and create a new channel.
+        let host = self.host_registry.get_host(validator).await?;
+
+        // Validators may register hosts in gRPC name-resolution format
+        // (e.g. "dns:///1.2.3.4:9091"). Tonic expects a standard http(s)
+        // URI, so normalise the address first.
+        let url = normalize_host(&host.0);
+
+        let client = GrpcClient::builder()
+            .url(&url)
+            .build()
+            .map_err(|e| FibreError::Other(format!("invalid endpoint '{}': {e}", url)))?;
+
+        let conn = Arc::new(GrpcValidatorConnection { client });
+
+        // Re-check cache under lock: another task may have inserted a
+        // connection for this validator while we were resolving/building.
+        let mut cache = self.connections.lock().await;
+        let conn = cache.entry(validator.address).or_insert(conn).clone();
+
+        Ok(conn as Arc<dyn ValidatorConnection>)
+    }
+}
+
+/// Normalise a host string into a standard `http://` URI.
+fn normalize_host(raw: &str) -> String {
+    // Strip the "dns:///" (or "dns://") prefix if present.
+    if let Some(rest) = raw
+        .strip_prefix("dns:///")
+        .or_else(|| raw.strip_prefix("dns://"))
+    {
+        return format!("http://{rest}");
+    }
+    // Already a normal URI (http:// or https://).
+    if raw.starts_with("http://") || raw.starts_with("https://") {
+        return raw.to_string();
+    }
+    // Bare host:port — assume http.
+    format!("http://{raw}")
+}
+
+/// A connection to a single validator's Fibre gRPC service.
+///
+/// Wraps a [`GrpcClient`] for issuing upload/download RPCs.
+pub struct GrpcValidatorConnection {
+    client: GrpcClient,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl ValidatorConnection for GrpcValidatorConnection {
+    async fn upload_shard(
+        &self,
+        promise: &PaymentPromise,
+        rows: &[rsema1d::RowInclusionProof],
+        rlc_coeffs: &[rsema1d::GF128],
+    ) -> Result<UploadResponse, FibreError> {
+        let proto_promise = promise.into();
+        let proto_shard = proto_conv::build_upload_shard(rows, rlc_coeffs);
+
+        let request = celestia_proto::celestia::fibre::v1::UploadShardRequest {
+            promise: Some(proto_promise),
+            shard: Some(proto_shard),
+        };
+
+        let response = self.client.upload_shard(request).await?;
+
+        Ok(UploadResponse {
+            validator_signature: response.validator_signature,
+        })
+    }
+
+    async fn download_shard(&self, blob_id: &BlobID) -> Result<DownloadResponse, FibreError> {
+        let response = self
+            .client
+            .download_shard(blob_id.as_bytes().to_vec())
+            .await?;
+
+        let proofs = proto_conv::parse_download_response(response)?;
+
+        Ok(DownloadResponse {
+            rows: proofs
+                .into_iter()
+                .map(|proof| DownloadedRow { proof })
+                .collect(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::host_registry::Host;
+    use crate::host_registry::HostRegistry;
+
+    struct MockHostRegistry {
+        hosts: std::collections::HashMap<[u8; 20], Host>,
+        call_count: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl HostRegistry for MockHostRegistry {
+        async fn get_host(&self, validator: &ValidatorInfo) -> Result<Host, FibreError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            self.hosts
+                .get(&validator.address)
+                .cloned()
+                .ok_or_else(|| FibreError::HostNotFound(hex::encode(validator.address)))
+        }
+    }
+
+    fn make_test_validator(seed: u8) -> ValidatorInfo {
+        let mut key_bytes = [0u8; 32];
+        key_bytes[0] = seed;
+        let sk = ed25519_dalek::SigningKey::from_bytes(&key_bytes);
+        ValidatorInfo {
+            address: [seed; 20],
+            pubkey: sk.verifying_key(),
+            voting_power: 100,
+        }
+    }
+
+    #[tokio::test]
+    async fn connector_caches_connections() {
+        let validator = make_test_validator(1);
+
+        let mut hosts = std::collections::HashMap::new();
+        hosts.insert(validator.address, Host("http://127.0.0.1:9090".to_string()));
+
+        let registry = Arc::new(MockHostRegistry {
+            hosts,
+            call_count: AtomicUsize::new(0),
+        });
+
+        let connector = GrpcValidatorConnector::new(registry.clone());
+
+        // First connect should call the registry.
+        let conn1 = connector.connect(&validator).await;
+        assert!(conn1.is_ok(), "first connect should succeed");
+
+        // Second connect should hit the cache.
+        let conn2 = connector.connect(&validator).await;
+        assert!(conn2.is_ok(), "second connect should succeed");
+
+        // The registry should only have been called once.
+        assert_eq!(
+            registry.call_count.load(Ordering::SeqCst),
+            1,
+            "registry should only be called once due to caching"
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_creates_separate_connections_for_different_validators() {
+        let validator_a = make_test_validator(1);
+        let validator_b = make_test_validator(2);
+
+        let mut hosts = std::collections::HashMap::new();
+        hosts.insert(
+            validator_a.address,
+            Host("http://127.0.0.1:9090".to_string()),
+        );
+        hosts.insert(
+            validator_b.address,
+            Host("http://127.0.0.1:9091".to_string()),
+        );
+
+        let registry = Arc::new(MockHostRegistry {
+            hosts,
+            call_count: AtomicUsize::new(0),
+        });
+
+        let connector = GrpcValidatorConnector::new(registry.clone());
+
+        let conn_a = connector.connect(&validator_a).await;
+        assert!(conn_a.is_ok(), "connect to validator A should succeed");
+
+        let conn_b = connector.connect(&validator_b).await;
+        assert!(conn_b.is_ok(), "connect to validator B should succeed");
+
+        // Both validators should have triggered a registry lookup.
+        assert_eq!(
+            registry.call_count.load(Ordering::SeqCst),
+            2,
+            "registry should be called once per distinct validator"
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_propagates_host_not_found_error() {
+        let validator = make_test_validator(42);
+
+        // Empty hosts map: every lookup will fail with HostNotFound.
+        let registry = Arc::new(MockHostRegistry {
+            hosts: std::collections::HashMap::new(),
+            call_count: AtomicUsize::new(0),
+        });
+
+        let connector = GrpcValidatorConnector::new(registry.clone());
+
+        let result = connector.connect(&validator).await;
+        match result {
+            Err(FibreError::HostNotFound(addr_hex)) => {
+                assert_eq!(
+                    addr_hex,
+                    hex::encode(validator.address),
+                    "error should contain the validator address"
+                );
+            }
+            Err(other) => panic!("expected HostNotFound error, got: {other}"),
+            Ok(_) => panic!("expected connect to fail for unknown validator"),
+        }
+    }
+
+    #[test]
+    fn normalize_host_strips_dns_prefix() {
+        assert_eq!(
+            normalize_host("dns:///138.68.236.99:9091"),
+            "http://138.68.236.99:9091"
+        );
+        assert_eq!(
+            normalize_host("dns://138.68.236.99:9091"),
+            "http://138.68.236.99:9091"
+        );
+    }
+
+    #[test]
+    fn normalize_host_preserves_http() {
+        assert_eq!(
+            normalize_host("http://127.0.0.1:9090"),
+            "http://127.0.0.1:9090"
+        );
+        assert_eq!(
+            normalize_host("https://validator.example.com:9090"),
+            "https://validator.example.com:9090"
+        );
+    }
+
+    #[test]
+    fn normalize_host_adds_http_to_bare() {
+        assert_eq!(
+            normalize_host("138.68.236.99:9091"),
+            "http://138.68.236.99:9091"
+        );
+    }
+}

--- a/fibre/src/transport/host_registry.rs
+++ b/fibre/src/transport/host_registry.rs
@@ -1,0 +1,325 @@
+//! Host registry for resolving validator network addresses.
+//!
+//! The [`HostRegistry`] trait maps validators to their fibre gRPC endpoints.
+//! [`GrpcHostRegistry`] is the production implementation that queries the
+//! `x/valaddr` on-chain module via gRPC.
+
+use std::collections::HashMap;
+
+use crate::error::FibreError;
+use crate::validator::ValidatorInfo;
+use celestia_grpc::GrpcClient;
+
+/// A validator's network address (e.g., `"dns:///validator.example.com:9090"`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Host(pub String);
+
+/// Maps validators to their fibre gRPC network addresses.
+///
+/// In production this is backed by the `x/valaddr` on-chain query service.
+/// In tests this can be a simple `HashMap`.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait HostRegistry: Send + Sync {
+    /// Resolve the fibre gRPC address for the given validator.
+    async fn get_host(&self, validator: &ValidatorInfo) -> Result<Host, FibreError>;
+}
+
+/// Production host registry backed by the `x/valaddr` on-chain query service.
+///
+/// Maintains a local cache of `[u8; 20]` -> [`Host`] mappings. The cache can
+/// be bulk-populated via [`pull_all()`](GrpcHostRegistry::pull_all) or
+/// lazily filled per-validator via
+/// [`pull_host()`](GrpcHostRegistry::pull_host).
+pub struct GrpcHostRegistry {
+    client: GrpcClient,
+    pub(crate) cache: tokio::sync::RwLock<HashMap<[u8; 20], Host>>,
+}
+
+impl GrpcHostRegistry {
+    /// Create a new registry using the given [`GrpcClient`] to the Cosmos app.
+    pub fn new(client: GrpcClient) -> Self {
+        Self {
+            client,
+            cache: tokio::sync::RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Fetch all fibre providers from the chain and populate the cache.
+    ///
+    /// Queries `AllFibreProviders` on the `x/valaddr` module, decodes each
+    /// provider's bech32 consensus address to a 20-byte key, and stores the
+    /// host mapping.
+    pub async fn pull_all(&self) -> Result<(), FibreError> {
+        let resp = self.client.get_all_fibre_providers().await?;
+
+        let providers = resp.providers;
+        let mut cache = self.cache.write().await;
+
+        for provider in providers {
+            let addr_bytes = decode_bech32_address(&provider.validator_consensus_address)?;
+            let host_str = provider.info.map(|info| info.host).unwrap_or_default();
+
+            if !host_str.is_empty() {
+                cache.insert(addr_bytes, Host(host_str));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Fetch the fibre host for a single validator and update the cache.
+    ///
+    /// Uses the validator's 20-byte address encoded as a bech32 consensus
+    /// address to query `FibreProviderInfo`.
+    pub async fn pull_host(&self, validator: &ValidatorInfo) -> Result<Host, FibreError> {
+        let bech32_addr = encode_bech32_address("celestiavalcons", &validator.address)?;
+
+        let resp = self.client.get_fibre_provider_info(bech32_addr).await?;
+
+        if !resp.found {
+            return Err(FibreError::HostNotFound(hex::encode_upper(
+                validator.address,
+            )));
+        }
+
+        let host_str = resp.info.map(|info| info.host).unwrap_or_default();
+
+        if host_str.is_empty() {
+            return Err(FibreError::HostNotFound(hex::encode_upper(
+                validator.address,
+            )));
+        }
+
+        let host = Host(host_str);
+
+        // Update cache.
+        self.cache
+            .write()
+            .await
+            .insert(validator.address, host.clone());
+
+        Ok(host)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl HostRegistry for GrpcHostRegistry {
+    async fn get_host(&self, validator: &ValidatorInfo) -> Result<Host, FibreError> {
+        // Check cache first.
+        {
+            let cache = self.cache.read().await;
+            if let Some(host) = cache.get(&validator.address) {
+                return Ok(host.clone());
+            }
+        }
+
+        // Cache miss: query the chain for this specific validator.
+        self.pull_host(validator).await
+    }
+}
+
+/// Decode a bech32-encoded address (e.g., `"celestiavalcons1..."`) into a
+/// 20-byte raw address.
+fn decode_bech32_address(bech32_addr: &str) -> Result<[u8; 20], FibreError> {
+    let (_hrp, data) = bech32::decode(bech32_addr).map_err(|e| {
+        FibreError::InvalidData(format!("invalid bech32 address '{bech32_addr}': {e}"))
+    })?;
+
+    let addr: [u8; 20] = data.try_into().map_err(|v: Vec<u8>| {
+        FibreError::InvalidData(format!(
+            "bech32 address decoded to {} bytes, expected 20",
+            v.len()
+        ))
+    })?;
+
+    Ok(addr)
+}
+
+/// Encode a 20-byte address into a bech32 string with the given human-readable
+/// prefix (e.g., `"celestiavalcons"`).
+fn encode_bech32_address(hrp: &str, addr: &[u8; 20]) -> Result<String, FibreError> {
+    let hrp = bech32::Hrp::parse(hrp)
+        .map_err(|e| FibreError::Other(format!("invalid bech32 hrp '{hrp}': {e}")))?;
+    let encoded = bech32::encode::<bech32::Bech32>(hrp, addr)
+        .map_err(|e| FibreError::Other(format!("bech32 encoding failed: {e}")))?;
+    Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_validator(seed: u8, address: [u8; 20]) -> ValidatorInfo {
+        let mut key_bytes = [0u8; 32];
+        key_bytes[0] = seed;
+        let sk = ed25519_dalek::SigningKey::from_bytes(&key_bytes);
+        let pubkey = sk.verifying_key();
+        ValidatorInfo {
+            address,
+            pubkey,
+            voting_power: 1,
+        }
+    }
+
+    #[test]
+    fn bech32_encode_decode_roundtrip() {
+        let addr: [u8; 20] = [
+            0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+            0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        ];
+
+        let encoded =
+            encode_bech32_address("celestiavalcons", &addr).expect("encoding should succeed");
+        let decoded = decode_bech32_address(&encoded).expect("decoding should succeed");
+
+        assert_eq!(decoded, addr);
+    }
+
+    #[test]
+    fn bech32_encode_known_vector() {
+        let addr = [1u8; 20];
+        let encoded =
+            encode_bech32_address("celestiavalcons", &addr).expect("encoding should succeed");
+
+        assert!(
+            encoded.starts_with("celestiavalcons1"),
+            "encoded address should start with 'celestiavalcons1', got: {encoded}"
+        );
+
+        // Round-trip check: decoding gives back the same bytes.
+        let decoded = decode_bech32_address(&encoded).expect("decoding should succeed");
+        assert_eq!(decoded, addr);
+    }
+
+    #[test]
+    fn bech32_decode_invalid_string() {
+        let result = decode_bech32_address("notvalid");
+        assert!(
+            result.is_err(),
+            "decoding an invalid bech32 string should fail"
+        );
+
+        let err = result.unwrap_err();
+        match &err {
+            FibreError::InvalidData(msg) => {
+                assert!(
+                    msg.contains("invalid bech32 address"),
+                    "error message should mention 'invalid bech32 address', got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidData error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bech32_decode_wrong_data_length() {
+        // Encode a 10-byte payload (not 20), which should fail on decode.
+        let short_bech32 =
+            bech32::encode::<bech32::Bech32>(bech32::Hrp::parse("test").unwrap(), &[0u8; 10])
+                .expect("bech32 encoding of short payload should succeed");
+
+        let result = decode_bech32_address(&short_bech32);
+        assert!(
+            result.is_err(),
+            "decoding a non-20-byte payload should fail"
+        );
+
+        let err = result.unwrap_err();
+        match &err {
+            FibreError::InvalidData(msg) => {
+                assert!(
+                    msg.contains("expected 20"),
+                    "error message should mention 'expected 20', got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidData error, got: {other:?}"),
+        }
+    }
+
+    struct MapRegistry {
+        hosts: HashMap<[u8; 20], Host>,
+    }
+
+    #[async_trait::async_trait]
+    impl HostRegistry for MapRegistry {
+        async fn get_host(&self, validator: &ValidatorInfo) -> Result<Host, FibreError> {
+            self.hosts
+                .get(&validator.address)
+                .cloned()
+                .ok_or_else(|| FibreError::HostNotFound(hex::encode_upper(validator.address)))
+        }
+    }
+
+    #[tokio::test]
+    async fn map_registry_returns_host_when_present() {
+        let addr = [42u8; 20];
+        let expected_host = Host("dns:///example.com:9090".to_string());
+
+        let mut hosts = HashMap::new();
+        hosts.insert(addr, expected_host.clone());
+
+        let registry = MapRegistry { hosts };
+        let validator = make_validator(1, addr);
+
+        let host = registry
+            .get_host(&validator)
+            .await
+            .expect("should find host");
+        assert_eq!(host, expected_host);
+    }
+
+    #[tokio::test]
+    async fn map_registry_returns_host_not_found_when_absent() {
+        let registry = MapRegistry {
+            hosts: HashMap::new(),
+        };
+        let validator = make_validator(1, [99u8; 20]);
+
+        let result = registry.get_host(&validator).await;
+        assert!(result.is_err(), "should return an error for missing host");
+
+        match result.unwrap_err() {
+            FibreError::HostNotFound(addr_hex) => {
+                assert_eq!(
+                    addr_hex,
+                    hex::encode_upper([99u8; 20]),
+                    "error should contain the hex-encoded address"
+                );
+            }
+            other => panic!("expected HostNotFound, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn grpc_registry_returns_cached_host() {
+        let client = GrpcClient::builder()
+            .url("http://localhost:50051")
+            .build()
+            .expect("GrpcClient builder should succeed for test URL");
+
+        let registry = GrpcHostRegistry::new(client);
+
+        let addr = [7u8; 20];
+        let expected_host = Host("dns:///cached-validator.example.com:9090".to_string());
+
+        // Manually populate the cache.
+        registry
+            .cache
+            .write()
+            .await
+            .insert(addr, expected_host.clone());
+
+        let validator = make_validator(2, addr);
+
+        // get_host should return the cached value without hitting the (unreachable) server.
+        let host = registry
+            .get_host(&validator)
+            .await
+            .expect("should return cached host");
+
+        assert_eq!(host, expected_host);
+    }
+}

--- a/fibre/src/transport/mod.rs
+++ b/fibre/src/transport/mod.rs
@@ -1,0 +1,6 @@
+//! Transport abstractions and gRPC adapters.
+
+pub(crate) mod grpc_validator_client;
+pub(crate) mod host_registry;
+pub(crate) mod proto_conv;
+pub(crate) mod validator_client;

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -1,0 +1,457 @@
+//! Conversions between domain types and protobuf types.
+//!
+//! These functions convert between the crate's domain types and the generated
+//! protobuf types from `celestia-proto`. They are used by the gRPC transport
+//! layer ([`crate::grpc_validator_client`]) and the put flow ([`crate::upload`]).
+
+#[cfg(test)]
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use celestia_proto::celestia::fibre::v1 as proto;
+use celestia_proto::cosmos::crypto::secp256k1::PubKey as ProtoPubKey;
+use ed25519_dalek::VerifyingKey as Ed25519PublicKey;
+use tendermint_proto::google::protobuf::Timestamp;
+use tendermint_proto::v0_38::crypto::public_key::Sum as CryptoKeySum;
+
+use crate::error::FibreError;
+use crate::payment_promise::PaymentPromise;
+use crate::validator::{ValidatorInfo, ValidatorSet};
+
+impl From<&PaymentPromise> for proto::PaymentPromise {
+    fn from(pp: &PaymentPromise) -> Self {
+        let creation_timestamp = system_time_to_timestamp(pp.creation_timestamp);
+
+        let signer_public_key = Some(ProtoPubKey {
+            key: pp.signer_pubkey.to_encoded_point(true).as_bytes().to_vec(),
+        });
+
+        proto::PaymentPromise {
+            chain_id: pp.chain_id.clone(),
+            height: pp.height as i64,
+            namespace: pp.namespace.clone(),
+            blob_size: pp.upload_size,
+            blob_version: pp.blob_version,
+            commitment: pp.commitment.to_vec(),
+            creation_timestamp: Some(creation_timestamp),
+            signer_public_key,
+            signature: pp.signature.clone().unwrap_or_default(),
+        }
+    }
+}
+
+/// Convert a [`rsema1d::RowInclusionProof`] to a proto [`proto::BlobRow`].
+pub(crate) fn row_proof_to_blob_row(proof: &rsema1d::RowInclusionProof) -> proto::BlobRow {
+    proto::BlobRow {
+        index: proof.index as u32,
+        data: proof.row.clone(),
+        proof: proof.row_proof.iter().map(|h| h.to_vec()).collect(),
+    }
+}
+
+/// Convert a proto [`proto::BlobRow`] and an RLC root into a
+/// [`rsema1d::RowInclusionProof`].
+pub(crate) fn blob_row_to_row_proof(
+    row: proto::BlobRow,
+    rlc_root: [u8; 32],
+) -> Result<rsema1d::RowInclusionProof, FibreError> {
+    let row_proof = row
+        .proof
+        .into_iter()
+        .map(|h| {
+            let len = h.len();
+            h.try_into().map_err(|_| {
+                FibreError::InvalidData(
+                    format!("proof hash has invalid length {len}, expected 32",),
+                )
+            })
+        })
+        .collect::<Result<Vec<[u8; 32]>, FibreError>>()?;
+
+    Ok(rsema1d::RowInclusionProof {
+        index: row.index as usize,
+        row: row.data,
+        row_proof,
+        rlc_root,
+    })
+}
+
+/// Build a proto [`proto::BlobShard`] for an upload request.
+///
+/// Upload shards carry RLC coefficients (not a root) so the validator can
+/// verify each row without having enough rows to reconstruct.
+pub(crate) fn build_upload_shard(
+    proofs: &[rsema1d::RowInclusionProof],
+    rlc_coeffs: &[rsema1d::GF128],
+) -> proto::BlobShard {
+    let rows = proofs.iter().map(row_proof_to_blob_row).collect();
+
+    // Flatten RLC coefficients: 16 bytes per original row (GF128 → bytes)
+    let mut coefficients = Vec::with_capacity(rlc_coeffs.len() * 16);
+    for coeff in rlc_coeffs {
+        coefficients.extend_from_slice(&coeff.to_bytes());
+    }
+
+    proto::BlobShard {
+        rows,
+        rlc: Some(proto::blob_shard::Rlc::Coefficients(coefficients)),
+    }
+}
+
+/// Parse a proto [`proto::DownloadShardResponse`] into a list of
+/// [`rsema1d::RowInclusionProof`]s.
+///
+/// Download shards carry an RLC root (not coefficients) — the client has
+/// enough rows to reconstruct and can verify the root after reconstruction.
+pub(crate) fn parse_download_response(
+    resp: proto::DownloadShardResponse,
+) -> Result<Vec<rsema1d::RowInclusionProof>, FibreError> {
+    let shard = resp
+        .shard
+        .ok_or_else(|| FibreError::InvalidData("download response missing shard".into()))?;
+
+    let rlc_root = match shard.rlc {
+        Some(proto::blob_shard::Rlc::Root(ref root)) => {
+            let arr: [u8; 32] = root.as_slice().try_into().map_err(|_| {
+                FibreError::InvalidData(format!(
+                    "rlc root has invalid length {}, expected 32",
+                    root.len()
+                ))
+            })?;
+            arr
+        }
+        _ => {
+            return Err(FibreError::InvalidData(
+                "download response shard missing rlc root".into(),
+            ));
+        }
+    };
+
+    shard
+        .rows
+        .into_iter()
+        .map(|row| blob_row_to_row_proof(row, rlc_root))
+        .collect()
+}
+
+impl TryFrom<(&tendermint_proto::v0_38::types::ValidatorSet, u64)> for ValidatorSet {
+    type Error = FibreError;
+
+    fn try_from(
+        (proto_set, height): (&tendermint_proto::v0_38::types::ValidatorSet, u64),
+    ) -> Result<Self, Self::Error> {
+        let validators = proto_set
+            .validators
+            .iter()
+            .map(ValidatorInfo::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ValidatorSet { validators, height })
+    }
+}
+
+impl TryFrom<&tendermint_proto::v0_38::types::Validator> for ValidatorInfo {
+    type Error = FibreError;
+
+    fn try_from(
+        proto_val: &tendermint_proto::v0_38::types::Validator,
+    ) -> Result<Self, Self::Error> {
+        let pubkey_bytes = match proto_val.pub_key.as_ref() {
+            Some(pk) => match &pk.sum {
+                Some(CryptoKeySum::Ed25519(bytes)) => bytes.clone(),
+                _ => {
+                    return Err(FibreError::Other(
+                        "expected ed25519 public key for validator".into(),
+                    ));
+                }
+            },
+            None => {
+                return Err(FibreError::Other("validator missing public key".into()));
+            }
+        };
+
+        let pubkey =
+            Ed25519PublicKey::from_bytes(pubkey_bytes.as_slice().try_into().map_err(|_| {
+                FibreError::InvalidData(format!(
+                    "ed25519 key has invalid length {}, expected 32",
+                    pubkey_bytes.len()
+                ))
+            })?)
+            .map_err(|e| FibreError::Other(format!("invalid ed25519 key: {e}")))?;
+
+        // CometBFT address = first 20 bytes of SHA-256(pubkey)
+        let address: [u8; 20] = {
+            use sha2::{Digest, Sha256};
+            let hash = Sha256::digest(pubkey.as_bytes());
+            hash[..20]
+                .try_into()
+                .expect("sha256 output is always 32 bytes")
+        };
+
+        Ok(ValidatorInfo {
+            address,
+            pubkey,
+            voting_power: proto_val.voting_power,
+        })
+    }
+}
+
+fn system_time_to_timestamp(t: SystemTime) -> Timestamp {
+    match t.duration_since(UNIX_EPOCH) {
+        Ok(d) => Timestamp {
+            seconds: d.as_secs() as i64,
+            nanos: d.subsec_nanos() as i32,
+        },
+        Err(e) => {
+            // Before epoch — use protobuf convention where nanos is
+            // always non-negative: seconds = -(secs+1), nanos = 1e9 - subsec.
+            let d = e.duration();
+            let subsec = d.subsec_nanos();
+            if subsec == 0 {
+                Timestamp {
+                    seconds: -(d.as_secs() as i64),
+                    nanos: 0,
+                }
+            } else {
+                Timestamp {
+                    seconds: -(d.as_secs() as i64) - 1,
+                    nanos: (1_000_000_000 - subsec) as i32,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn timestamp_to_system_time(t: &Timestamp) -> Result<SystemTime, FibreError> {
+    if t.seconds >= 0 {
+        let d = Duration::new(t.seconds as u64, t.nanos as u32);
+        UNIX_EPOCH
+            .checked_add(d)
+            .ok_or_else(|| FibreError::Other("timestamp overflow".into()))
+    } else {
+        // Reverse the protobuf convention: if nanos > 0 the actual
+        // duration is (|seconds| - 1) seconds + (1e9 - nanos) subsec nanos.
+        let (secs, nanos) = if t.nanos > 0 {
+            ((-t.seconds - 1) as u64, (1_000_000_000 - t.nanos) as u32)
+        } else {
+            ((-t.seconds) as u64, 0u32)
+        };
+        let d = Duration::new(secs, nanos);
+        UNIX_EPOCH
+            .checked_sub(d)
+            .ok_or_else(|| FibreError::Other("timestamp underflow".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k256::ecdsa::SigningKey;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn payment_promise_to_proto_roundtrip_fields() {
+        let sk = SigningKey::random(&mut OsRng);
+        let pp = PaymentPromise {
+            chain_id: "test-chain".into(),
+            height: 42,
+            namespace: vec![0u8; 29],
+            upload_size: 1024,
+            blob_version: 0,
+            commitment: [7u8; 32],
+            creation_timestamp: SystemTime::now(),
+            signer_pubkey: *sk.verifying_key(),
+            signature: Some(vec![1u8; 64]),
+        };
+
+        let proto_pp = proto::PaymentPromise::from(&pp);
+        assert_eq!(proto_pp.chain_id, "test-chain");
+        assert_eq!(proto_pp.height, 42);
+        assert_eq!(proto_pp.namespace, vec![0u8; 29]);
+        assert_eq!(proto_pp.blob_size, 1024);
+        assert_eq!(proto_pp.blob_version, 0);
+        assert_eq!(proto_pp.commitment, vec![7u8; 32]);
+        assert_eq!(proto_pp.signature, vec![1u8; 64]);
+
+        let ts = proto_pp.creation_timestamp.unwrap();
+        assert!(ts.seconds > 0);
+
+        let pk = proto_pp.signer_public_key.unwrap();
+        assert_eq!(pk.key.len(), 33); // compressed secp256k1
+    }
+
+    #[test]
+    fn row_proof_blob_row_roundtrip() {
+        let proof = rsema1d::RowInclusionProof {
+            index: 5,
+            row: vec![42u8; 64],
+            row_proof: vec![[1u8; 32], [2u8; 32]],
+            rlc_root: [3u8; 32],
+        };
+
+        let blob_row = row_proof_to_blob_row(&proof);
+        assert_eq!(blob_row.index, 5);
+        assert_eq!(blob_row.data, vec![42u8; 64]);
+        assert_eq!(blob_row.proof.len(), 2);
+
+        let back = blob_row_to_row_proof(blob_row, [3u8; 32]).unwrap();
+        assert_eq!(back.index, 5);
+        assert_eq!(back.row, vec![42u8; 64]);
+        assert_eq!(back.row_proof, vec![[1u8; 32], [2u8; 32]]);
+        assert_eq!(back.rlc_root, [3u8; 32]);
+    }
+
+    #[test]
+    fn blob_row_to_row_proof_invalid_hash_length() {
+        let row = proto::BlobRow {
+            index: 0,
+            data: vec![0u8; 64],
+            proof: vec![vec![0u8; 31]], // wrong length
+        };
+        let result = blob_row_to_row_proof(row, [0u8; 32]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_upload_shard_includes_coefficients() {
+        let proofs = vec![rsema1d::RowInclusionProof {
+            index: 0,
+            row: vec![0u8; 64],
+            row_proof: vec![[0u8; 32]],
+            rlc_root: [0u8; 32],
+        }];
+        let coeffs = vec![rsema1d::GF128::zero(); 2];
+
+        let shard = build_upload_shard(&proofs, &coeffs);
+        assert_eq!(shard.rows.len(), 1);
+        match shard.rlc {
+            Some(proto::blob_shard::Rlc::Coefficients(c)) => {
+                assert_eq!(c.len(), 32); // 2 coefficients × 16 bytes
+            }
+            _ => panic!("expected Coefficients variant"),
+        }
+    }
+
+    #[test]
+    fn parse_download_response_success() {
+        let rlc_root = [9u8; 32];
+        let resp = proto::DownloadShardResponse {
+            shard: Some(proto::BlobShard {
+                rows: vec![proto::BlobRow {
+                    index: 3,
+                    data: vec![1u8; 64],
+                    proof: vec![vec![2u8; 32]],
+                }],
+                rlc: Some(proto::blob_shard::Rlc::Root(rlc_root.to_vec())),
+            }),
+        };
+
+        let proofs = parse_download_response(resp).unwrap();
+        assert_eq!(proofs.len(), 1);
+        assert_eq!(proofs[0].index, 3);
+        assert_eq!(proofs[0].rlc_root, rlc_root);
+    }
+
+    #[test]
+    fn parse_download_response_missing_shard() {
+        let resp = proto::DownloadShardResponse { shard: None };
+        assert!(parse_download_response(resp).is_err());
+    }
+
+    #[test]
+    fn parse_download_response_missing_rlc_root() {
+        let resp = proto::DownloadShardResponse {
+            shard: Some(proto::BlobShard {
+                rows: vec![],
+                rlc: None,
+            }),
+        };
+        assert!(parse_download_response(resp).is_err());
+    }
+
+    #[test]
+    fn timestamp_roundtrip() {
+        let now = SystemTime::now();
+        let ts = system_time_to_timestamp(now);
+        let back = timestamp_to_system_time(&ts).unwrap();
+
+        // Compare with nanosecond tolerance
+        let diff = now
+            .duration_since(back)
+            .or_else(|_| back.duration_since(now))
+            .unwrap();
+        assert!(diff < Duration::from_micros(1));
+    }
+
+    #[test]
+    fn pre_epoch_timestamp_roundtrip() {
+        // 1969-06-15 00:00:00.500 UTC → 0.5s before some whole-second boundary
+        let t = UNIX_EPOCH - Duration::new(10, 500_000_000);
+        let ts = system_time_to_timestamp(t);
+
+        // Protobuf convention: nanos must be non-negative
+        assert!(ts.nanos >= 0, "nanos must be non-negative: {}", ts.nanos);
+        assert_eq!(ts.seconds, -11);
+        assert_eq!(ts.nanos, 500_000_000);
+
+        let back = timestamp_to_system_time(&ts).unwrap();
+        let diff = t
+            .duration_since(back)
+            .or_else(|_| back.duration_since(t))
+            .unwrap();
+        assert_eq!(diff.as_nanos(), 0, "pre-epoch roundtrip lost precision");
+    }
+
+    #[test]
+    fn pre_epoch_timestamp_exact_second() {
+        let t = UNIX_EPOCH - Duration::new(5, 0);
+        let ts = system_time_to_timestamp(t);
+        assert_eq!(ts.seconds, -5);
+        assert_eq!(ts.nanos, 0);
+
+        let back = timestamp_to_system_time(&ts).unwrap();
+        let diff = t
+            .duration_since(back)
+            .or_else(|_| back.duration_since(t))
+            .unwrap();
+        assert_eq!(diff.as_nanos(), 0);
+    }
+
+    #[test]
+    fn validator_from_proto_valid() {
+        // Generate a random ed25519 key using raw bytes
+        let mut secret = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut OsRng, &mut secret);
+        let sk = ed25519_dalek::SigningKey::from_bytes(&secret);
+        let pk = sk.verifying_key();
+
+        let proto_val = tendermint_proto::v0_38::types::Validator {
+            address: vec![0u8; 20], // not used in conversion (derived from pubkey)
+            pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
+                sum: Some(CryptoKeySum::Ed25519(pk.as_bytes().to_vec())),
+            }),
+            voting_power: 100,
+            proposer_priority: 0,
+        };
+
+        let info = ValidatorInfo::try_from(&proto_val).unwrap();
+        assert_eq!(info.pubkey, pk);
+        assert_eq!(info.voting_power, 100);
+        // Verify address is derived from pubkey
+        use sha2::{Digest, Sha256};
+        let expected_addr: [u8; 20] = Sha256::digest(pk.as_bytes())[..20].try_into().unwrap();
+        assert_eq!(info.address, expected_addr);
+    }
+
+    #[test]
+    fn validator_from_proto_missing_key() {
+        let proto_val = tendermint_proto::v0_38::types::Validator {
+            address: vec![],
+            pub_key: None,
+            voting_power: 100,
+            proposer_priority: 0,
+        };
+        assert!(ValidatorInfo::try_from(&proto_val).is_err());
+    }
+}

--- a/fibre/src/transport/validator_client.rs
+++ b/fibre/src/transport/validator_client.rs
@@ -1,0 +1,69 @@
+//! Abstract transport traits for communicating with validators.
+//!
+//! The transport is split into two traits:
+//! - [`ValidatorConnection`] — a connection to a single validator (upload/download shards)
+//! - [`ValidatorConnector`] — factory that creates/caches connections by validator address
+//!
+//! Production uses gRPC ([`crate::grpc_validator_client`]); tests use in-memory mocks.
+
+use std::sync::Arc;
+
+use crate::blob::BlobID;
+use crate::error::FibreError;
+use crate::payment_promise::PaymentPromise;
+use crate::validator::ValidatorInfo;
+
+/// Response from a validator after accepting a shard upload.
+#[derive(Debug, Clone)]
+pub struct UploadResponse {
+    /// Ed25519 signature over the payment promise sign bytes.
+    pub validator_signature: Vec<u8>,
+}
+
+/// Response from a validator when downloading a shard.
+#[derive(Debug, Clone)]
+pub struct DownloadResponse {
+    /// The blob shard containing rows with inclusion proofs.
+    pub rows: Vec<DownloadedRow>,
+}
+
+/// A single row from a download response.
+#[derive(Debug, Clone)]
+pub struct DownloadedRow {
+    /// The row inclusion proof from rsema1d.
+    pub proof: rsema1d::RowInclusionProof,
+}
+
+/// A connection to a single validator's fibre service.
+///
+/// In production this is backed by a tonic gRPC channel.
+/// In tests this is an in-memory store with signing capability.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait ValidatorConnection: Send + Sync {
+    /// Upload a shard (payment promise + row proofs + RLC coefficients) and receive a validator signature.
+    async fn upload_shard(
+        &self,
+        promise: &PaymentPromise,
+        rows: &[rsema1d::RowInclusionProof],
+        rlc_coeffs: &[rsema1d::GF128],
+    ) -> Result<UploadResponse, FibreError>;
+
+    /// Download rows for a blob by its ID.
+    async fn download_shard(&self, blob_id: &BlobID) -> Result<DownloadResponse, FibreError>;
+}
+
+/// Factory for creating/caching connections to individual validators.
+///
+/// In production this resolves hosts via [`crate::host_registry::HostRegistry`]
+/// and manages tonic channels. In tests this returns mock connections that
+/// can be inspected after the test.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait ValidatorConnector: Send + Sync {
+    /// Get or create a connection to the given validator.
+    async fn connect(
+        &self,
+        validator: &ValidatorInfo,
+    ) -> Result<Arc<dyn ValidatorConnection>, FibreError>;
+}


### PR DESCRIPTION
## Summary
- Adds `GrpcValidatorClient` for uploading/downloading shards to validators
- Adds `HostRegistry` for resolving validator addresses (with `dns:///` to `http://` normalization)
- Adds `ValidatorClient` trait for abstracting validator connections
- Adds proto conversion module for mapping between domain types and protobuf messages

## Test plan
- [ ] Proto round-trip tests pass (domain -> proto -> domain)
- [ ] Host registry resolves validator addresses correctly
- [ ] GrpcValidatorClient connects and communicates with validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)