### PR TITLE
ci: make release-plz PR creation manual-only

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,14 +5,13 @@ permissions:
   contents: write
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
 
     outputs:
       pr: ${{ steps.release-plz.outputs.pr }}


### PR DESCRIPTION
## Summary

Switch `release-plz.yml` from a push-on-main trigger to `workflow_dispatch`, so release PRs are opened on demand from the Actions tab rather than being generated automatically after every merge to main.

## Motivation

The auto-proposed bumps have been misaligned with actual release intent — for example, a single `ci!:` or `feat!:` commit causes release-plz to propose a major bump across all 13 workspace crates (all sharing `[workspace.package] version`). Moving to manual dispatch lets the release driver pick the version, review the proposed changelog, and merge when appropriate, without the tool pre-committing to a number on every merge.

## What changes

- `on: push: { branches: [main] }` → `on: workflow_dispatch:`
- Added `if: github.ref == 'refs/heads/main'` guard so the dispatch can only run against main, matching the previous trigger's scope.
- The `release-plz-pr-npm-update` job is unchanged — it still runs after `release-plz` when that job produces a PR, so the npm/wasm sync continues to happen on the release PR.

## What does NOT change

- `release-plz-release.yml` — still triggers on merge of any `release-plz-*` PR into main, still publishes to crates.io and npm. The publish side is version-driven and idempotent, so it behaves identically.
- Workspace version layout or conventional-commit conventions. Those are separate conversations (independent per-crate versions, splitting CLI/wasm/uniffi out of the shared version, tightening what counts as a breaking change).

## How to cut a release after this lands

1. Actions → Release-plz PR → Run workflow → select `main` → Run.
2. Review the PR it opens. Edit the version numbers in `Cargo.toml` if release-plz's proposal is wrong.
3. (If you edited versions) Re-run the workflow so the changelog and npm sync job re-converge on your chosen version.
4. Merge the PR. `release-plz-release.yml` publishes.

## Test plan

- [ ] Confirm dispatch-only trigger appears in the Actions tab after merge.
- [ ] Confirm a normal merge to main no longer triggers `Release-plz PR`.
- [ ] Dispatch the workflow once on main and verify it still opens a release PR with the npm sync applied.
- [ ] Merge a dispatched release PR once and verify `release-plz-release.yml` still publishes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)