### PR TITLE
feat: add fibre download client and lumina client integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "async-stream",
  "blockstore",
  "bytes",
+ "celestia-fibre",
  "celestia-grpc",
  "celestia-proto",
  "celestia-rpc",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,6 +20,7 @@ categories = [
 ]
 
 [dependencies]
+celestia-fibre.workspace = true
 celestia-grpc.workspace = true
 celestia-proto.workspace  = true
 celestia-rpc = { workspace = true, default-features = false }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -79,6 +79,7 @@ pub struct Client {
     share: ShareApi,
     fraud: FraudApi,
     blobstream: BlobstreamApi,
+    fibre: Option<crate::fibre::FibreApi>,
 }
 
 pub(crate) struct ClientInner {
@@ -89,12 +90,31 @@ pub(crate) struct ClientInner {
 }
 
 /// A builder for [`Client`].
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct ClientBuilder {
     rpc_url: Option<String>,
     rpc_auth_token: Option<String>,
     timeout: Option<Duration>,
     grpc_builder: Option<GrpcClientBuilder>,
+    fibre_client: Option<celestia_fibre::FibreClient>,
+}
+
+impl fmt::Debug for ClientBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClientBuilder")
+            .field("rpc_url", &self.rpc_url)
+            .field(
+                "rpc_auth_token",
+                &self.rpc_auth_token.as_ref().map(|_| "***"),
+            )
+            .field("timeout", &self.timeout)
+            .field("grpc_builder", &self.grpc_builder)
+            .field(
+                "fibre_client",
+                &self.fibre_client.as_ref().map(|_| "FibreClient { .. }"),
+            )
+            .finish()
+    }
 }
 
 impl ClientInner {
@@ -167,6 +187,14 @@ impl Client {
     /// Returns fraud API accessor.
     pub fn fraud(&self) -> &FraudApi {
         &self.fraud
+    }
+
+    /// Returns fibre API accessor.
+    ///
+    /// Returns `None` if the client was not configured with a fibre client.
+    /// Use [`ClientBuilder::fibre_client()`] to provide one.
+    pub fn fibre(&self) -> Option<&crate::fibre::FibreApi> {
+        self.fibre.as_ref()
     }
 }
 
@@ -295,6 +323,19 @@ impl ClientBuilder {
         self
     }
 
+    /// Set a pre-built [`FibreClient`](celestia_fibre::FibreClient) for the Fibre
+    /// data availability protocol.
+    ///
+    /// When set, the client exposes a [`FibreApi`](crate::fibre::FibreApi) via
+    /// [`Client::fibre()`].
+    ///
+    /// Use [`FibreClient::from_endpoint()`](celestia_fibre::FibreClient::from_endpoint) for
+    /// convenient construction from a gRPC endpoint URL.
+    pub fn fibre_client(mut self, fibre_client: celestia_fibre::FibreClient) -> Self {
+        self.fibre_client = Some(fibre_client);
+        self
+    }
+
     /// Build [`Client`].
     pub async fn build(self) -> Result<Client> {
         let rpc_url = self.rpc_url.as_ref().ok_or(Error::RpcEndpointNotSet)?;
@@ -329,6 +370,10 @@ impl ClientBuilder {
             chain_id: head.chain_id().to_owned(),
         });
 
+        let fibre = self
+            .fibre_client
+            .map(|fc| crate::fibre::FibreApi::new(inner.clone(), fc));
+
         Ok(Client {
             inner: inner.clone(),
             blob: BlobApi::new(inner.clone()),
@@ -337,6 +382,7 @@ impl ClientBuilder {
             fraud: FraudApi::new(inner.clone()),
             blobstream: BlobstreamApi::new(inner.clone()),
             state: StateApi::new(inner.clone()),
+            fibre,
         })
     }
 }

--- a/client/src/fibre.rs
+++ b/client/src/fibre.rs
@@ -1,0 +1,105 @@
+//! Fibre API for off-chain data availability.
+//!
+//! The [`FibreApi`] wraps a [`celestia_fibre::FibreClient`] to provide
+//! upload and download operations through the celestia-client.
+
+use std::sync::Arc;
+
+use celestia_fibre::{
+    Blob, BlobID, DownloadOptions, FibreClient, FibreError, SignedPaymentPromise,
+};
+use celestia_grpc::{SubmittedTx, TxConfig};
+use k256::ecdsa::SigningKey;
+
+use crate::Error;
+use crate::client::ClientInner;
+
+/// Fibre API for off-chain data availability.
+///
+/// Provides access to the Fibre DA protocol for uploading and downloading
+/// blobs directly to/from validators, bypassing on-chain blob submission.
+pub struct FibreApi {
+    inner: Arc<ClientInner>,
+    fibre_client: Arc<FibreClient>,
+}
+
+impl FibreApi {
+    pub(crate) fn new(inner: Arc<ClientInner>, fibre_client: FibreClient) -> Self {
+        Self {
+            inner,
+            fibre_client: Arc::new(fibre_client),
+        }
+    }
+
+    /// Upload a pre-encoded [`Blob`] and collect validator signatures.
+    ///
+    /// Returns a [`SignedPaymentPromise`] once enough validator signatures
+    /// have been collected to meet the safety threshold.
+    pub async fn upload(
+        &self,
+        signing_key: &SigningKey,
+        namespace: &[u8],
+        blob: Blob,
+    ) -> Result<SignedPaymentPromise, FibreError> {
+        self.fibre_client.upload(signing_key, namespace, blob).await
+    }
+
+    /// Upload data and broadcast `MsgPayForFibre` on-chain.
+    ///
+    /// Encodes the data into a blob, distributes it to validators via the
+    /// Fibre protocol, collects signatures, and broadcasts a `MsgPayForFibre`
+    /// transaction. Returns a [`SubmittedTx`] handle that can be used to
+    /// confirm the transaction.
+    ///
+    /// Requires the client to have a gRPC endpoint and signer configured.
+    pub async fn put(
+        &self,
+        signing_key: &SigningKey,
+        namespace: &[u8],
+        data: &[u8],
+    ) -> Result<SubmittedTx, Error> {
+        let grpc = self.inner.grpc()?;
+        let signer_address = grpc
+            .get_account_address()
+            .ok_or(Error::NoAssociatedAddress)?;
+
+        let msg = self
+            .fibre_client
+            .upload_and_prepare(signing_key, namespace, data, &signer_address.to_string())
+            .await
+            .map_err(fibre_err)?;
+
+        let submitted = grpc.broadcast_message(msg, TxConfig::default()).await?;
+
+        Ok(submitted)
+    }
+
+    /// Download and reconstruct a blob by its [`BlobID`].
+    ///
+    /// Fetches row proofs from validators and reconstructs the original data
+    /// using erasure coding.
+    pub async fn download(&self, id: &BlobID, opts: DownloadOptions) -> Result<Blob, FibreError> {
+        self.fibre_client.download(id, opts).await
+    }
+
+    /// Returns `true` if the underlying fibre client has been closed.
+    pub fn is_closed(&self) -> bool {
+        self.fibre_client.is_closed()
+    }
+
+    /// Close the underlying fibre client.
+    pub fn close(&self) {
+        self.fibre_client.close();
+    }
+}
+
+/// Convert a [`FibreError`] into the client [`Error`] type.
+fn fibre_err(e: FibreError) -> Error {
+    match e {
+        FibreError::Grpc(status) => Error::Grpc(celestia_grpc::Error::from(*status)),
+        FibreError::GrpcClient(grpc_err) => Error::Grpc(grpc_err),
+        #[cfg(not(target_arch = "wasm32"))]
+        FibreError::Transport(t) => Error::Grpc(celestia_grpc::Error::from(t)),
+        other => Error::Fibre(other),
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -6,6 +6,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 mod blob;
 mod blobstream;
 mod client;
+mod fibre;
 mod fraud;
 mod header;
 mod share;
@@ -18,6 +19,7 @@ mod utils;
 pub mod api {
     pub use crate::blob::BlobApi;
     pub use crate::blobstream::BlobstreamApi;
+    pub use crate::fibre::FibreApi;
     pub use crate::fraud::FraudApi;
     pub use crate::header::HeaderApi;
     pub use crate::share::ShareApi;
@@ -27,6 +29,15 @@ pub mod api {
     pub mod blob {
         #[doc(inline)]
         pub use celestia_rpc::blob::BlobsAtHeight;
+    }
+
+    /// Fibre API related types.
+    pub mod fibre {
+        #[doc(inline)]
+        pub use celestia_fibre::{
+            Blob as FibreBlob, BlobID, DownloadOptions, FibreClient, FibreClientConfig, FibreError,
+            PaymentPromise, SignedPaymentPromise,
+        };
     }
 
     /// Share API related types.
@@ -55,7 +66,9 @@ pub mod tx {
     #[doc(inline)]
     pub use celestia_grpc::grpc::{GasEstimate, TxPriority};
     #[doc(inline)]
-    pub use celestia_grpc::{DocSigner, IntoProtobufAny, SignDoc, TxConfig, TxInfo};
+    pub use celestia_grpc::{
+        BroadcastedTx, DocSigner, IntoProtobufAny, SignDoc, SubmittedTx, TxConfig, TxInfo,
+    };
     #[doc(inline)]
     pub use k256::ecdsa::signature::{Error as SignatureError, Keypair};
     #[doc(inline)]
@@ -131,6 +144,10 @@ pub enum Error {
     /// gRPC endpoint is not set.
     #[error("Signer is set but gRPC endpoint is not")]
     GrpcEndpointNotSet,
+
+    /// An error from the Fibre client library.
+    #[error("Fibre error: {0}")]
+    Fibre(celestia_fibre::FibreError),
 }
 
 impl From<jsonrpsee_core::ClientError> for Error {

--- a/fibre/src/client/download.rs
+++ b/fibre/src/client/download.rs
@@ -1,0 +1,503 @@
+//! Download flow orchestration.
+//!
+//! Retrieves a blob from validators and reconstructs it using erasure coding
+//! with an adaptive fan-out strategy.
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use tokio_util::sync::CancellationToken;
+
+use lumina_utils::cond_send::BoxFuture;
+
+use crate::client::task::spawn_task;
+
+use crate::ValidatorInfo;
+use crate::blob::{Blob, BlobID};
+use crate::client::FibreClient;
+#[cfg(test)]
+use crate::config::BlobConfig;
+use crate::error::FibreError;
+use crate::validator::ValidatorSet;
+
+/// Options for configuring blob download behavior.
+#[derive(Default)]
+pub struct DownloadOptions {
+    /// When set, use the validator set at this height instead of head.
+    pub height: Option<u64>,
+}
+
+impl FibreClient {
+    /// Download and reconstruct a blob by its [`BlobID`].
+    ///
+    /// The method:
+    /// 1. Fetches the current validator set (or at a specific height via `opts`).
+    /// 2. Selects validators ordered by download priority.
+    /// 3. Downloads row inclusion proofs from validators using adaptive fan-out.
+    /// 4. Reconstructs the original data from collected proofs.
+    ///
+    /// Returns the reconstructed [`Blob`] whose `data()` contains the original payload.
+    ///
+    /// # Errors
+    ///
+    /// - [`FibreError::ClientClosed`] if the client has been closed.
+    /// - [`FibreError::NotFound`] if no validator returned any rows.
+    /// - [`FibreError::NotEnoughShards`] if too few unique rows were collected.
+    /// - Any error from reconstruction (commitment mismatch, encoding, etc.).
+    pub async fn download(&self, id: &BlobID, opts: DownloadOptions) -> Result<Blob, FibreError> {
+        if self.cancel_token.is_cancelled() {
+            return Err(FibreError::ClientClosed);
+        }
+
+        let val_set = match opts.height {
+            Some(h) => self.set_getter.get_by_height(h).await?,
+            None => self.set_getter.head().await?,
+        };
+        let mut blob = Blob::empty(id.clone())?;
+        self.select_and_download(&val_set, &mut blob).await?;
+        blob.reconstruct()?;
+        Ok(blob)
+    }
+
+    /// Internal download with a custom [`BlobConfig`].
+    ///
+    /// This allows tests to use small K/N parameters without going through
+    /// the production `Blob::empty()` path which hardcodes production params.
+    #[cfg(test)]
+    pub(crate) async fn download_with_config(
+        &self,
+        id: &BlobID,
+        blob_cfg: BlobConfig,
+    ) -> Result<Blob, FibreError> {
+        if self.cancel_token.is_cancelled() {
+            return Err(FibreError::ClientClosed);
+        }
+
+        let val_set = self.set_getter.head().await?;
+        let mut blob = Blob::empty_with_config(id.clone(), blob_cfg);
+        self.select_and_download(&val_set, &mut blob).await?;
+        blob.reconstruct()?;
+        Ok(blob)
+    }
+
+    async fn select_and_download(
+        &self,
+        val_set: &ValidatorSet,
+        blob: &mut Blob,
+    ) -> Result<(), FibreError> {
+        let selected = val_set.select(
+            blob.config().original_rows,
+            self.cfg.min_rows_per_validator,
+            self.cfg.liveness_threshold,
+        );
+
+        self.download_blob(
+            &selected,
+            blob.config().original_rows,
+            blob,
+            &self.cancel_token,
+        )
+        .await
+    }
+
+    /// Download row proofs from validators and apply them to the blob.
+    ///
+    /// Maintains a dynamic concurrency invariant:
+    ///   `unique_rows + inflight_rows >= original_rows`
+    /// When a validator fails, the shortfall immediately triggers spawning
+    /// more validators to compensate.
+    async fn download_blob(
+        &self,
+        selected: &[(usize, &ValidatorInfo)],
+        original_rows: usize,
+        blob: &mut Blob,
+        cancel_token: &CancellationToken,
+    ) -> Result<(), FibreError> {
+        if selected.is_empty() {
+            return Err(FibreError::NotFound);
+        }
+
+        let blob_id = blob.id().clone();
+        #[allow(clippy::type_complexity)]
+        let mut futures: FuturesUnordered<
+            BoxFuture<
+                'static,
+                (
+                    usize,
+                    Option<Result<Vec<rsema1d::RowInclusionProof>, FibreError>>,
+                ),
+            >,
+        > = FuturesUnordered::new();
+
+        let mut cur_idx = 0;
+        let mut unique_rows: usize = 0;
+        let mut inflight_rows: usize = 0;
+
+        loop {
+            // Spawn more validators while we need more rows covered.
+            let need_more =
+                (unique_rows + inflight_rows) < original_rows && cur_idx < selected.len();
+
+            if !need_more && futures.is_empty() {
+                break;
+            }
+
+            tokio::select! {
+                result = self.download_semaphore.clone().acquire_owned(), if need_more => {
+                    let global_permit = result
+                        .map_err(|_| FibreError::Other("global semaphore closed".into()))?;
+                    let val_idx = cur_idx;
+                    cur_idx += 1;
+                    let (rows, info) = selected[val_idx];
+                    inflight_rows += rows;
+
+                    let connector = self.connector.clone();
+                    let validator = info.clone();
+                    let blob_id = blob_id.clone();
+
+                    spawn_task(&mut futures, val_idx, async move {
+                        let _global = global_permit;
+                        let conn = connector.connect(&validator).await?;
+                        let resp = conn.download_shard(&blob_id).await?;
+                        if resp.rows.is_empty() {
+                            return Err(FibreError::EmptyShardResponse);
+                        }
+                        Ok(resp.rows.into_iter().map(|r| r.proof).collect())
+                    });
+                }
+                task_result = futures.next(), if !futures.is_empty() => {
+                    match task_result {
+                        Some((val_idx, Some(Ok(proofs)))) => {
+                            let (rows, info) = selected[val_idx];
+                            inflight_rows = inflight_rows.saturating_sub(rows);
+                            let total = proofs.len();
+                            let mut applied = 0usize;
+                            for proof in proofs {
+                                if matches!(blob.set_row(proof), Ok(true)) {
+                                    applied += 1;
+                                }
+                            }
+                            unique_rows += applied;
+                            if applied == 0 && total > 0 {
+                                tracing::warn!(
+                                    validator = %hex::encode(info.address),
+                                    total,
+                                    "no rows applied from validator response"
+                                );
+                            }
+                            if unique_rows >= original_rows {
+                                break;
+                            }
+                        }
+                        Some((val_idx, Some(Err(e)))) => {
+                            let (rows, info) = selected[val_idx];
+                            inflight_rows = inflight_rows.saturating_sub(rows);
+                            tracing::warn!(
+                                validator = %hex::encode(info.address),
+                                error = %e,
+                                "shard download failed"
+                            );
+                            // Invariant violated — loop will spawn more validators.
+                        }
+                        Some((val_idx, None)) => {
+                            let (rows, info) = selected[val_idx];
+                            inflight_rows = inflight_rows.saturating_sub(rows);
+                            tracing::warn!(
+                                validator = %hex::encode(info.address),
+                                "download task dropped unexpectedly"
+                            );
+                        }
+                        None => break,
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    return Err(FibreError::Cancelled);
+                }
+            }
+        }
+
+        if unique_rows == 0 {
+            return Err(FibreError::NotFound);
+        }
+        if unique_rows < original_rows {
+            return Err(FibreError::NotEnoughShards {
+                got: unique_rows,
+                need: original_rows,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::blob::{Blob, BlobID};
+    use crate::config::BlobConfig;
+    use crate::error::FibreError;
+    use crate::test_utils::{
+        MockConnector, MockValidatorConnection, build_test_client, make_validator, test_blob_config,
+    };
+    use crate::validator::ValidatorSet;
+
+    /// Encode a blob, extract all row proofs, and store them on each mock
+    /// validator connection. Returns the BlobID.
+    fn prepare_blob_and_distribute(
+        data: &[u8],
+        connections: &[Arc<MockValidatorConnection>],
+        cfg: &BlobConfig,
+    ) -> BlobID {
+        let blob = Blob::new(data, cfg.clone()).unwrap();
+        let blob_id = blob.id().clone();
+        let total_rows = cfg.total_rows();
+
+        for conn in connections {
+            let mut proofs = Vec::new();
+            for i in 0..total_rows {
+                proofs.push(blob.row(i).unwrap());
+            }
+            conn.store_proofs(blob_id.commitment(), proofs);
+        }
+
+        blob_id
+    }
+
+    #[tokio::test]
+    async fn download_reconstructs_blob() {
+        let cfg = test_blob_config();
+        let data: Vec<u8> = (0u8..=199).collect();
+
+        let validators = [
+            make_validator(100, 1),
+            make_validator(100, 2),
+            make_validator(100, 3),
+        ];
+        let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
+        let val_set = ValidatorSet {
+            validators: val_infos.clone(),
+            height: 1,
+        };
+
+        let conns: Vec<Arc<MockValidatorConnection>> = validators
+            .iter()
+            .map(|(k, _)| Arc::new(MockValidatorConnection::new(k.clone())))
+            .collect();
+
+        let blob_id = prepare_blob_and_distribute(&data, &conns, &cfg);
+
+        let mut connector = MockConnector::new();
+        for (i, (_, v)) in validators.iter().enumerate() {
+            connector.add(v.address, conns[i].clone());
+        }
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        let blob = client.download_with_config(&blob_id, cfg).await.unwrap();
+
+        assert_eq!(blob.data().unwrap(), &data);
+    }
+
+    #[tokio::test]
+    async fn download_handles_validator_failure() {
+        let cfg = test_blob_config();
+        let data: Vec<u8> = (0u8..=199).collect();
+
+        // 5 validators; validator 0 and 1 will fail
+        let validators = [
+            make_validator(100, 1),
+            make_validator(100, 2),
+            make_validator(100, 3),
+            make_validator(100, 4),
+            make_validator(100, 5),
+        ];
+        let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
+        let val_set = ValidatorSet {
+            validators: val_infos.clone(),
+            height: 1,
+        };
+
+        let failing_conn_0 = Arc::new(MockValidatorConnection::new_failing(
+            validators[0].0.clone(),
+        ));
+        let failing_conn_1 = Arc::new(MockValidatorConnection::new_failing(
+            validators[1].0.clone(),
+        ));
+        let good_conns: Vec<Arc<MockValidatorConnection>> = validators[2..]
+            .iter()
+            .map(|(k, _)| Arc::new(MockValidatorConnection::new(k.clone())))
+            .collect();
+
+        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob_id = blob.id().clone();
+        let total_rows = cfg.total_rows();
+
+        for conn in &good_conns {
+            let mut proofs = Vec::new();
+            for i in 0..total_rows {
+                proofs.push(blob.row(i).unwrap());
+            }
+            conn.store_proofs(blob_id.commitment(), proofs);
+        }
+
+        let mut connector = MockConnector::new();
+        connector.add(val_infos[0].address, failing_conn_0);
+        connector.add(val_infos[1].address, failing_conn_1);
+        for (i, conn) in good_conns.iter().enumerate() {
+            connector.add(val_infos[i + 2].address, conn.clone());
+        }
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        let result = client.download_with_config(&blob_id, cfg).await.unwrap();
+
+        assert_eq!(result.data().unwrap(), &data);
+    }
+
+    #[tokio::test]
+    async fn download_fails_when_not_enough_shards() {
+        let cfg = test_blob_config();
+        let data: Vec<u8> = (0u8..=99).collect();
+
+        // Single validator that fails
+        let validators = [make_validator(100, 1)];
+        let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
+        let val_set = ValidatorSet {
+            validators: val_infos.clone(),
+            height: 1,
+        };
+
+        let failing_conn = Arc::new(MockValidatorConnection::new_failing(
+            validators[0].0.clone(),
+        ));
+        let mut connector = MockConnector::new();
+        connector.add(val_infos[0].address, failing_conn);
+
+        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob_id = blob.id().clone();
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        let result = client.download_with_config(&blob_id, cfg).await;
+
+        assert!(
+            matches!(result, Err(FibreError::NotFound)),
+            "expected NotFound error"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_fails_when_client_closed() {
+        let cfg = test_blob_config();
+        let (key, val) = make_validator(100, 1);
+        let val_set = ValidatorSet {
+            validators: vec![val.clone()],
+            height: 1,
+        };
+
+        let conn = Arc::new(MockValidatorConnection::new(key));
+        let mut connector = MockConnector::new();
+        connector.add(val.address, conn);
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        client.close();
+
+        let blob_id = BlobID::new(0, [0u8; 32]);
+        let result = client.download_with_config(&blob_id, cfg).await;
+
+        assert!(
+            matches!(result, Err(FibreError::ClientClosed)),
+            "expected ClientClosed error"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_roundtrip_upload_then_download() {
+        let cfg = test_blob_config();
+        let original_data: Vec<u8> = (0u8..=249).collect();
+
+        let validators = [
+            make_validator(100, 10),
+            make_validator(100, 20),
+            make_validator(100, 30),
+        ];
+        let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
+        let val_set = ValidatorSet {
+            validators: val_infos.clone(),
+            height: 42,
+        };
+
+        let blob = Blob::new(&original_data, cfg.clone()).unwrap();
+        let blob_id = blob.id().clone();
+        let total_rows = cfg.total_rows();
+
+        let conns: Vec<Arc<MockValidatorConnection>> = validators
+            .iter()
+            .map(|(k, _)| Arc::new(MockValidatorConnection::new(k.clone())))
+            .collect();
+
+        for conn in &conns {
+            let mut proofs = Vec::new();
+            for i in 0..total_rows {
+                proofs.push(blob.row(i).unwrap());
+            }
+            conn.store_proofs(blob_id.commitment(), proofs);
+        }
+
+        let mut connector = MockConnector::new();
+        for (i, (_, v)) in validators.iter().enumerate() {
+            connector.add(v.address, conns[i].clone());
+        }
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        let downloaded = client.download_with_config(&blob_id, cfg).await.unwrap();
+
+        assert_eq!(downloaded.data().unwrap(), &original_data);
+        assert_eq!(downloaded.id(), &blob_id);
+    }
+
+    #[tokio::test]
+    async fn download_empty_response_triggers_replacement() {
+        let cfg = test_blob_config();
+        let data: Vec<u8> = (0u8..=149).collect();
+
+        // 3 validators; validator 0 returns NotFound (no proofs stored)
+        let validators = [
+            make_validator(100, 1),
+            make_validator(100, 2),
+            make_validator(100, 3),
+        ];
+        let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
+        let val_set = ValidatorSet {
+            validators: val_infos.clone(),
+            height: 1,
+        };
+
+        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob_id = blob.id().clone();
+        let total_rows = cfg.total_rows();
+
+        // Validator 0 has an empty store (returns NotFound)
+        let empty_conn = Arc::new(MockValidatorConnection::new(validators[0].0.clone()));
+
+        // Validators 1 and 2 have proofs
+        let good_conns: Vec<Arc<MockValidatorConnection>> = validators[1..]
+            .iter()
+            .map(|(k, _)| {
+                let conn = Arc::new(MockValidatorConnection::new(k.clone()));
+                let mut proofs = Vec::new();
+                for i in 0..total_rows {
+                    proofs.push(blob.row(i).unwrap());
+                }
+                conn.store_proofs(blob_id.commitment(), proofs);
+                conn
+            })
+            .collect();
+
+        let mut connector = MockConnector::new();
+        connector.add(val_infos[0].address, empty_conn);
+        connector.add(val_infos[1].address, good_conns[0].clone());
+        connector.add(val_infos[2].address, good_conns[1].clone());
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        let downloaded = client.download_with_config(&blob_id, cfg).await.unwrap();
+
+        assert_eq!(downloaded.data().unwrap(), &data);
+    }
+}

--- a/fibre/src/client/mod.rs
+++ b/fibre/src/client/mod.rs
@@ -7,6 +7,7 @@
 //! Use [`FibreClientBuilder`] (via [`FibreClient::builder()`]) to construct
 //! an instance.
 
+pub(crate) mod download;
 pub(crate) mod task;
 pub(crate) mod upload;
 
@@ -30,6 +31,7 @@ pub struct FibreClient {
     pub(crate) set_getter: Arc<dyn SetGetter>,
     pub(crate) connector: Arc<dyn ValidatorConnector>,
     pub(crate) upload_semaphore: Arc<tokio::sync::Semaphore>,
+    pub(crate) download_semaphore: Arc<tokio::sync::Semaphore>,
     pub(crate) cancel_token: CancellationToken,
 }
 
@@ -141,6 +143,7 @@ impl FibreClientBuilder {
 
         Ok(FibreClient {
             upload_semaphore: Arc::new(tokio::sync::Semaphore::new(cfg.upload_concurrency)),
+            download_semaphore: Arc::new(tokio::sync::Semaphore::new(cfg.download_concurrency)),
             cfg,
             set_getter,
             connector,

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -259,3 +259,268 @@ impl FibreClient {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use k256::ecdsa::SigningKey;
+    use rand::rngs::OsRng;
+
+    use crate::blob::Blob;
+    use crate::config::BlobConfig;
+    use crate::error::FibreError;
+    use crate::test_utils::{
+        FailingConnector, MockConnector, MockValidatorConnection, build_test_client,
+        make_connector, make_validator,
+    };
+    use crate::validator::{ValidatorInfo, ValidatorSet};
+
+    fn make_test_blob() -> Blob {
+        let cfg = BlobConfig::new_test(0, 4, 4, 4096, 4, 64);
+        let data: Vec<u8> = (0u8..200).collect();
+        Blob::new(&data, cfg).unwrap()
+    }
+
+    fn test_signing_key() -> SigningKey {
+        SigningKey::random(&mut OsRng)
+    }
+
+    #[tokio::test]
+    async fn upload_fails_when_client_closed() {
+        let (_, val) = make_validator(100, 1);
+        let validators = vec![make_validator(100, 1)];
+        let connector = make_connector(&validators);
+
+        let val_set = ValidatorSet {
+            validators: vec![val],
+            height: 1,
+        };
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        client.close();
+
+        let sk = test_signing_key();
+        let blob = make_test_blob();
+        let namespace = vec![0u8; 29];
+        let result = client.upload(&sk, &namespace, blob).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            FibreError::ClientClosed => {}
+            other => panic!("expected ClientClosed, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn upload_collects_signatures() {
+        let validators = vec![
+            make_validator(100, 1),
+            make_validator(100, 2),
+            make_validator(100, 3),
+        ];
+
+        let val_infos: Vec<ValidatorInfo> =
+            validators.iter().map(|(_, info)| info.clone()).collect();
+
+        let connector = make_connector(&validators);
+
+        let val_set = ValidatorSet {
+            validators: val_infos,
+            height: 42,
+        };
+
+        let sk = test_signing_key();
+        let client = build_test_client(val_set, connector, "test-chain");
+        let blob = make_test_blob();
+        let namespace = vec![0u8; 29];
+
+        let result = client.upload(&sk, &namespace, blob).await;
+        assert!(result.is_ok(), "upload should succeed: {:?}", result.err());
+
+        let signed = result.unwrap();
+        assert_eq!(signed.promise.height, 42);
+        assert_eq!(signed.promise.chain_id, "test-chain");
+
+        let sig_count = signed
+            .validator_signatures
+            .iter()
+            .filter(|s| s.is_some())
+            .count();
+        assert!(
+            sig_count >= 2,
+            "expected at least 2 signatures, got {sig_count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_delivers_to_all_validators() {
+        let validators = vec![
+            make_validator(100, 1),
+            make_validator(100, 2),
+            make_validator(100, 3),
+            make_validator(100, 4),
+            make_validator(100, 5),
+        ];
+
+        let val_infos: Vec<ValidatorInfo> =
+            validators.iter().map(|(_, info)| info.clone()).collect();
+
+        // Build the connector manually so we can inspect each connection after upload.
+        let mut connector = MockConnector::new();
+        let mut connections: Vec<Arc<MockValidatorConnection>> = Vec::new();
+        for (ed_key, info) in &validators {
+            let conn = Arc::new(MockValidatorConnection::new(ed_key.clone()));
+            connections.push(conn.clone());
+            connector.add(info.address, conn);
+        }
+
+        let val_set = ValidatorSet {
+            validators: val_infos,
+            height: 1,
+        };
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        let blob = make_test_blob();
+        let namespace = vec![0u8; 29];
+
+        // Upload returns once signature threshold is met.
+        client
+            .upload(&test_signing_key(), &namespace, blob)
+            .await
+            .unwrap();
+
+        // Background tasks continue delivering to remaining validators.
+        // Wait for every connection to receive at least one upload.
+        for (i, conn) in connections.iter().enumerate() {
+            tokio::time::timeout(tokio::time::Duration::from_secs(5), conn.wait_for_upload())
+                .await
+                .unwrap_or_else(|_| panic!("validator {i} did not receive upload data in time"));
+        }
+    }
+
+    #[tokio::test]
+    async fn upload_returns_when_threshold_met() {
+        let v1 = make_validator(200, 1);
+        let v2 = make_validator(200, 2);
+        let v3 = make_validator(200, 3);
+        let v4 = make_validator(100, 4);
+        let v5 = make_validator(100, 5);
+
+        let all_validators = [v1.clone(), v2.clone(), v3.clone(), v4.clone(), v5.clone()];
+        let val_infos: Vec<ValidatorInfo> = all_validators
+            .iter()
+            .map(|(_, info)| info.clone())
+            .collect();
+
+        let successful = vec![v1, v2, v3];
+        let inner = make_connector(&successful);
+        let fail_addresses = vec![val_infos[3].address, val_infos[4].address];
+
+        let failing_connector = FailingConnector {
+            inner,
+            fail_addresses,
+        };
+
+        let val_set = ValidatorSet {
+            validators: val_infos,
+            height: 10,
+        };
+
+        let client = build_test_client(val_set, failing_connector, "test-chain");
+        let blob = make_test_blob();
+        let namespace = vec![0u8; 29];
+
+        let result = client.upload(&test_signing_key(), &namespace, blob).await;
+        assert!(
+            result.is_ok(),
+            "upload should succeed with 3/5 validators: {:?}",
+            result.err()
+        );
+
+        let signed = result.unwrap();
+        let sig_count = signed
+            .validator_signatures
+            .iter()
+            .filter(|s| s.is_some())
+            .count();
+        assert!(
+            sig_count >= 2,
+            "expected at least 2 signatures, got {sig_count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_fails_when_not_enough_signatures() {
+        let v1 = make_validator(100, 1);
+        let v2 = make_validator(100, 2);
+        let v3 = make_validator(100, 3);
+        let v4 = make_validator(100, 4);
+        let v5 = make_validator(100, 5);
+
+        let all_validators = [v1.clone(), v2.clone(), v3.clone(), v4.clone(), v5.clone()];
+        let val_infos: Vec<ValidatorInfo> = all_validators
+            .iter()
+            .map(|(_, info)| info.clone())
+            .collect();
+
+        let successful = vec![v1];
+        let inner = make_connector(&successful);
+        let fail_addresses = vec![
+            val_infos[1].address,
+            val_infos[2].address,
+            val_infos[3].address,
+            val_infos[4].address,
+        ];
+
+        let failing_connector = FailingConnector {
+            inner,
+            fail_addresses,
+        };
+
+        let val_set = ValidatorSet {
+            validators: val_infos,
+            height: 10,
+        };
+
+        let client = build_test_client(val_set, failing_connector, "test-chain");
+        let blob = make_test_blob();
+        let namespace = vec![0u8; 29];
+
+        let result = client.upload(&test_signing_key(), &namespace, blob).await;
+        assert!(
+            result.is_err(),
+            "upload should fail when not enough signatures"
+        );
+        match result.unwrap_err() {
+            FibreError::NotEnoughSignatures { .. } => {}
+            other => panic!("expected NotEnoughSignatures, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn put_fails_when_client_closed() {
+        let (_, val) = make_validator(100, 1);
+        let validators = vec![make_validator(100, 1)];
+        let connector = make_connector(&validators);
+
+        let val_set = ValidatorSet {
+            validators: vec![val],
+            height: 1,
+        };
+
+        let client = build_test_client(val_set, connector, "test-chain");
+        client.close();
+
+        let namespace = vec![0u8; 29];
+        let data = vec![1u8; 100];
+        let sk = test_signing_key();
+        let result = client
+            .upload_and_prepare(&sk, &namespace, &data, "celestia1test")
+            .await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            FibreError::ClientClosed => {}
+            other => panic!("expected ClientClosed, got: {other}"),
+        }
+    }
+}

--- a/fibre/src/lib.rs
+++ b/fibre/src/lib.rs
@@ -17,7 +17,13 @@ pub use domain::error;
 pub(crate) use domain::{blob, blob_header, payment_promise};
 pub(crate) use transport::{grpc_validator_client, host_registry, proto_conv, validator_client};
 
+#[cfg(test)]
+mod roundtrip_test;
+#[cfg(test)]
+mod test_utils;
+
 pub use celestia_grpc::Endpoint;
+pub use client::download::DownloadOptions;
 pub use client::{FibreClient, FibreClientBuilder};
 pub use config::{
     BlobConfig, DEFAULT_PROTOCOL_PARAMS, FibreClientConfig, Fraction, ProtocolParams,

--- a/fibre/src/roundtrip_test.rs
+++ b/fibre/src/roundtrip_test.rs
@@ -1,0 +1,138 @@
+//! End-to-end roundtrip tests for FibreClient.
+//!
+//! These tests exercise the full client flow: `upload()` → `download()` → verify
+//! data matches. Mock validators store rows on upload and return them on download,
+//! with valid ed25519 signatures so the upload signature collection succeeds.
+
+use std::sync::Arc;
+
+use crate::blob::Blob;
+use crate::test_utils::{
+    MockConnector, MockValidatorConnection, build_test_client, make_connector, make_validator,
+    test_blob_config,
+};
+
+#[tokio::test]
+async fn upload_then_download_roundtrip() {
+    let cfg = test_blob_config();
+    let original_data: Vec<u8> = (0u8..200).collect();
+
+    let blob = Blob::new(&original_data, cfg.clone()).unwrap();
+    let blob_id = blob.id().clone();
+
+    let validators = vec![
+        make_validator(100, 1),
+        make_validator(100, 2),
+        make_validator(100, 3),
+    ];
+
+    let connector = make_connector(&validators);
+    let val_infos = validators.iter().map(|(_, v)| v.clone()).collect();
+    let val_set = crate::validator::ValidatorSet {
+        validators: val_infos,
+        height: 42,
+    };
+
+    let client = build_test_client(val_set, connector, "roundtrip-test");
+
+    // Upload.
+    let signed = client
+        .upload(
+            &k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng),
+            &[0u8; 29],
+            blob,
+        )
+        .await;
+    assert!(signed.is_ok(), "upload should succeed: {:?}", signed.err());
+
+    let signed = signed.unwrap();
+    let sig_count = signed
+        .validator_signatures
+        .iter()
+        .filter(|s| s.is_some())
+        .count();
+    assert!(
+        sig_count >= 2,
+        "expected at least 2 validator signatures, got {sig_count}"
+    );
+
+    // Download and verify data matches.
+    let downloaded = client.download_with_config(&blob_id, cfg).await;
+    assert!(
+        downloaded.is_ok(),
+        "download should succeed: {:?}",
+        downloaded.err()
+    );
+
+    let downloaded = downloaded.unwrap();
+    assert_eq!(
+        downloaded.data().unwrap(),
+        &original_data,
+        "downloaded data should match original"
+    );
+    assert_eq!(downloaded.id(), &blob_id);
+}
+
+#[tokio::test]
+async fn roundtrip_with_partial_validator_failure() {
+    let cfg = test_blob_config();
+    let original_data: Vec<u8> = (0u8..200).collect();
+
+    let blob = Blob::new(&original_data, cfg.clone()).unwrap();
+    let blob_id = blob.id().clone();
+
+    // 5 validators: first 3 succeed, last 2 fail.
+    let v1 = make_validator(200, 1);
+    let v2 = make_validator(200, 2);
+    let v3 = make_validator(200, 3);
+    let v4 = make_validator(100, 4);
+    let v5 = make_validator(100, 5);
+
+    let all_validators = [v1.clone(), v2.clone(), v3.clone(), v4.clone(), v5.clone()];
+
+    let mut connector = MockConnector::new();
+    for (ed_key, info) in &[v1, v2, v3] {
+        connector.add(
+            info.address,
+            Arc::new(MockValidatorConnection::new(ed_key.clone())),
+        );
+    }
+    for (ed_key, info) in &[v4, v5] {
+        connector.add(
+            info.address,
+            Arc::new(MockValidatorConnection::new_failing(ed_key.clone())),
+        );
+    }
+
+    let val_infos = all_validators.iter().map(|(_, v)| v.clone()).collect();
+    let val_set = crate::validator::ValidatorSet {
+        validators: val_infos,
+        height: 42,
+    };
+
+    let client = build_test_client(val_set, connector, "roundtrip-test");
+
+    // Total voting power = 800. 2/3 threshold = 533.
+    // 3 good validators have 600 voting power > 533 → upload should succeed.
+    let signed = client
+        .upload(
+            &k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng),
+            &[0u8; 29],
+            blob,
+        )
+        .await;
+    assert!(
+        signed.is_ok(),
+        "upload should succeed with 3/5 validators: {:?}",
+        signed.err()
+    );
+
+    // Download should reconstruct from the 3 good validators.
+    let downloaded = client.download_with_config(&blob_id, cfg).await;
+    assert!(
+        downloaded.is_ok(),
+        "download should succeed: {:?}",
+        downloaded.err()
+    );
+    assert_eq!(downloaded.unwrap().data().unwrap(), &original_data);
+}

--- a/fibre/src/test_utils.rs
+++ b/fibre/src/test_utils.rs
@@ -1,0 +1,277 @@
+//! Shared test utilities for FibreClient tests.
+//!
+//! Contains unified mock implementations used across upload, download, and
+//! roundtrip tests.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use ed25519_dalek::SigningKey as Ed25519SigningKey;
+
+use crate::blob::BlobID;
+use crate::client::FibreClient;
+use crate::config::{BlobConfig, FibreClientConfig, Fraction};
+use crate::error::FibreError;
+use crate::payment_promise::PaymentPromise;
+use crate::validator::{SetGetter, ValidatorInfo, ValidatorSet};
+use crate::validator_client::{
+    DownloadResponse, DownloadedRow, UploadResponse, ValidatorConnection, ValidatorConnector,
+};
+
+/// Mock [`SetGetter`] that returns a fixed validator set.
+pub(crate) struct MockSetGetter {
+    pub val_set: ValidatorSet,
+}
+
+#[async_trait::async_trait]
+impl SetGetter for MockSetGetter {
+    async fn head(&self) -> Result<ValidatorSet, FibreError> {
+        Ok(self.val_set.clone())
+    }
+
+    async fn get_by_height(&self, _height: u64) -> Result<ValidatorSet, FibreError> {
+        Ok(self.val_set.clone())
+    }
+}
+
+/// A mock validator connection that signs upload responses and stores/returns
+/// rows for download. Supports an optional `fail` flag to simulate failures.
+pub(crate) struct MockValidatorConnection {
+    /// Ed25519 signing key for this mock validator.
+    ed_signing_key: Ed25519SigningKey,
+    /// Rows stored by commitment hash.
+    stored: Mutex<HashMap<[u8; 32], Vec<rsema1d::RowInclusionProof>>>,
+    /// Record of what was uploaded (each call appends a list of row proofs).
+    uploaded: Mutex<Vec<Vec<rsema1d::RowInclusionProof>>>,
+    /// Watch channel incremented on each upload, for awaiting uploads in tests.
+    upload_tx: tokio::sync::watch::Sender<usize>,
+    /// If true, all operations return an error.
+    fail: bool,
+}
+
+impl MockValidatorConnection {
+    pub fn new(ed_signing_key: Ed25519SigningKey) -> Self {
+        let (tx, _) = tokio::sync::watch::channel(0usize);
+        Self {
+            ed_signing_key,
+            stored: Mutex::new(HashMap::new()),
+            uploaded: Mutex::new(Vec::new()),
+            upload_tx: tx,
+            fail: false,
+        }
+    }
+
+    pub fn new_failing(ed_signing_key: Ed25519SigningKey) -> Self {
+        let (tx, _) = tokio::sync::watch::channel(0usize);
+        Self {
+            ed_signing_key,
+            stored: Mutex::new(HashMap::new()),
+            uploaded: Mutex::new(Vec::new()),
+            upload_tx: tx,
+            fail: true,
+        }
+    }
+
+    /// Store row proofs externally (for download-only tests where upload is skipped).
+    pub fn store_proofs(&self, commitment: [u8; 32], proofs: Vec<rsema1d::RowInclusionProof>) {
+        self.stored
+            .lock()
+            .unwrap()
+            .entry(commitment)
+            .or_default()
+            .extend(proofs);
+    }
+
+    /// Returns the list of uploaded row proof batches.
+    #[allow(dead_code)]
+    pub fn uploaded(&self) -> Vec<Vec<rsema1d::RowInclusionProof>> {
+        self.uploaded.lock().unwrap().clone()
+    }
+
+    /// Wait until at least one upload has been received.
+    pub async fn wait_for_upload(&self) {
+        let mut rx = self.upload_tx.subscribe();
+        // If already uploaded, return immediately.
+        if *rx.borrow() > 0 {
+            return;
+        }
+        // Otherwise wait for the next change.
+        let _ = rx.changed().await;
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatorConnection for MockValidatorConnection {
+    async fn upload_shard(
+        &self,
+        promise: &PaymentPromise,
+        rows: &[rsema1d::RowInclusionProof],
+        _rlc_coeffs: &[rsema1d::GF128],
+    ) -> Result<UploadResponse, FibreError> {
+        if self.fail {
+            return Err(FibreError::Other("mock connection failure".into()));
+        }
+
+        // Record what was uploaded and notify waiters.
+        self.uploaded.lock().unwrap().push(rows.to_vec());
+        self.upload_tx.send_modify(|n| *n += 1);
+
+        // Store uploaded rows keyed by commitment.
+        self.stored
+            .lock()
+            .unwrap()
+            .entry(promise.commitment)
+            .or_default()
+            .extend(rows.to_vec());
+
+        // Sign the promise's sign bytes (CometBFT-wrapped, same for client and validators).
+        use ed25519_dalek::Signer;
+        let sign_bytes = promise.sign_bytes()?;
+        let signature = self.ed_signing_key.sign(&sign_bytes);
+
+        Ok(UploadResponse {
+            validator_signature: signature.to_bytes().to_vec(),
+        })
+    }
+
+    async fn download_shard(&self, blob_id: &BlobID) -> Result<DownloadResponse, FibreError> {
+        if self.fail {
+            return Err(FibreError::Other("mock connection failure".into()));
+        }
+
+        let stored = self.stored.lock().unwrap();
+        let proofs = stored
+            .get(&blob_id.commitment())
+            .ok_or(FibreError::NotFound)?;
+
+        Ok(DownloadResponse {
+            rows: proofs
+                .iter()
+                .map(|p| DownloadedRow { proof: p.clone() })
+                .collect(),
+        })
+    }
+}
+
+/// A connector that returns pre-configured connections by validator address.
+pub(crate) struct MockConnector {
+    connections: HashMap<[u8; 20], Arc<MockValidatorConnection>>,
+}
+
+impl MockConnector {
+    pub fn new() -> Self {
+        Self {
+            connections: HashMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, address: [u8; 20], conn: Arc<MockValidatorConnection>) {
+        self.connections.insert(address, conn);
+    }
+
+    /// Returns the connection for the given address, if any.
+    #[allow(dead_code)]
+    pub fn get(&self, address: &[u8; 20]) -> Option<&Arc<MockValidatorConnection>> {
+        self.connections.get(address)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatorConnector for MockConnector {
+    async fn connect(
+        &self,
+        validator: &ValidatorInfo,
+    ) -> Result<Arc<dyn ValidatorConnection>, FibreError> {
+        self.connections
+            .get(&validator.address)
+            .cloned()
+            .map(|c| c as Arc<dyn ValidatorConnection>)
+            .ok_or_else(|| FibreError::HostNotFound(hex::encode(validator.address)))
+    }
+}
+
+/// A connector that fails for specific validator addresses, delegating
+/// everything else to an inner connector.
+pub(crate) struct FailingConnector {
+    pub inner: MockConnector,
+    pub fail_addresses: Vec<[u8; 20]>,
+}
+
+#[async_trait::async_trait]
+impl ValidatorConnector for FailingConnector {
+    async fn connect(
+        &self,
+        validator: &ValidatorInfo,
+    ) -> Result<Arc<dyn ValidatorConnection>, FibreError> {
+        if self.fail_addresses.contains(&validator.address) {
+            return Err(FibreError::HostNotFound(hex::encode(validator.address)));
+        }
+        self.inner.connect(validator).await
+    }
+}
+
+/// Create a validator with a deterministic ed25519 keypair.
+pub(crate) fn make_validator(power: i64, seed: u8) -> (Ed25519SigningKey, ValidatorInfo) {
+    let mut key_bytes = [0u8; 32];
+    key_bytes[0] = seed;
+    let ed_key = Ed25519SigningKey::from_bytes(&key_bytes);
+    let pubkey = ed_key.verifying_key();
+    (
+        ed_key,
+        ValidatorInfo {
+            address: [seed; 20],
+            pubkey,
+            voting_power: power,
+        },
+    )
+}
+
+/// Standard test blob configuration: K=4, N=4, min_row_size=64.
+pub(crate) fn test_blob_config() -> BlobConfig {
+    BlobConfig::new_test(0, 4, 4, 4096, 4, 64)
+}
+
+/// Standard test client configuration.
+pub(crate) fn test_client_config(chain_id: &str) -> FibreClientConfig {
+    FibreClientConfig {
+        chain_id: chain_id.to_string(),
+        safety_threshold: Fraction {
+            numerator: 2,
+            denominator: 3,
+        },
+        liveness_threshold: Fraction {
+            numerator: 1,
+            denominator: 3,
+        },
+        min_rows_per_validator: 1,
+        max_message_size: 1 << 20,
+        upload_concurrency: 10,
+        download_concurrency: 10,
+    }
+}
+
+/// Build a [`FibreClient`] from a validator set and connector with test config.
+pub(crate) fn build_test_client(
+    val_set: ValidatorSet,
+    connector: impl ValidatorConnector + 'static,
+    chain_id: &str,
+) -> FibreClient {
+    FibreClient::builder()
+        .config(test_client_config(chain_id))
+        .set_getter(MockSetGetter { val_set })
+        .connector(connector)
+        .build()
+        .unwrap()
+}
+
+/// Create a [`MockConnector`] with connections for each validator.
+pub(crate) fn make_connector(validators: &[(Ed25519SigningKey, ValidatorInfo)]) -> MockConnector {
+    let mut connector = MockConnector::new();
+    for (ed_key, info) in validators {
+        connector.add(
+            info.address,
+            Arc::new(MockValidatorConnection::new(ed_key.clone())),
+        );
+    }
+    connector
+}


### PR DESCRIPTION
## Summary
Combines PR 9 (fibre download + roundtrip tests) and PR 10 (lumina client integration) into a single PR. Adds:
- `FibreClient::download()` for reconstructing blobs from validator shards (parallel retrieval + rsema1d reconstruction)
- `fibre/src/test_utils.rs` — mock validators, test configs, key generation
- `fibre/src/roundtrip_test.rs` — upload → download integration test
- Restores the `upload.rs` test module that was deferred from PR 7+8 (depends on `test_utils`)
- Re-wires `download_semaphore` / `download_concurrency` on `FibreClient`
- New `FibreApi` on `celestia_client::Client`, exposed via `Client::fibre()` and configured via `ClientBuilder::fibre_client()`
- `FibreApi::put()` delegates to `FibreClient::upload_and_prepare()` and broadcasts `MsgPayForFibre` on-chain

## Test plan
- [ ] CI passes (clippy native + wasm32, missing-docs, fmt, rustdoc, tests)
- [ ] Roundtrip test covers upload → download with partial validator failure
- [ ] Upload test module (restored from PR 7+8) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)