### PR TITLE
feat(client): expose get_tx on StateApi for reading submitted transactions

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -64,7 +64,7 @@ pub mod api {
 /// TX related types.
 pub mod tx {
     #[doc(inline)]
-    pub use celestia_grpc::grpc::{GasEstimate, TxPriority};
+    pub use celestia_grpc::grpc::{GasEstimate, GetTxResponse, TxPriority};
     #[doc(inline)]
     pub use celestia_grpc::{
         BroadcastedTx, DocSigner, IntoProtobufAny, SignDoc, SubmittedTx, TxConfig, TxInfo,

--- a/client/src/state.rs
+++ b/client/src/state.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use celestia_rpc::{HeaderClient, StateClient};
+use celestia_types::hash::Hash;
 
 use crate::Error;
 use crate::client::ClientInner;
@@ -8,7 +9,7 @@ use crate::proto::cosmos::bank::v1beta1::MsgSend;
 use crate::proto::cosmos::staking::v1beta1::{
     MsgBeginRedelegate, MsgCancelUnbondingDelegation, MsgDelegate, MsgUndelegate,
 };
-use crate::tx::{GasEstimate, IntoProtobufAny, TxConfig, TxInfo, TxPriority};
+use crate::tx::{GasEstimate, GetTxResponse, IntoProtobufAny, TxConfig, TxInfo, TxPriority};
 use crate::types::Blob;
 use crate::types::state::{
     AccAddress, Address, Coin, PageRequest, QueryDelegationResponse, QueryRedelegationsResponse,
@@ -264,6 +265,53 @@ impl StateApi {
                 .submit_blobs(&blobs, cfg)
                 .context(&context)
                 .await?)
+        })
+    }
+
+    /// Fetches a transaction by its hash, returning both the decoded
+    /// `Tx` (with auth info, messages, fee) and the `TxResponse`
+    /// (gas used, raw log, etc.).
+    ///
+    /// Useful for callers that need to inspect what a previously
+    /// broadcast transaction actually paid in fees or consumed in
+    /// gas. The `submit_*` helpers on this struct return [`TxInfo`]
+    /// which only carries the hash and block height; this is the
+    /// follow-up call to get everything else.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use celestia_client::{Client, Result};
+    /// # use celestia_client::tx::TxConfig;
+    /// # async fn docs() -> Result<()> {
+    /// use celestia_types::nmt::Namespace;
+    /// use celestia_types::Blob;
+    ///
+    /// let client = Client::builder()
+    ///     .rpc_url("ws://localhost:26658")
+    ///     .grpc_url("http://localhost:9090")
+    ///     .private_key_hex("393fdb5def075819de55756b45c9e2c8531a8c78dd6eede483d3440e9457d839")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let ns = Namespace::new_v0(b"abcd").unwrap();
+    /// let blob = Blob::new(ns, "some data".into(), None).unwrap();
+    ///
+    /// let info = client
+    ///     .state()
+    ///     .submit_pay_for_blob(&[blob], TxConfig::default())
+    ///     .await?;
+    ///
+    /// let resp = client.state().get_tx(info.hash).await?;
+    /// println!("gas used: {}", resp.tx_response.gas_used);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_tx(&self, hash: Hash) -> AsyncGrpcCall<GetTxResponse> {
+        let inner = self.inner.clone();
+
+        AsyncGrpcCall::new(move |context| async move {
+            Ok(inner.grpc()?.get_tx(hash).context(&context).await?)
         })
     }
 


### PR DESCRIPTION
## Summary

Adds a `get_tx(hash)` method to `StateApi` that returns the full `GetTxResponse` (decoded `Tx` plus `TxResponse`) for a previously broadcast transaction. Wraps the existing `GrpcClient::get_tx` and follows the same `inner.grpc()?` pattern as `submit_pay_for_blob` right next door.

## Why I wanted this

I'm running a Sovereign-SDK rollup that posts batches to Celestia via `submit_pay_for_blob`. That method gives me back `TxInfo { hash, height }`, which is enough to identify the blob but not enough to record what it cost. Specifically the fee paid (nanoTIA, on `auth_info.fee.amount`) and the gas used (on the `TxResponse`).

Today the only public path to that data is `Client::grpc()`, which is `pub(crate)`. Consumers either reach for `celestia-grpc` directly and rebuild a parallel client (extra connection, separate config) or do without. This puts the read alongside the matching write, which felt like the smallest change that solves the actual need.

## Notes for review

- I dropped this in `StateApi` because that's where `submit_pay_for_blob` lives and the doc cross-references read naturally. If you'd rather have a dedicated `TxApi` for `get_tx` plus the related `tx_status` / `broadcast_tx` / `simulate` over time, happy to follow up with that refactor in a separate PR.
- `GetTxResponse` is re-exported from the `tx` module so the signature resolves through public types.
- `cargo check -p celestia-client` and `cargo clippy --no-deps -p celestia-client -- -D warnings` are clean locally on the 1.88 MSRV.
- The doc example is `no_run`, matches the surrounding style, and demonstrates the natural follow-up flow from a `submit_pay_for_blob` result.

## Test plan

- [ ] `cargo check -p celestia-client` passes
- [ ] `cargo clippy --no-deps -p celestia-client -- -D warnings` passes
- [ ] Doc example compiles via `cargo test --doc -p celestia-client`
- [ ] Integration smoke against a local Celestia bridge: submit a PFB, then `get_tx(info.hash)` returns a populated `TxResponse` with non-zero `gas_used`

## CONTRIBUTING checklist

Followed `CONTRIBUTING.md`: Conventional Commits prefix (`feat(client):`), commit is SSH-signed, no breaking changes.