### PR TITLE
feat: share one failover engine across RPC and gRPC clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,15 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
-name = "arc-swap"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +765,6 @@ dependencies = [
 name = "celestia-grpc"
 version = "1.0.0"
 dependencies = [
- "arc-swap",
  "async-trait",
  "bytes",
  "celestia-grpc-macros",
@@ -3647,6 +3637,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use blockstore::cond_send::CondSend;
 pub use celestia_grpc::Endpoint;
 use celestia_grpc::{GrpcClient, GrpcClientBuilder};
-use celestia_rpc::{Client as RpcClient, HeaderClient};
+pub use celestia_rpc::RpcEndpoint;
+use celestia_rpc::{FailoverClient, HeaderClient};
 use http::Request;
 use tonic::body::Body as TonicBody;
 use tonic::codegen::{Bytes, Service};
@@ -83,7 +84,7 @@ pub struct Client {
 }
 
 pub(crate) struct ClientInner {
-    pub(crate) rpc: RpcClient,
+    pub(crate) rpc: FailoverClient,
     grpc: Option<GrpcClient>,
     pubkey: Option<VerifyingKey>,
     chain_id: tendermint::chain::Id,
@@ -94,6 +95,9 @@ pub(crate) struct ClientInner {
 pub struct ClientBuilder {
     rpc_url: Option<String>,
     rpc_auth_token: Option<String>,
+    rpc_endpoints: Vec<RpcEndpoint>,
+    rpc_health_check_interval: Option<Duration>,
+    rpc_max_head_age: Option<Duration>,
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
     grpc_builder: Option<GrpcClientBuilder>,
@@ -108,6 +112,16 @@ impl fmt::Debug for ClientBuilder {
                 "rpc_auth_token",
                 &self.rpc_auth_token.as_ref().map(|_| "***"),
             )
+            .field(
+                "rpc_endpoints",
+                &self
+                    .rpc_endpoints
+                    .iter()
+                    .map(|e| &e.url)
+                    .collect::<Vec<_>>(),
+            )
+            .field("rpc_health_check_interval", &self.rpc_health_check_interval)
+            .field("rpc_max_head_age", &self.rpc_max_head_age)
             .field("timeout", &self.timeout)
             .field("connect_timeout", &self.connect_timeout)
             .field("grpc_builder", &self.grpc_builder)
@@ -252,6 +266,58 @@ impl ClientBuilder {
         self
     }
 
+    /// Add an RPC endpoint for failover.
+    ///
+    /// Accepts [`RpcEndpoint`], `&str`, or `String`. Use [`RpcEndpoint`] when an
+    /// endpoint needs its own authentication token (e.g. a fallback provider
+    /// such as QuickNode that uses a different token than your own node).
+    ///
+    /// Endpoints are tried in priority order: the first endpoint added (or the
+    /// one set via [`rpc_url`](ClientBuilder::rpc_url)) is the most preferred.
+    /// When the preferred endpoint fails, the client automatically falls back to
+    /// the next one, and a background health-check switches back to the preferred
+    /// endpoint once it recovers.
+    pub fn rpc_endpoint(mut self, endpoint: impl Into<RpcEndpoint>) -> ClientBuilder {
+        self.rpc_endpoints.push(endpoint.into());
+        self
+    }
+
+    /// Add multiple RPC endpoints at once for failover.
+    ///
+    /// Accepts [`RpcEndpoint`], `&str`, or `String` items. See
+    /// [`rpc_endpoint`](ClientBuilder::rpc_endpoint) for the failover semantics.
+    pub fn rpc_endpoints<I, E>(mut self, endpoints: I) -> ClientBuilder
+    where
+        I: IntoIterator<Item = E>,
+        E: Into<RpcEndpoint>,
+    {
+        self.rpc_endpoints
+            .extend(endpoints.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the interval at which the preferred RPC endpoint is probed for
+    /// recovery while a fallback is in use.
+    ///
+    /// Only has an effect when more than one RPC endpoint is configured.
+    /// Defaults to [`celestia_rpc::DEFAULT_HEALTH_CHECK_INTERVAL`].
+    pub fn rpc_health_check_interval(mut self, interval: Duration) -> ClientBuilder {
+        self.rpc_health_check_interval = Some(interval);
+        self
+    }
+
+    /// Set the maximum age of the preferred RPC endpoint's head for it to be
+    /// considered healthy enough to switch back to.
+    ///
+    /// While a fallback is in use, the background health-check only switches back
+    /// to the preferred endpoint once its head is no older than this (i.e. it has
+    /// caught up to the chain tip). Defaults to
+    /// [`celestia_rpc::DEFAULT_MAX_HEAD_AGE`].
+    pub fn rpc_max_head_age(mut self, max_head_age: Duration) -> ClientBuilder {
+        self.rpc_max_head_age = Some(max_head_age);
+        self
+    }
+
     /// Set the request timeout for both RPC and gRPC endpoints.
     ///
     /// This bounds the duration of individual requests only. To bound how long
@@ -364,8 +430,22 @@ impl ClientBuilder {
 
     /// Build [`Client`].
     pub async fn build(self) -> Result<Client> {
-        let rpc_url = self.rpc_url.as_ref().ok_or(Error::RpcEndpointNotSet)?;
-        let rpc_auth_token = self.rpc_auth_token.as_deref();
+        // The endpoint set via `rpc_url` (with its optional `rpc_auth_token`) is
+        // the most preferred one; any endpoints added via `rpc_endpoint(s)`
+        // follow it as fallbacks.
+        let mut rpc_endpoints = Vec::with_capacity(self.rpc_endpoints.len() + 1);
+        if let Some(url) = self.rpc_url {
+            let mut endpoint = RpcEndpoint::new(url);
+            if let Some(token) = self.rpc_auth_token {
+                endpoint = endpoint.auth_token(token);
+            }
+            rpc_endpoints.push(endpoint);
+        }
+        rpc_endpoints.extend(self.rpc_endpoints);
+
+        if rpc_endpoints.is_empty() {
+            return Err(Error::RpcEndpointNotSet);
+        }
 
         let (grpc, pubkey) = if let Some(mut grpc_builder) = self.grpc_builder {
             if let Some(timeout) = self.timeout {
@@ -381,8 +461,24 @@ impl ClientBuilder {
             (None, None)
         };
 
-        let rpc =
-            RpcClient::new(rpc_url, rpc_auth_token, self.connect_timeout, self.timeout).await?;
+        // Only run the background health-check when there is a preferred endpoint
+        // to switch back to.
+        let health_check_interval = (rpc_endpoints.len() > 1).then(|| {
+            self.rpc_health_check_interval
+                .unwrap_or(celestia_rpc::DEFAULT_HEALTH_CHECK_INTERVAL)
+        });
+
+        let max_head_age = self
+            .rpc_max_head_age
+            .unwrap_or(celestia_rpc::DEFAULT_MAX_HEAD_AGE);
+
+        let rpc = FailoverClient::new(
+            rpc_endpoints,
+            self.connect_timeout,
+            self.timeout,
+            health_check_interval,
+            max_head_age,
+        )?;
 
         let head = rpc.header_network_head().await?;
         head.validate()?;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -89,7 +89,7 @@ pub use celestia_proto as proto;
 #[doc(inline)]
 pub use celestia_types as types;
 
-pub use crate::client::{Client, ClientBuilder, Endpoint};
+pub use crate::client::{Client, ClientBuilder, Endpoint, RpcEndpoint};
 
 /// Alias for a `Result` with the error type [`celestia_client::Error`].
 ///

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -26,9 +26,8 @@ crate-type = ["cdylib", "lib"]
 celestia-grpc-macros.workspace = true
 celestia-proto = { workspace = true, features = ["tonic"] }
 celestia-types.workspace = true
-lumina-utils = { workspace = true, features = ["time", "executor"] }
+lumina-utils = { workspace = true, features = ["time", "executor", "failover"] }
 
-arc-swap = "1"
 async-trait = { workspace = true }
 bytes.workspace = true
 dyn-clone = "1"

--- a/grpc/grpc-macros/src/lib.rs
+++ b/grpc/grpc-macros/src/lib.rs
@@ -53,73 +53,55 @@ impl GrpcMethod {
 
         let method = quote! {
             pub #signature {
-                let transports = self.inner.transports.clone();
+                let failover = self.inner.failover.clone();
                 let param = crate::grpc::IntoGrpcParam::into_parameter(( #( #params ),* ));
 
                 crate::grpc::AsyncGrpcCall::new(move |call_context: crate::grpc::Context| async move {
                     // 256 mb, future proof as celestia blocks grow
                     const MAX_MSG_SIZE: usize = 256 * 1024 * 1024;
 
-                    let mut last_error: Option<crate::Error> = None;
-                    let transport_snapshot = transports.load();
+                    // Failover (and switch-back) is handled by the shared engine;
+                    // this closure performs a single request against one endpoint
+                    // and is replayed across endpoints on network errors.
+                    failover.run(move |transport: ::std::sync::Arc<crate::boxed::BoxedTransport>| {
+                        let param = ::std::clone::Clone::clone(&param);
+                        let call_context = call_context.clone();
+                        async move {
+                            // Endpoint-specific context (metadata, timeout).
+                            let transport_context = &transport.metadata.context;
 
-                    for idx in 0..transport_snapshot.len() {
-                        let transport_url = transport_snapshot[idx].metadata.url.as_deref();
-                        // Get the transport's endpoint-specific context
-                        let transport_context = &transport_snapshot[idx].metadata.context;
+                            let mut client = #grpc_client_struct::new((*transport).clone())
+                                .max_decoding_message_size(MAX_MSG_SIZE)
+                                .max_encoding_message_size(MAX_MSG_SIZE);
 
-                        let transport = transport_snapshot[idx].clone();
-                        let mut client = #grpc_client_struct::new(transport)
-                            .max_decoding_message_size(MAX_MSG_SIZE)
-                            .max_encoding_message_size(MAX_MSG_SIZE);
+                            // Merge transport context with per-call context.
+                            let mut merged_context = transport_context.clone();
+                            merged_context.extend(&call_context);
 
-                        // Merge transport context with per-call context
-                        let mut merged_context = transport_context.clone();
-                        merged_context.extend(&call_context);
+                            let mut request = ::tonic::Request::from_parts(
+                                merged_context.metadata.clone(),
+                                ::tonic::Extensions::new(),
+                                param,
+                            );
 
-                        let mut request = ::tonic::Request::from_parts(
-                            merged_context.metadata.clone(),
-                            ::tonic::Extensions::new(),
-                            ::std::clone::Clone::clone(&param),
-                        );
-
-                        if let Some(timeout) = merged_context.timeout {
-                            request.set_timeout(timeout);
-                        } else {
-                            request.set_timeout(::std::time::Duration::from_secs(30));
-                        }
-
-                        let fut = client.#grpc_method_name(request);
-
-                        #[cfg(target_arch = "wasm32")]
-                        let fut = ::send_wrapper::SendWrapper::new(fut);
-
-                        match fut.await {
-                            Ok(resp) => {
-                                if idx > 0 {
-                                    let mut new_transports = transport_snapshot.as_ref().clone();
-                                    new_transports.swap(0, idx);
-                                    transports.store(::std::sync::Arc::new(new_transports));
-                                }
-                                return crate::grpc::FromGrpcResponse::try_from_response(resp.into_inner());
+                            if let Some(timeout) = merged_context.timeout {
+                                request.set_timeout(timeout);
+                            } else {
+                                request.set_timeout(::std::time::Duration::from_secs(30));
                             }
-                            Err(e) => {
-                                let error: crate::Error = e.into();
-                                if error.is_network_error() {
-                                    ::tracing::warn!(
-                                        "Transport {} failed with network error: {}",
-                                        transport_url.unwrap_or("unknown"),
-                                        error,
-                                    );
-                                    last_error = Some(error);
-                                    continue;
-                                }
-                                return Err(error);
+
+                            let fut = client.#grpc_method_name(request);
+
+                            #[cfg(target_arch = "wasm32")]
+                            let fut = ::send_wrapper::SendWrapper::new(fut);
+
+                            match fut.await {
+                                Ok(resp) => crate::grpc::FromGrpcResponse::try_from_response(resp.into_inner()),
+                                Err(e) => Err(crate::Error::from(e)),
                             }
                         }
-                    }
-
-                    Err(last_error.expect("at least one transport should be tried"))
+                    })
+                    .await
                 })
             }
         };

--- a/grpc/src/builder.rs
+++ b/grpc/src/builder.rs
@@ -1,4 +1,3 @@
-use arc_swap::ArcSwap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::sync::Arc;
@@ -6,6 +5,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use k256::ecdsa::{SigningKey, VerifyingKey};
+use lumina_utils::failover::{Endpoint as FailoverEndpoint, Failover};
 use signature::Keypair;
 use tonic::body::Body as TonicBody;
 use tonic::codegen::Service;
@@ -13,11 +13,21 @@ use tonic::metadata::MetadataMap;
 use zeroize::Zeroizing;
 
 use crate::boxed::{BoxedTransport, TransportMetadata, boxed};
-use crate::client::AccountState;
+use crate::client::{AccountState, probe_head};
 use crate::grpc::Context;
 use crate::signer::{AccountSigner, BoxedDocSigner};
 use crate::utils::CondSend;
-use crate::{DocSigner, GrpcClient, GrpcClientBuilderError};
+use crate::{DocSigner, Error, GrpcClient, GrpcClientBuilderError};
+
+/// Default interval between background health-checks of the preferred endpoint.
+const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Default timeout for a single gRPC health-check probe.
+const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default maximum head age for an endpoint to be considered healthy enough to
+/// switch back to.
+const DEFAULT_MAX_HEAD_AGE: Duration = Duration::from_secs(30);
 
 /// A URL endpoint with per-endpoint configuration.
 ///
@@ -142,6 +152,8 @@ pub struct GrpcClientBuilder {
     transports: Vec<TransportEntry>,
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
+    health_check_interval: Option<Duration>,
+    max_head_age: Option<Duration>,
     signer_kind: Option<SignerKind>,
 }
 
@@ -303,6 +315,34 @@ impl GrpcClientBuilder {
         self
     }
 
+    /// Override the interval of the background health-check that switches back to
+    /// the preferred endpoint once it recovers.
+    ///
+    /// Endpoints are tried in priority order (the first added is the most
+    /// preferred). When a network error makes the client fail over to a
+    /// fallback, this task probes the preferred endpoint on the given interval
+    /// and switches back to it once it has recovered and its head is recent
+    /// enough (within [`max_head_age`](GrpcClientBuilder::max_head_age)).
+    ///
+    /// The health-check is enabled by default (every 10s) whenever more than one
+    /// endpoint is configured; use this only to change the interval.
+    pub fn health_check_interval(mut self, interval: Duration) -> GrpcClientBuilder {
+        self.health_check_interval = Some(interval);
+        self
+    }
+
+    /// Set the maximum age of the preferred endpoint's head (by timestamp) for
+    /// it to be considered healthy enough to switch back to.
+    ///
+    /// While a fallback is in use, the background health-check only switches back
+    /// to the preferred endpoint once its head is no older than this. Defaults to
+    /// 30 seconds. Only relevant when
+    /// [`health_check_interval`](GrpcClientBuilder::health_check_interval) is set.
+    pub fn max_head_age(mut self, max_head_age: Duration) -> GrpcClientBuilder {
+        self.max_head_age = Some(max_head_age);
+        self
+    }
+
     /// Build [`GrpcClient`]
     ///
     /// Returns error if no transports were configured.
@@ -339,11 +379,40 @@ impl GrpcClientBuilder {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let transports = Arc::new(ArcSwap::from_pointee(transports));
+        // gRPC transports are built eagerly (lazily-connecting channels), so each
+        // endpoint slot is pre-cached and never rebuilt.
+        let endpoints = transports
+            .into_iter()
+            .map(|transport| {
+                let label = transport.metadata.url.clone().unwrap_or_default();
+                FailoverEndpoint::prebuilt(label, transport)
+            })
+            .collect();
+
+        let probe_timeout = self.timeout.unwrap_or(DEFAULT_PROBE_TIMEOUT);
+        let max_head_age = self.max_head_age.unwrap_or(DEFAULT_MAX_HEAD_AGE);
+        let failover = Failover::new(
+            endpoints,
+            Error::is_network_error,
+            probe_timeout,
+            max_head_age,
+        )
+        .expect("transports were checked to be non-empty");
+        let failover = Arc::new(failover);
+
+        // Enabled by default; `spawn_health_check` is a no-op for a single
+        // endpoint, so this only starts a task when there's a fallback.
+        let health_check_interval = self
+            .health_check_interval
+            .unwrap_or(DEFAULT_HEALTH_CHECK_INTERVAL);
+        failover.spawn_health_check(
+            health_check_interval,
+            |transport: Arc<BoxedTransport>| async move { probe_head(transport).await },
+        );
 
         let signer_config = self.signer_kind.map(TryInto::try_into).transpose()?;
 
-        Ok(GrpcClient::new(transports, signer_config))
+        Ok(GrpcClient::new(failover, signer_config))
     }
 }
 

--- a/grpc/src/builder.rs
+++ b/grpc/src/builder.rs
@@ -19,8 +19,8 @@ use crate::signer::{AccountSigner, BoxedDocSigner};
 use crate::utils::CondSend;
 use crate::{DocSigner, Error, GrpcClient, GrpcClientBuilderError};
 
-/// Default interval between background health-checks of the preferred endpoint.
-const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+/// Default interval between background health-checks of unhealthy endpoints.
+const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(3);
 
 /// Default timeout for a single gRPC health-check probe.
 const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -2,9 +2,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use ::tendermint::chain::Id;
-use arc_swap::ArcSwap;
 use celestia_types::any::IntoProtobufAny;
 use k256::ecdsa::VerifyingKey;
+use lumina_utils::failover::Failover;
 use lumina_utils::time::Interval;
 use prost::Message;
 use std::time::Duration;
@@ -24,6 +24,7 @@ use celestia_proto::celestia::valaddr::v1::{
 };
 use celestia_proto::cosmos::auth::v1beta1::query_client::QueryClient as AuthQueryClient;
 use celestia_proto::cosmos::bank::v1beta1::query_client::QueryClient as BankQueryClient;
+use celestia_proto::cosmos::base::node::v1beta1::StatusRequest;
 use celestia_proto::cosmos::base::node::v1beta1::service_client::ServiceClient as ConfigServiceClient;
 use celestia_proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient as TendermintServiceClient;
 use celestia_proto::cosmos::staking::v1beta1::query_client::QueryClient as StakingQueryClient;
@@ -98,20 +99,20 @@ pub struct GrpcClient {
 }
 
 struct GrpcClientInner {
-    transports: Arc<ArcSwap<Vec<BoxedTransport>>>,
+    failover: Arc<Failover<BoxedTransport, Error>>,
     account: Option<AccountState>,
     chain_state: OnceCell<ChainState>,
 }
 
 impl GrpcClient {
-    /// Create a new client wrapping given transports
+    /// Create a new client wrapping the given failover engine over the transports.
     pub(crate) fn new(
-        transports: Arc<ArcSwap<Vec<BoxedTransport>>>,
+        failover: Arc<Failover<BoxedTransport, Error>>,
         account: Option<AccountState>,
     ) -> Self {
         Self {
             inner: Arc::new(GrpcClientInner {
-                transports,
+                failover,
                 account,
                 chain_state: OnceCell::new(),
             }),
@@ -998,6 +999,38 @@ impl fmt::Debug for GrpcClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("GrpcClient { .. }")
     }
+}
+
+/// Probe a single transport for its current head's timestamp (unix seconds).
+///
+/// Used by the failover health-check to tell whether a recovered preferred
+/// endpoint's head is recent. Uses the lightweight node `Status` query (just
+/// metadata, no block body). Returns `None` if the endpoint is unreachable or
+/// reports no timestamp.
+///
+/// The endpoint's own metadata and timeout are applied to the request, mirroring
+/// the generated call path, so an endpoint that requires per-endpoint auth (e.g.
+/// a bearer token) is probed with that auth too.
+pub(crate) async fn probe_head(transport: Arc<BoxedTransport>) -> Option<i64> {
+    let context = &transport.metadata.context;
+
+    let mut request = tonic::Request::from_parts(
+        context.metadata.clone(),
+        tonic::Extensions::new(),
+        StatusRequest {},
+    );
+    if let Some(timeout) = context.timeout {
+        request.set_timeout(timeout);
+    }
+
+    let mut client = ConfigServiceClient::new((*transport).clone());
+
+    let fut = client.status(request);
+
+    #[cfg(target_arch = "wasm32")]
+    let fut = send_wrapper::SendWrapper::new(fut);
+
+    Some(fut.await.ok()?.into_inner().timestamp?.seconds)
 }
 
 fn is_wrong_sequence(code: ErrorCode) -> bool {

--- a/node/tests/node.rs
+++ b/node/tests/node.rs
@@ -15,7 +15,7 @@ use lumina_node::test_utils::{
 };
 use rand::Rng;
 use tendermint_proto::Protobuf;
-use tokio::{select, spawn, sync::mpsc, time::sleep};
+use tokio::{select, spawn, sync::mpsc, time::sleep, time::timeout};
 
 use crate::utils::{fetch_bridge_info, new_connected_node};
 
@@ -124,19 +124,52 @@ async fn peer_discovery() {
 
     node3.wait_connected().await.unwrap();
 
-    // Small wait until all nodes are discovered and connected
-    sleep(Duration::from_millis(2000)).await;
+    let node1_peer_id = *node1.local_peer_id();
+    let node2_peer_id = *node2.local_peer_id();
+    let node3_peer_id = *node3.local_peer_id();
 
-    let node1_peer_id = node1.local_peer_id();
-    let node2_peer_id = node2.local_peer_id();
-    let node3_peer_id = node3.local_peer_id();
+    // Wait until all nodes have discovered and connected to each other.
+    //
+    // Discovery is transitive (Node2/Node3 learn the bridge's address via
+    // Node1) and its timing depends on Kademlia and identify round-trips,
+    // which vary with machine load. Poll for the observed end-state instead
+    // of sleeping a fixed amount, otherwise the test is flaky on slow CI.
+    let mesh_formed = timeout(Duration::from_secs(30), async {
+        loop {
+            let n1 = node1.connected_peers().await.unwrap();
+            let n2 = node2.connected_peers().await.unwrap();
+            let n3 = node3.connected_peers().await.unwrap();
+
+            let n1_ok = n1.contains(&bridge_peer_id)
+                && n1.contains(&node2_peer_id)
+                && n1.contains(&node3_peer_id);
+            let n2_ok = n2.contains(&bridge_peer_id)
+                && n2.contains(&node1_peer_id)
+                && n2.contains(&node3_peer_id);
+            let n3_ok = n3.contains(&bridge_peer_id)
+                && n3.contains(&node1_peer_id)
+                && n3.contains(&node2_peer_id);
+
+            if n1_ok && n2_ok && n3_ok {
+                break;
+            }
+
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+
+    assert!(
+        mesh_formed.is_ok(),
+        "Timed out waiting for all nodes to discover and connect to each other"
+    );
 
     // Check Node1 connected peers
     let connected_peers = node1.connected_peers().await.unwrap();
     let tracker_info = node1.peer_tracker_info();
     assert!(connected_peers.contains(&bridge_peer_id));
-    assert!(connected_peers.contains(node2_peer_id));
-    assert!(connected_peers.contains(node3_peer_id));
+    assert!(connected_peers.contains(&node2_peer_id));
+    assert!(connected_peers.contains(&node3_peer_id));
     assert!(tracker_info.num_connected_peers >= 3);
     assert_eq!(tracker_info.num_connected_trusted_peers, 1);
 
@@ -144,17 +177,17 @@ async fn peer_discovery() {
     let connected_peers = node2.connected_peers().await.unwrap();
     let tracker_info = node2.peer_tracker_info();
     assert!(connected_peers.contains(&bridge_peer_id));
-    assert!(connected_peers.contains(node1_peer_id));
-    assert!(connected_peers.contains(node3_peer_id));
+    assert!(connected_peers.contains(&node1_peer_id));
+    assert!(connected_peers.contains(&node3_peer_id));
     assert!(tracker_info.num_connected_peers >= 3);
     assert_eq!(tracker_info.num_connected_trusted_peers, 1);
 
     // Check Node3 connected peers
     let connected_peers = node3.connected_peers().await.unwrap();
-    let tracker_info = node2.peer_tracker_info();
+    let tracker_info = node3.peer_tracker_info();
     assert!(connected_peers.contains(&bridge_peer_id));
-    assert!(connected_peers.contains(node1_peer_id));
-    assert!(connected_peers.contains(node2_peer_id));
+    assert!(connected_peers.contains(&node1_peer_id));
+    assert!(connected_peers.contains(&node2_peer_id));
     assert!(tracker_info.num_connected_peers >= 3);
     assert_eq!(tracker_info.num_connected_trusted_peers, 1);
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -78,7 +78,13 @@ libp2p = { workspace = true, features = [
   "noise",
   "yamux",
 ] }
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = [
+  "rt",
+  "macros",
+  "net",
+  "io-util",
+  "time",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom_02.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -31,6 +31,7 @@ jsonrpsee = { workspace = true, features = [
   "macros",
   "server-core",
 ] }
+lumina-utils = { workspace = true, features = ["executor", "time", "failover"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_repr.workspace = true

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     #[error("Protocol not supported or missing: {0}")]
     ProtocolNotSupported(String),
 
+    /// No RPC endpoints were provided when constructing a failover client.
+    #[error("No RPC endpoints provided")]
+    NoEndpoints,
+
     /// Error propagated from the [`jsonrpsee`].
     #[error(transparent)]
     JsonRpc(#[from] jsonrpsee::core::ClientError),

--- a/rpc/src/failover.rs
+++ b/rpc/src/failover.rs
@@ -1,0 +1,334 @@
+//! Multi-endpoint Json-RPC client with automatic failover and switch-back.
+//!
+//! [`FailoverClient`] wraps a priority-ordered list of RPC endpoints. Requests
+//! are sent to the most-preferred endpoint that is currently reachable; if a
+//! network error occurs, the client transparently falls back to the next
+//! endpoint. A background health-check task periodically probes the preferred
+//! endpoint and, as soon as it recovers *and its head is recent enough* (within
+//! a configurable max age), switches back to it.
+//!
+//! The actual failover state machine lives in the transport-agnostic
+//! [`lumina_utils::failover::Failover`] engine; this module is the JSON-RPC
+//! adapter around it.
+//!
+//! The first endpoint in the list (index `0`) is the most preferred one.
+//!
+//! # Notes
+//!
+//! - Only *network* errors trigger failover. Server-returned JSON-RPC errors
+//!   (e.g. a method returning an error) are returned to the caller as-is and do
+//!   not cause a retry on another endpoint.
+//! - Batch requests are routed to the currently selected endpoint without
+//!   failover, because [`jsonrpsee`]'s batch builder cannot be replayed.
+//! - For subscriptions, only the initial subscribe call is subject to failover.
+//!   If the underlying connection drops mid-stream the subscription ends, and
+//!   the caller is expected to re-subscribe (which will pick a healthy endpoint).
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use jsonrpsee::core::ClientError;
+use jsonrpsee::core::JsonRawValue as RawValue;
+use jsonrpsee::core::client::{BatchResponse, ClientT, Subscription, SubscriptionClientT};
+use jsonrpsee::core::params::BatchRequestBuilder;
+use jsonrpsee::core::traits::ToRpcParams;
+use lumina_utils::failover::{Endpoint as FailoverEndpoint, Failover, box_build};
+use serde::de::DeserializeOwned;
+
+use crate::HeaderClient;
+use crate::client::Client;
+use crate::error::Error;
+
+/// Default interval between background health-checks of the preferred endpoint.
+pub const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Default timeout for a single health-check probe.
+pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default maximum head age for an endpoint to be considered healthy enough to
+/// switch back to.
+pub const DEFAULT_MAX_HEAD_AGE: Duration = Duration::from_secs(30);
+
+/// A single RPC endpoint with its optional authentication token.
+///
+/// Different providers (e.g. your own node and a fallback such as QuickNode)
+/// commonly require different auth tokens, hence the per-endpoint token.
+#[derive(Debug, Clone)]
+pub struct RpcEndpoint {
+    /// The endpoint url, e.g. `ws://localhost:26658` or `https://rpc.example.com`.
+    pub url: String,
+    /// Optional bearer authentication token for this endpoint.
+    pub auth_token: Option<String>,
+}
+
+impl RpcEndpoint {
+    /// Create a new endpoint from a url, without an auth token.
+    pub fn new(url: impl Into<String>) -> RpcEndpoint {
+        RpcEndpoint {
+            url: url.into(),
+            auth_token: None,
+        }
+    }
+
+    /// Set the authentication token for this endpoint.
+    pub fn auth_token(mut self, token: impl Into<String>) -> RpcEndpoint {
+        self.auth_token = Some(token.into());
+        self
+    }
+}
+
+impl<S> From<S> for RpcEndpoint
+where
+    S: Into<String>,
+{
+    fn from(url: S) -> RpcEndpoint {
+        RpcEndpoint::new(url)
+    }
+}
+
+/// Pre-serialized RPC params, so that a request can be replayed across endpoints.
+///
+/// [`ToRpcParams::to_rpc_params`] consumes its receiver, so to retry the same
+/// request on a different endpoint we serialize the params once up front and
+/// hand out clones.
+struct RawParams(Option<Box<RawValue>>);
+
+impl ToRpcParams for RawParams {
+    fn to_rpc_params(self) -> Result<Option<Box<RawValue>>, serde_json::Error> {
+        Ok(self.0)
+    }
+}
+
+/// A Json-RPC client over multiple endpoints with automatic failover and
+/// switch-back to the preferred endpoint once it recovers.
+///
+/// Requests go to the most-preferred reachable endpoint; on a network error the
+/// client transparently fails over to the next one. When a health-check interval
+/// is configured, a background task switches back to the preferred endpoint once
+/// it recovers and its head is recent enough.
+pub struct FailoverClient {
+    inner: Arc<Failover<Client, ClientError>>,
+}
+
+impl FailoverClient {
+    /// Create a new failover client over the given priority-ordered endpoints.
+    ///
+    /// The first endpoint is the most preferred. When more than one endpoint is
+    /// provided and `health_check_interval` is `Some`, a background task probes
+    /// the preferred endpoint on that interval and switches back to it once it
+    /// recovers.
+    ///
+    /// Endpoint clients are built lazily on first use, so a fallback endpoint
+    /// being unreachable at construction time does not prevent the client from
+    /// being created.
+    pub fn new(
+        endpoints: Vec<RpcEndpoint>,
+        connect_timeout: Option<Duration>,
+        request_timeout: Option<Duration>,
+        health_check_interval: Option<Duration>,
+        max_head_age: Duration,
+    ) -> Result<FailoverClient, Error> {
+        let probe_timeout = request_timeout.unwrap_or(DEFAULT_PROBE_TIMEOUT);
+
+        let slots = endpoints
+            .into_iter()
+            .map(|endpoint| {
+                let url = endpoint.url.clone();
+                FailoverEndpoint::lazy(url, move || {
+                    let url = endpoint.url.clone();
+                    let auth_token = endpoint.auth_token.clone();
+                    box_build(async move {
+                        Client::new(
+                            &url,
+                            auth_token.as_deref(),
+                            connect_timeout,
+                            request_timeout,
+                        )
+                        .await
+                        .map_err(build_error_to_client_error)
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let inner = Failover::new(slots, is_network_error, probe_timeout, max_head_age)
+            .ok_or(Error::NoEndpoints)?;
+        let inner = Arc::new(inner);
+
+        if let Some(interval) = health_check_interval {
+            inner.spawn_health_check(interval, |client: Arc<Client>| async move {
+                HeaderClient::header_network_head(client.as_ref())
+                    .await
+                    .ok()
+                    .map(|header| header.time().unix_timestamp())
+            });
+        }
+
+        Ok(FailoverClient { inner })
+    }
+}
+
+/// Returns whether an error should trigger failover to another endpoint.
+///
+/// Only connectivity/transport-level failures count; server-returned JSON-RPC
+/// errors and response parsing errors are treated as real results.
+pub(crate) fn is_network_error(err: &ClientError) -> bool {
+    matches!(
+        err,
+        ClientError::Transport(_)
+            | ClientError::RestartNeeded(_)
+            | ClientError::RequestTimeout
+            | ClientError::ServiceDisconnect
+            | ClientError::Custom(_)
+    )
+}
+
+/// Convert an endpoint-build error into a [`ClientError`], preserving the
+/// underlying jsonrpsee error (e.g. a `Transport` connection failure) where
+/// possible so callers see the same error variant as with a single endpoint.
+fn build_error_to_client_error(err: Error) -> ClientError {
+    match err {
+        Error::JsonRpc(client_err) => client_err,
+        other => ClientError::Custom(other.to_string()),
+    }
+}
+
+impl ClientT for FailoverClient {
+    async fn notification<Params>(&self, method: &str, params: Params) -> Result<(), ClientError>
+    where
+        Params: ToRpcParams + Send,
+    {
+        let raw = params.to_rpc_params()?;
+        self.inner
+            .run(|client| {
+                let raw = raw.clone();
+                async move { client.notification(method, RawParams(raw)).await }
+            })
+            .await
+    }
+
+    async fn request<R, Params>(&self, method: &str, params: Params) -> Result<R, ClientError>
+    where
+        R: DeserializeOwned,
+        Params: ToRpcParams + Send,
+    {
+        let raw = params.to_rpc_params()?;
+        self.inner
+            .run(|client| {
+                let raw = raw.clone();
+                async move { client.request::<R, _>(method, RawParams(raw)).await }
+            })
+            .await
+    }
+
+    async fn batch_request<'a, R>(
+        &self,
+        batch: BatchRequestBuilder<'a>,
+    ) -> Result<BatchResponse<'a, R>, ClientError>
+    where
+        R: DeserializeOwned + fmt::Debug + 'a,
+    {
+        // The batch builder cannot be replayed, so route to the active endpoint
+        // without failover.
+        let client = self.inner.active_client().await?;
+        client.batch_request(batch).await
+    }
+}
+
+impl SubscriptionClientT for FailoverClient {
+    async fn subscribe<'a, N, Params>(
+        &self,
+        subscribe_method: &'a str,
+        params: Params,
+        unsubscribe_method: &'a str,
+    ) -> Result<Subscription<N>, ClientError>
+    where
+        Params: ToRpcParams + Send,
+        N: DeserializeOwned,
+    {
+        let raw = params.to_rpc_params()?;
+        self.inner
+            .run(|client| {
+                let raw = raw.clone();
+                async move {
+                    client
+                        .subscribe(subscribe_method, RawParams(raw), unsubscribe_method)
+                        .await
+                }
+            })
+            .await
+    }
+
+    async fn subscribe_to_method<N>(&self, method: &str) -> Result<Subscription<N>, ClientError>
+    where
+        N: DeserializeOwned,
+    {
+        self.inner
+            .run(|client| async move { client.subscribe_to_method(method).await })
+            .await
+    }
+}
+
+impl fmt::Debug for FailoverClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("FailoverClient { .. }")
+    }
+}
+
+// Integration tests against a live node, mirroring the gRPC failover tests in
+// `celestia-grpc`. The deterministic state-machine coverage lives in the shared
+// engine's unit tests (`lumina_utils::failover`); these check the JSON-RPC
+// adapter end-to-end: requests fail over from an unreachable endpoint to a real
+// one, and exhausting all endpoints surfaces an error.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::HeaderClient;
+
+    // An endpoint with nothing listening, so connecting fails fast.
+    const BAD_URL: &str = "ws://localhost:19999";
+    const BAD_URL_2: &str = "ws://localhost:19998";
+
+    /// The live node RPC url, overridable via `CELESTIA_RPC_URL` (node-2, the
+    /// light node, allows unauthenticated header reads).
+    fn celestia_rpc_url() -> String {
+        std::env::var("CELESTIA_RPC_URL").unwrap_or_else(|_| "ws://localhost:46658".to_string())
+    }
+
+    fn failover_client(endpoints: Vec<RpcEndpoint>) -> FailoverClient {
+        FailoverClient::new(endpoints, None, None, None, DEFAULT_MAX_HEAD_AGE).unwrap()
+    }
+
+    #[tokio::test]
+    async fn failover_to_second_endpoint() {
+        // First endpoint is unreachable, should fail over to the second, real one.
+        let client = failover_client(vec![
+            RpcEndpoint::new(BAD_URL),
+            RpcEndpoint::new(celestia_rpc_url()),
+        ]);
+
+        let head = client.header_network_head().await.unwrap();
+        assert!(head.height() > 0);
+    }
+
+    #[tokio::test]
+    async fn endpoint_multiple_requests() {
+        let client = failover_client(vec![
+            RpcEndpoint::new(BAD_URL),
+            RpcEndpoint::new(celestia_rpc_url()),
+        ]);
+
+        for _ in 0..5 {
+            let head = client.header_network_head().await.unwrap();
+            assert!(head.height() > 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn all_endpoints_fail_returns_error() {
+        let client = failover_client(vec![RpcEndpoint::new(BAD_URL), RpcEndpoint::new(BAD_URL_2)]);
+
+        client.header_network_head().await.unwrap_err();
+    }
+}

--- a/rpc/src/failover.rs
+++ b/rpc/src/failover.rs
@@ -40,8 +40,8 @@ use crate::HeaderClient;
 use crate::client::Client;
 use crate::error::Error;
 
-/// Default interval between background health-checks of the preferred endpoint.
-pub const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+/// Default interval between background health-checks of unhealthy endpoints.
+pub const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(3);
 
 /// Default timeout for a single health-check probe.
 pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);

--- a/rpc/src/failover.rs
+++ b/rpc/src/failover.rs
@@ -331,4 +331,177 @@ mod tests {
 
         client.header_network_head().await.unwrap_err();
     }
+
+    /// The live node's `host:port`, derived from [`celestia_rpc_url`].
+    fn celestia_rpc_host_port() -> String {
+        celestia_rpc_url()
+            .trim_start_matches("wss://")
+            .trim_start_matches("ws://")
+            .to_string()
+    }
+
+    /// A controllable TCP proxy placed in front of a real node so a test can
+    /// simulate the upstream disconnecting and recovering.
+    ///
+    /// While enabled it forwards each accepted connection to the upstream. When
+    /// disabled it force-closes live connections and refuses new ones (the ws
+    /// client then sees the connection drop, exactly like a node going away).
+    /// `forwarded` counts the connections it has proxied, so a test can tell
+    /// which endpoint actually served traffic.
+    mod tcp_proxy {
+        use std::net::SocketAddr;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        use tokio::net::{TcpListener, TcpStream};
+
+        pub struct TcpProxy {
+            addr: SocketAddr,
+            enabled: Arc<AtomicBool>,
+            forwarded: Arc<AtomicUsize>,
+        }
+
+        impl TcpProxy {
+            pub async fn start(upstream: String) -> TcpProxy {
+                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let addr = listener.local_addr().unwrap();
+                let enabled = Arc::new(AtomicBool::new(true));
+                let forwarded = Arc::new(AtomicUsize::new(0));
+
+                let task_enabled = enabled.clone();
+                let task_forwarded = forwarded.clone();
+                tokio::spawn(async move {
+                    loop {
+                        let Ok((mut inbound, _)) = listener.accept().await else {
+                            break;
+                        };
+                        if !task_enabled.load(Ordering::SeqCst) {
+                            // Refuse: dropping `inbound` closes the connection.
+                            continue;
+                        }
+                        task_forwarded.fetch_add(1, Ordering::SeqCst);
+
+                        let conn_enabled = task_enabled.clone();
+                        let upstream = upstream.clone();
+                        tokio::spawn(async move {
+                            let Ok(mut outbound) = TcpStream::connect(&upstream).await else {
+                                return;
+                            };
+                            tokio::select! {
+                                _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound) => {}
+                                // Force-close the connection as soon as we're disabled.
+                                _ = wait_until_disabled(&conn_enabled) => {}
+                            }
+                        });
+                    }
+                });
+
+                TcpProxy {
+                    addr,
+                    enabled,
+                    forwarded,
+                }
+            }
+
+            pub fn ws_url(&self) -> String {
+                format!("ws://{}", self.addr)
+            }
+
+            pub fn disable(&self) {
+                self.enabled.store(false, Ordering::SeqCst);
+            }
+
+            pub fn enable(&self) {
+                self.enabled.store(true, Ordering::SeqCst);
+            }
+
+            pub fn forwarded(&self) -> usize {
+                self.forwarded.load(Ordering::SeqCst)
+            }
+        }
+
+        async fn wait_until_disabled(enabled: &AtomicBool) {
+            while enabled.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+
+    /// End-to-end against a real node: the preferred endpoint goes through a
+    /// controllable TCP proxy, the fallback is the node directly. Killing the
+    /// proxy drops the preferred connection (→ fail over); restoring it must let
+    /// the background health-check reconnect through the *same cached* client and
+    /// route traffic back to the preferred endpoint.
+    ///
+    /// `WsReconnectClient` keeps a single persistent connection, so the proxy's
+    /// per-connection counter rising again is exactly the signal that the cached
+    /// client reconnected after the drop. We use a generous `max_head_age` so the
+    /// switch-back tests the reconnect path rather than chain liveness (a static
+    /// devnet may have a stale head).
+    #[tokio::test]
+    async fn switches_back_to_preferred_after_reconnect() {
+        use std::time::Duration;
+
+        // Large enough that a reachable-but-not-advancing devnet still counts as
+        // fresh; this test is about reconnect/switch-back, not head freshness.
+        let max_head_age = Duration::from_secs(3600 * 24 * 365 * 10);
+
+        let proxy = tcp_proxy::TcpProxy::start(celestia_rpc_host_port()).await;
+
+        let client = FailoverClient::new(
+            vec![
+                RpcEndpoint::new(proxy.ws_url()),
+                RpcEndpoint::new(celestia_rpc_url()),
+            ],
+            None,
+            None,
+            // Fast health-check so the test doesn't wait long for switch-back.
+            Some(Duration::from_millis(500)),
+            max_head_age,
+        )
+        .unwrap();
+
+        // Preferred (through the proxy) serves the first request, opening one
+        // connection.
+        client.header_network_head().await.unwrap();
+        assert_eq!(
+            proxy.forwarded(),
+            1,
+            "preferred endpoint should serve first"
+        );
+
+        // Kill the preferred: force-close its connection and refuse new ones. Give
+        // the force-close a moment to land, then a request must fail over to the
+        // fallback (real node) and succeed.
+        proxy.disable();
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let head = client.header_network_head().await.unwrap();
+        assert!(
+            head.height() > 0,
+            "fallback should serve while preferred is down"
+        );
+
+        // The preferred is now unhealthy and its connection is gone; the counter
+        // is stable while disabled.
+        let before = proxy.forwarded();
+
+        // Restore the preferred. The background health-check reuses the SAME cached
+        // client, which reconnects (a new proxied connection → counter rises) and
+        // is marked healthy again, so routing returns to the preferred endpoint.
+        proxy.enable();
+        let mut switched_back = false;
+        for _ in 0..40 {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            client.header_network_head().await.unwrap();
+            if proxy.forwarded() > before {
+                switched_back = true;
+                break;
+            }
+        }
+        assert!(
+            switched_back,
+            "should reconnect and route back through the preferred endpoint after it recovers"
+        );
+    }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -10,6 +10,11 @@ pub mod blobstream;
 pub mod client;
 pub mod das;
 mod error;
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(target_arch = "wasm32", feature = "wasm-bindgen")
+))]
+mod failover;
 pub mod fraud;
 mod header;
 #[cfg(feature = "p2p")]
@@ -40,6 +45,21 @@ pub use crate::blobstream::BlobstreamServer;
 pub use crate::client::Client;
 pub use crate::das::DasClient;
 pub use crate::error::{Error, Result};
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(target_arch = "wasm32", feature = "wasm-bindgen")
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        not(target_arch = "wasm32"),
+        all(target_arch = "wasm32", feature = "wasm-bindgen")
+    )))
+)]
+pub use crate::failover::{
+    DEFAULT_HEALTH_CHECK_INTERVAL, DEFAULT_MAX_HEAD_AGE, DEFAULT_PROBE_TIMEOUT, FailoverClient,
+    RpcEndpoint,
+};
 pub use crate::fraud::FraudClient;
 pub use crate::fraud::FraudRpcServer;
 pub use crate::fraud::FraudServer;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.85"
 [dependencies]
 tokio = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures = { workspace = true, optional = true }
@@ -40,6 +41,7 @@ wasm-bindgen-test.workspace = true
 [features]
 default = []
 executor = ["token", "dep:tokio-util", "dep:tokio", "tokio/rt", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:send_wrapper"]
+failover = ["executor", "time", "dep:tracing"]
 token = ["dep:tokio-util"]
 time = ["dep:gloo-timers", "dep:tokio", "tokio/time", "dep:send_wrapper", "dep:futures", "dep:pin-project", "dep:web-time"]
 test-utils = ["dep:tokio", "tokio/macros", "dep:wasm-bindgen-test"]

--- a/utils/src/failover.rs
+++ b/utils/src/failover.rs
@@ -1,0 +1,713 @@
+//! Transport-agnostic multi-endpoint failover engine.
+//!
+//! [`Failover`](crate::failover::Failover) holds a priority-ordered list of endpoints and runs logical
+//! requests against the most-preferred reachable one, transparently falling
+//! back to the next endpoint on a *network* error. An optional background
+//! health-check probes the preferred endpoint and switches back to it once it
+//! has recovered *and its head is fresh* (within a configurable max age).
+//!
+//! The engine knows nothing about the concrete transport (`C`) or its error
+//! type (`E`): callers inject
+//!
+//! - a per-endpoint *build* closure that lazily constructs the transport
+//!   client (or pre-cache it for transports that are built eagerly),
+//! - an `is_network_error` classifier deciding which errors trigger failover,
+//! - a *call* closure performing a single request against one client, and
+//! - (for switch-back) a *probe* closure returning an endpoint's current head
+//!   timestamp.
+//!
+//! Note: the switch-back "healthy" criterion is purely the head's **timestamp
+//! age**, not its block height. An endpoint can be a few blocks behind and still
+//! count as healthy if its head time is within `max_head_age`. This favours a
+//! simple, transport-agnostic signal over strict height parity.
+//!
+//! This lets both the JSON-RPC and the gRPC clients share one implementation.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
+
+use tracing::{debug, warn};
+
+use crate::executor::spawn;
+use crate::time::{Interval, timeout};
+
+/// A future that builds a client for a single endpoint.
+///
+/// It is `Send` on all targets (see [`box_build`]) so that the futures awaiting
+/// it stay `Send` even on wasm, matching what transport client traits require.
+/// Produce one with [`box_build`].
+pub type BuildFut<C, E> = std::pin::Pin<Box<dyn std::future::Future<Output = Result<C, E>> + Send>>;
+
+type BuildFn<C, E> = Arc<dyn Fn() -> BuildFut<C, E> + Send + Sync>;
+
+/// Box an endpoint-build future into a `Send` [`BuildFut`].
+///
+/// On wasm the underlying transport futures are `!Send`, so we wrap them in
+/// `send_wrapper::SendWrapper`, which is valid on wasm's single thread.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn box_build<C, E, F>(fut: F) -> BuildFut<C, E>
+where
+    C: 'static,
+    E: 'static,
+    F: std::future::Future<Output = Result<C, E>> + Send + 'static,
+{
+    Box::pin(fut)
+}
+
+/// Box an endpoint-build future into a `Send` [`BuildFut`] (wasm32 variant).
+#[cfg(target_arch = "wasm32")]
+pub fn box_build<C, E, F>(fut: F) -> BuildFut<C, E>
+where
+    C: 'static,
+    E: 'static,
+    F: std::future::Future<Output = Result<C, E>> + 'static,
+{
+    Box::pin(send_wrapper::SendWrapper::new(fut))
+}
+
+/// Configuration for a single endpoint passed to [`Failover::new`].
+pub struct Endpoint<C, E> {
+    /// Human-readable label used in logs (typically the url).
+    pub label: String,
+    /// How to lazily build the endpoint's client.
+    ///
+    /// `None` is only valid together with a pre-built `client`, for transports
+    /// (e.g. gRPC channels) that are constructed eagerly and never rebuilt.
+    pub build: Option<BuildFn<C, E>>,
+    /// A pre-built client, cached up front so `build` is never invoked.
+    pub client: Option<Arc<C>>,
+}
+
+impl<C, E> Endpoint<C, E> {
+    /// An endpoint whose client is built lazily on first use.
+    ///
+    /// `build` is invoked (possibly repeatedly, after failures) to construct the
+    /// client; have it return [`box_build`]`(async { ... })`.
+    pub fn lazy<F>(label: impl Into<String>, build: F) -> Endpoint<C, E>
+    where
+        F: Fn() -> BuildFut<C, E> + Send + Sync + 'static,
+    {
+        Endpoint {
+            label: label.into(),
+            build: Some(Arc::new(build)),
+            client: None,
+        }
+    }
+
+    /// An endpoint whose client is already built.
+    pub fn prebuilt(label: impl Into<String>, client: C) -> Endpoint<C, E> {
+        Endpoint {
+            label: label.into(),
+            build: None,
+            client: Some(Arc::new(client)),
+        }
+    }
+}
+
+/// State of a single endpoint: how to build its client, the cached client, and
+/// whether it is currently believed to be healthy.
+struct EndpointSlot<C, E> {
+    label: String,
+    build: Option<BuildFn<C, E>>,
+    // Only ever locked briefly and never across an `.await`, so a std mutex is
+    // fine on both native and wasm.
+    client: Mutex<Option<Arc<C>>>,
+    healthy: AtomicBool,
+}
+
+impl<C, E> EndpointSlot<C, E> {
+    fn cached(&self) -> Option<Arc<C>> {
+        self.client.lock().expect("mutex poisoned").clone()
+    }
+
+    /// Returns the endpoint's client, building it on first use (or after a
+    /// previous build failure).
+    async fn get_or_build(&self) -> Result<Arc<C>, E> {
+        if let Some(client) = self.cached() {
+            return Ok(client);
+        }
+
+        let build = self
+            .build
+            .as_ref()
+            .expect("pre-built endpoints must always be cached");
+
+        // Build without holding the lock.
+        let built = Arc::new((build)().await?);
+
+        let mut guard = self.client.lock().expect("mutex poisoned");
+        if let Some(existing) = guard.clone() {
+            // Another task built it concurrently; keep theirs.
+            return Ok(existing);
+        }
+        *guard = Some(built.clone());
+        Ok(built)
+    }
+
+    fn set_healthy(&self, healthy: bool) {
+        self.healthy.store(healthy, Ordering::Release);
+    }
+}
+
+/// A transport-agnostic failover engine over a priority-ordered endpoint list.
+///
+/// See the [module documentation](self) for details.
+pub struct Failover<C, E> {
+    endpoints: Vec<EndpointSlot<C, E>>,
+    /// Index of the endpoint requests currently start from.
+    active: AtomicUsize,
+    probe_timeout: Duration,
+    /// Maximum age of an endpoint's head (by timestamp) for it to be considered
+    /// healthy.
+    ///
+    /// Used by the switch-back check: a preferred endpoint whose head timestamp
+    /// is older than this is treated as stale (e.g. reconnected but still
+    /// syncing), so we don't switch back to it. This is a timestamp check only —
+    /// it does not compare block heights.
+    max_head_age: Duration,
+    is_network_error: fn(&E) -> bool,
+}
+
+impl<C, E> Failover<C, E> {
+    /// Create a new failover engine over the given priority-ordered endpoints.
+    ///
+    /// The first endpoint is the most preferred. `is_network_error` decides
+    /// which errors trigger failover; `probe_timeout` bounds a single
+    /// health-check probe; `max_head_age` is how recent a preferred endpoint's
+    /// head must be for the switch-back to consider it healthy.
+    ///
+    /// Returns `None` if `endpoints` is empty.
+    pub fn new(
+        endpoints: Vec<Endpoint<C, E>>,
+        is_network_error: fn(&E) -> bool,
+        probe_timeout: Duration,
+        max_head_age: Duration,
+    ) -> Option<Failover<C, E>> {
+        if endpoints.is_empty() {
+            return None;
+        }
+
+        let endpoints = endpoints
+            .into_iter()
+            .map(|endpoint| EndpointSlot {
+                label: endpoint.label,
+                build: endpoint.build,
+                client: Mutex::new(endpoint.client),
+                healthy: AtomicBool::new(true),
+            })
+            .collect();
+
+        Some(Failover {
+            endpoints,
+            active: AtomicUsize::new(0),
+            probe_timeout,
+            max_head_age,
+            is_network_error,
+        })
+    }
+
+    /// Number of configured endpoints.
+    pub fn len(&self) -> usize {
+        self.endpoints.len()
+    }
+
+    /// Whether there are no endpoints. Always `false` for a constructed engine.
+    pub fn is_empty(&self) -> bool {
+        self.endpoints.is_empty()
+    }
+
+    /// Index of the endpoint requests currently start from.
+    pub fn active(&self) -> usize {
+        self.active
+            .load(Ordering::Acquire)
+            .min(self.endpoints.len() - 1)
+    }
+
+    /// The cached client of the currently active endpoint, building it if needed.
+    ///
+    /// Used by callers that cannot replay a request across endpoints (e.g.
+    /// JSON-RPC batches) and so must target a single endpoint without failover.
+    pub async fn active_client(&self) -> Result<Arc<C>, E> {
+        self.endpoints[self.active()].get_or_build().await
+    }
+
+    /// Order in which endpoints are attempted: the active endpoint first, then
+    /// all others in priority order (so we always re-try the preferred ones).
+    fn attempt_order(&self) -> Vec<usize> {
+        let n = self.endpoints.len();
+        let active = self.active();
+        let mut order = Vec::with_capacity(n);
+        order.push(active);
+        order.extend((0..n).filter(|&i| i != active));
+        order
+    }
+
+    fn select(&self, idx: usize) {
+        if self.active.load(Ordering::Acquire) != idx {
+            self.active.store(idx, Ordering::Release);
+        }
+    }
+
+    /// Whether a head produced at `head_unix_secs` is recent enough (within
+    /// `max_head_age`) for the endpoint to count as healthy. This is a timestamp
+    /// check only and does not consider block height.
+    ///
+    /// A head slightly in the future (clock skew) is treated as fresh.
+    fn is_fresh(&self, head_unix_secs: i64) -> bool {
+        let age = now_unix_secs().saturating_sub(head_unix_secs);
+        age <= self.max_head_age.as_secs() as i64
+    }
+
+    /// Run a single logical request against the endpoints, failing over on
+    /// network errors and returning the first success (or the last error).
+    ///
+    /// `call` is invoked once per attempted endpoint with that endpoint's
+    /// client; it must be replayable. Non-network errors are surfaced
+    /// immediately without trying another endpoint. If every endpoint fails to
+    /// even build, the last build error is returned.
+    pub async fn run<T, F, Fut>(&self, call: F) -> Result<T, E>
+    where
+        E: std::fmt::Display,
+        F: Fn(Arc<C>) -> Fut,
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        let mut last_err: Option<E> = None;
+
+        for idx in self.attempt_order() {
+            let slot = &self.endpoints[idx];
+
+            let client = match slot.get_or_build().await {
+                Ok(client) => client,
+                Err(err) => {
+                    warn!("failover: endpoint {} unavailable: {err}", slot.label);
+                    slot.set_healthy(false);
+                    last_err = Some(err);
+                    continue;
+                }
+            };
+
+            match call(client).await {
+                Ok(value) => {
+                    slot.set_healthy(true);
+                    self.select(idx);
+                    return Ok(value);
+                }
+                Err(err) if (self.is_network_error)(&err) => {
+                    warn!("failover: endpoint {} network error: {err}", slot.label);
+                    slot.set_healthy(false);
+                    last_err = Some(err);
+                    continue;
+                }
+                // Application-level error: surface it without failing over.
+                Err(err) => return Err(err),
+            }
+        }
+
+        Err(last_err.expect("attempt_order is never empty"))
+    }
+
+    /// If the preferred endpoint (index `0`) is not the active one and has
+    /// recovered, switch the active endpoint back to it.
+    ///
+    /// The preferred endpoint counts as healthy only if it answers the probe
+    /// **and** its head is fresh (within `max_head_age`). A reconnected-but-still
+    /// -syncing endpoint reports an old head, so we keep using the fallback
+    /// rather than switch back to stale data.
+    ///
+    /// `probe` returns the endpoint's current head time (unix seconds) if it
+    /// answers, or `None` if it is unreachable (the engine applies
+    /// `probe_timeout`).
+    pub async fn switch_back_with<F, Fut>(&self, probe: F)
+    where
+        F: Fn(Arc<C>) -> Fut,
+        Fut: std::future::Future<Output = Option<i64>>,
+    {
+        if self.active() == 0 {
+            return;
+        }
+
+        let slot = &self.endpoints[0];
+        let client = match slot.get_or_build().await {
+            Ok(client) => client,
+            Err(_) => {
+                slot.set_healthy(false);
+                return;
+            }
+        };
+
+        let Some(head) = self.probe(&probe, client).await else {
+            slot.set_healthy(false);
+            return;
+        };
+
+        if !self.is_fresh(head) {
+            slot.set_healthy(false);
+            debug!(
+                "failover: preferred endpoint {} recovered but its head is stale \
+                 (older than {:?}); staying on the active endpoint",
+                slot.label, self.max_head_age
+            );
+            return;
+        }
+
+        slot.set_healthy(true);
+        self.select(0);
+        debug!(
+            "failover: switched back to preferred endpoint {}",
+            slot.label
+        );
+    }
+
+    async fn probe<F, Fut>(&self, probe: &F, client: Arc<C>) -> Option<i64>
+    where
+        F: Fn(Arc<C>) -> Fut,
+        Fut: std::future::Future<Output = Option<i64>>,
+    {
+        (timeout(self.probe_timeout, probe(client)).await).unwrap_or(None)
+    }
+}
+
+/// Current wall-clock time as unix seconds, on native and wasm.
+fn now_unix_secs() -> i64 {
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::time::{SystemTime, UNIX_EPOCH};
+    #[cfg(target_arch = "wasm32")]
+    use web_time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// The shared body of [`Failover::spawn_health_check`]. The public method is
+/// `cfg`-split only to carry the right `Send`/`Sync` bounds per target.
+#[cfg(not(target_arch = "wasm32"))]
+impl<C, E> Failover<C, E>
+where
+    C: Send + Sync + 'static,
+    E: Send + 'static,
+{
+    /// Spawn the background health-check task.
+    ///
+    /// Every `interval` it probes the preferred endpoint via `probe` and, once
+    /// it has recovered and its head is recent enough, switches the active
+    /// endpoint back to it (see
+    /// [`switch_back_with`](Failover::switch_back_with)). The task holds a
+    /// [`Weak`] reference, so it stops on its own once the engine is dropped.
+    ///
+    /// Does nothing when only a single endpoint is configured.
+    pub fn spawn_health_check<F, Fut>(self: &Arc<Self>, interval: Duration, probe: F)
+    where
+        F: Fn(Arc<C>) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Option<i64>> + Send + 'static,
+    {
+        if self.endpoints.len() < 2 {
+            return;
+        }
+        spawn(health_check_loop(Arc::downgrade(self), interval, probe));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<C, E> Failover<C, E>
+where
+    C: 'static,
+    E: 'static,
+{
+    /// Spawn the background health-check task. See the non-wasm impl for docs.
+    pub fn spawn_health_check<F, Fut>(self: &Arc<Self>, interval: Duration, probe: F)
+    where
+        F: Fn(Arc<C>) -> Fut + 'static,
+        Fut: std::future::Future<Output = Option<i64>> + 'static,
+    {
+        if self.endpoints.len() < 2 {
+            return;
+        }
+        spawn(health_check_loop(Arc::downgrade(self), interval, probe));
+    }
+}
+
+async fn health_check_loop<C, E, F, Fut>(weak: Weak<Failover<C, E>>, interval: Duration, probe: F)
+where
+    F: Fn(Arc<C>) -> Fut,
+    Fut: std::future::Future<Output = Option<i64>>,
+{
+    let mut ticker = Interval::new(interval);
+    loop {
+        ticker.tick().await;
+        let Some(engine) = weak.upgrade() else {
+            break;
+        };
+        engine.switch_back_with(&probe).await;
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// A head this many seconds old is considered stale by the tests.
+    const STALE_AGE_SECS: i64 = 3600;
+
+    /// A configurable fake transport client. `head` is the head's unix-seconds
+    /// timestamp; the probe returns it so the engine can judge freshness.
+    struct FakeClient {
+        up: AtomicBool,
+        calls: AtomicUsize,
+        head: AtomicI64,
+    }
+
+    /// A simple error type with a "network error" variant.
+    #[derive(Debug)]
+    enum FakeError {
+        Network,
+        App,
+    }
+
+    impl std::fmt::Display for FakeError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                FakeError::Network => f.write_str("network"),
+                FakeError::App => f.write_str("app"),
+            }
+        }
+    }
+
+    fn is_network(err: &FakeError) -> bool {
+        matches!(err, FakeError::Network)
+    }
+
+    impl FakeClient {
+        /// A client that is up and whose head is fresh (current time).
+        fn new(up: bool) -> Self {
+            FakeClient {
+                up: AtomicBool::new(up),
+                calls: AtomicUsize::new(0),
+                head: AtomicI64::new(now_unix_secs()),
+            }
+        }
+
+        fn set_up(&self, up: bool) {
+            self.up.store(up, Ordering::SeqCst);
+        }
+
+        fn set_fresh_head(&self) {
+            self.head.store(now_unix_secs(), Ordering::SeqCst);
+        }
+
+        fn set_stale_head(&self) {
+            self.head
+                .store(now_unix_secs() - STALE_AGE_SECS, Ordering::SeqCst);
+        }
+
+        fn head(&self) -> i64 {
+            self.head.load(Ordering::SeqCst)
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        /// Returns `1` when up, a network error otherwise.
+        fn request(&self) -> Result<u64, FakeError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.up.load(Ordering::SeqCst) {
+                Ok(1)
+            } else {
+                Err(FakeError::Network)
+            }
+        }
+    }
+
+    /// Build a `Failover` whose endpoint clients are the provided fakes.
+    fn engine(fakes: Vec<Arc<FakeClient>>) -> Failover<FakeClient, FakeError> {
+        let endpoints = fakes
+            .into_iter()
+            .enumerate()
+            .map(|(i, fake)| EndpointSlot {
+                label: format!("fake://{i}"),
+                build: None,
+                client: Mutex::new(Some(fake)),
+                healthy: AtomicBool::new(true),
+            })
+            .collect();
+
+        Failover {
+            endpoints,
+            active: AtomicUsize::new(0),
+            probe_timeout: Duration::from_secs(1),
+            max_head_age: Duration::from_secs(30),
+            is_network_error: is_network,
+        }
+    }
+
+    async fn do_request(engine: &Failover<FakeClient, FakeError>) -> Result<u64, FakeError> {
+        engine.run(|client| async move { client.request() }).await
+    }
+
+    /// A switch-back probe reporting a reachable endpoint's head height.
+    async fn do_switch_back(engine: &Failover<FakeClient, FakeError>) {
+        engine
+            .switch_back_with(|client| async move {
+                match client.request() {
+                    Ok(_) => Some(client.head()),
+                    Err(_) => None,
+                }
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn uses_preferred_endpoint_when_healthy() {
+        let preferred = Arc::new(FakeClient::new(true));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        do_request(&engine).await.unwrap();
+
+        assert_eq!(preferred.calls(), 1);
+        assert_eq!(fallback.calls(), 0);
+        assert_eq!(engine.active(), 0);
+    }
+
+    #[tokio::test]
+    async fn fails_over_to_next_endpoint() {
+        let preferred = Arc::new(FakeClient::new(false));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        let value = do_request(&engine).await.unwrap();
+
+        assert_eq!(value, 1);
+        assert_eq!(preferred.calls(), 1, "preferred should be tried first");
+        assert_eq!(fallback.calls(), 1, "fallback should serve the request");
+        assert_eq!(engine.active(), 1);
+    }
+
+    #[tokio::test]
+    async fn application_errors_do_not_fail_over() {
+        let preferred = Arc::new(FakeClient::new(true));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        let err = engine
+            .run(|_client| async move { Err::<u64, _>(FakeError::App) })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, FakeError::App));
+        assert_eq!(fallback.calls(), 0, "must not fall back on app error");
+    }
+
+    #[tokio::test]
+    async fn returns_last_error_when_all_endpoints_down() {
+        let preferred = Arc::new(FakeClient::new(false));
+        let fallback = Arc::new(FakeClient::new(false));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        let err = do_request(&engine).await.unwrap_err();
+
+        assert!(is_network(&err));
+        assert_eq!(preferred.calls(), 1);
+        assert_eq!(fallback.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn switches_back_to_preferred_after_recovery() {
+        let preferred = Arc::new(FakeClient::new(false));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        do_request(&engine).await.unwrap();
+        assert_eq!(engine.active(), 1);
+
+        preferred.set_up(true);
+        do_switch_back(&engine).await;
+
+        assert_eq!(engine.active(), 0, "should switch back to preferred");
+
+        let before = fallback.calls();
+        do_request(&engine).await.unwrap();
+        assert_eq!(fallback.calls(), before, "fallback no longer used");
+    }
+
+    #[tokio::test]
+    async fn no_switch_back_while_preferred_still_down() {
+        let preferred = Arc::new(FakeClient::new(false));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        do_request(&engine).await.unwrap();
+        assert_eq!(engine.active(), 1);
+
+        do_switch_back(&engine).await;
+
+        assert_eq!(engine.active(), 1, "must stay on fallback");
+    }
+
+    #[tokio::test]
+    async fn no_switch_back_while_preferred_is_stale() {
+        let preferred = Arc::new(FakeClient::new(false));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        do_request(&engine).await.unwrap();
+        assert_eq!(engine.active(), 1);
+
+        // Preferred answers again but its head is old: it has reconnected but is
+        // still catching up.
+        preferred.set_up(true);
+        preferred.set_stale_head();
+        do_switch_back(&engine).await;
+        assert_eq!(
+            engine.active(),
+            1,
+            "must not switch back to a stale preferred"
+        );
+
+        // Once its head is fresh again, the next health-check switches back.
+        preferred.set_fresh_head();
+        do_switch_back(&engine).await;
+        assert_eq!(engine.active(), 0, "switches back once caught up");
+    }
+
+    #[tokio::test]
+    async fn only_switches_back_to_preferred_not_intermediate() {
+        let preferred = Arc::new(FakeClient::new(false));
+        let middle = Arc::new(FakeClient::new(false));
+        let last = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), middle.clone(), last.clone()]);
+
+        do_request(&engine).await.unwrap();
+        assert_eq!(engine.active(), 2);
+
+        // The intermediate endpoint recovers but the preferred is still down.
+        middle.set_up(true);
+        do_switch_back(&engine).await;
+        assert_eq!(
+            engine.active(),
+            2,
+            "intermediate recovery must not switch back"
+        );
+
+        // Once the preferred recovers, the next probe switches straight back.
+        preferred.set_up(true);
+        do_switch_back(&engine).await;
+        assert_eq!(engine.active(), 0, "should switch back to preferred");
+    }
+
+    #[tokio::test]
+    async fn empty_endpoints_returns_none() {
+        let engine = Failover::<FakeClient, FakeError>::new(
+            vec![],
+            is_network,
+            Duration::from_secs(1),
+            Duration::from_secs(30),
+        );
+        assert!(engine.is_none());
+    }
+}

--- a/utils/src/failover.rs
+++ b/utils/src/failover.rs
@@ -477,10 +477,19 @@ mod tests {
 
     /// A configurable fake transport client. `head` is the head's unix-seconds
     /// timestamp; the probe returns it so the engine can judge freshness.
+    ///
+    /// It also models a *self-healing* connection like `celestia_rpc`'s
+    /// `WsReconnectClient`: `connected` tracks the live socket, and a request made
+    /// while disconnected transparently reconnects (bumping `reconnects`) before
+    /// serving — provided the backend (`up`) is reachable. This lets a test drive
+    /// recovery through the engine's *cached* client without the engine ever
+    /// rebuilding it.
     struct FakeClient {
         up: AtomicBool,
         calls: AtomicUsize,
         head: AtomicI64,
+        connected: AtomicBool,
+        reconnects: AtomicUsize,
     }
 
     /// A simple error type with a "network error" variant.
@@ -510,11 +519,21 @@ mod tests {
                 up: AtomicBool::new(up),
                 calls: AtomicUsize::new(0),
                 head: AtomicI64::new(now_unix_secs()),
+                connected: AtomicBool::new(true),
+                reconnects: AtomicUsize::new(0),
             }
         }
 
         fn set_up(&self, up: bool) {
             self.up.store(up, Ordering::SeqCst);
+        }
+
+        fn is_connected(&self) -> bool {
+            self.connected.load(Ordering::SeqCst)
+        }
+
+        fn reconnects(&self) -> usize {
+            self.reconnects.load(Ordering::SeqCst)
         }
 
         fn set_fresh_head(&self) {
@@ -534,12 +553,28 @@ mod tests {
             self.calls.load(Ordering::SeqCst)
         }
 
-        /// Returns `1` when up, a network error otherwise.
+        /// Returns `1` when reachable, a network error otherwise — reconnecting in
+        /// place if the socket had dropped (mirroring `WsReconnectClient`).
         fn request(&self) -> Result<u64, FakeError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
+
+            // Socket previously dropped: reconnect on use if the backend is up,
+            // otherwise the reconnect fails and we stay disconnected.
+            if !self.connected.load(Ordering::SeqCst) {
+                if self.up.load(Ordering::SeqCst) {
+                    self.connected.store(true, Ordering::SeqCst);
+                    self.reconnects.fetch_add(1, Ordering::SeqCst);
+                } else {
+                    return Err(FakeError::Network);
+                }
+            }
+
             if self.up.load(Ordering::SeqCst) {
                 Ok(1)
             } else {
+                // Backend dropped under a live socket: detect it and mark the
+                // connection dead so the next use must reconnect.
+                self.connected.store(false, Ordering::SeqCst);
                 Err(FakeError::Network)
             }
         }
@@ -757,6 +792,59 @@ mod tests {
         }
         assert_eq!(fallback.calls(), before, "fallback must not be re-pinned");
         assert_eq!(engine.active(), 0);
+    }
+
+    #[tokio::test]
+    async fn recovery_reconnects_cached_client_without_rebuilding() {
+        // The seam the engine relies on: it keeps an endpoint's cached client and
+        // never rebuilds it (these slots have no build factory), so recovery after
+        // a disconnect can only come from the client self-healing on its next use
+        // — exactly how celestia_rpc's WsReconnectClient reconnects on
+        // RestartNeeded. This test drives a real disconnect/recovery through the
+        // engine and asserts the switch-back happens via an in-place reconnect.
+        let preferred = Arc::new(FakeClient::new(true));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        do_request(&engine).await.unwrap();
+        assert_eq!(engine.active(), 0);
+
+        // The preferred backend goes down: the next request detects the dropped
+        // connection, fails over to the fallback, and leaves the preferred's
+        // cached client disconnected.
+        preferred.set_up(false);
+        do_request(&engine).await.unwrap();
+        assert_eq!(engine.active(), 1);
+        assert!(
+            !preferred.is_connected(),
+            "the dropped socket is now disconnected"
+        );
+
+        // While still down, the recovery probe reuses the cached client but cannot
+        // reconnect it, so we stay on the fallback.
+        do_health_check(&engine).await;
+        assert_eq!(engine.active(), 1);
+        assert_eq!(
+            preferred.reconnects(),
+            0,
+            "must not reconnect while the backend is down"
+        );
+
+        // The backend recovers. The next probe reuses the SAME cached client,
+        // which reconnects itself, and routing switches back — the engine never
+        // rebuilt the client.
+        preferred.set_up(true);
+        do_health_check(&engine).await;
+        assert_eq!(
+            engine.active(),
+            0,
+            "switches back once the cached client has reconnected"
+        );
+        assert_eq!(
+            preferred.reconnects(),
+            1,
+            "recovery came from a single in-place reconnect"
+        );
     }
 
     #[tokio::test]

--- a/utils/src/failover.rs
+++ b/utils/src/failover.rs
@@ -373,7 +373,10 @@ impl<C, E> Failover<C, E> {
             }
 
             slot.set_healthy(true);
-            debug!("failover: endpoint {} recovered and is active again", slot.label);
+            debug!(
+                "failover: endpoint {} recovered and is active again",
+                slot.label
+            );
         }
     }
 
@@ -716,7 +719,11 @@ mod tests {
         // Once the preferred recovers too, it takes precedence again.
         preferred.set_up(true);
         do_health_check(&engine).await;
-        assert_eq!(engine.active(), 0, "preferred takes precedence once recovered");
+        assert_eq!(
+            engine.active(),
+            0,
+            "preferred takes precedence once recovered"
+        );
     }
 
     #[tokio::test]
@@ -736,7 +743,11 @@ mod tests {
         assert_eq!(engine.active(), 1);
 
         do_health_check(&engine).await;
-        assert_eq!(engine.active(), 0, "preferred is active again after recovery");
+        assert_eq!(
+            engine.active(),
+            0,
+            "preferred is active again after recovery"
+        );
 
         // Further requests go to the preferred and never touch the fallback, no
         // matter how many succeed.

--- a/utils/src/failover.rs
+++ b/utils/src/failover.rs
@@ -1,10 +1,14 @@
 //! Transport-agnostic multi-endpoint failover engine.
 //!
 //! [`Failover`](crate::failover::Failover) holds a priority-ordered list of endpoints and runs logical
-//! requests against the most-preferred reachable one, transparently falling
-//! back to the next endpoint on a *network* error. An optional background
-//! health-check probes the preferred endpoint and switches back to it once it
-//! has recovered *and its head is fresh* (within a configurable max age).
+//! requests against the most-preferred *healthy* one, transparently falling
+//! back to the next endpoint on a *network* error. Each endpoint carries a
+//! health flag; the active endpoint is **derived** as the lowest-index healthy
+//! one rather than stored, so an in-flight fallback request can never clobber a
+//! concurrent recovery of a more-preferred endpoint. An optional background
+//! health-check probes the currently-unhealthy endpoints and brings each one
+//! back once it has recovered *and its head is fresh* (within a configurable max
+//! age).
 //!
 //! The engine knows nothing about the concrete transport (`C`) or its error
 //! type (`E`): callers inject
@@ -13,17 +17,17 @@
 //!   client (or pre-cache it for transports that are built eagerly),
 //! - an `is_network_error` classifier deciding which errors trigger failover,
 //! - a *call* closure performing a single request against one client, and
-//! - (for switch-back) a *probe* closure returning an endpoint's current head
+//! - (for recovery) a *probe* closure returning an endpoint's current head
 //!   timestamp.
 //!
-//! Note: the switch-back "healthy" criterion is purely the head's **timestamp
+//! Note: the recovery "healthy" criterion is purely the head's **timestamp
 //! age**, not its block height. An endpoint can be a few blocks behind and still
 //! count as healthy if its head time is within `max_head_age`. This favours a
 //! simple, transport-agnostic signal over strict height parity.
 //!
 //! This lets both the JSON-RPC and the gRPC clients share one implementation.
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
@@ -148,23 +152,32 @@ impl<C, E> EndpointSlot<C, E> {
     fn set_healthy(&self, healthy: bool) {
         self.healthy.store(healthy, Ordering::Release);
     }
+
+    fn is_healthy(&self) -> bool {
+        self.healthy.load(Ordering::Acquire)
+    }
 }
 
 /// A transport-agnostic failover engine over a priority-ordered endpoint list.
 ///
 /// See the [module documentation](self) for details.
 pub struct Failover<C, E> {
+    /// Priority-ordered endpoints; index `0` is the most preferred.
+    ///
+    /// There is deliberately no stored "active" index: the endpoint a request
+    /// uses is *derived* as the lowest-index healthy endpoint (see
+    /// [`attempt_order`](Failover::attempt_order)). Routing being a pure function
+    /// of the per-endpoint `healthy` flags means an in-flight fallback request
+    /// can never clobber a concurrent recovery of a more-preferred endpoint.
     endpoints: Vec<EndpointSlot<C, E>>,
-    /// Index of the endpoint requests currently start from.
-    active: AtomicUsize,
     probe_timeout: Duration,
     /// Maximum age of an endpoint's head (by timestamp) for it to be considered
     /// healthy.
     ///
-    /// Used by the switch-back check: a preferred endpoint whose head timestamp
-    /// is older than this is treated as stale (e.g. reconnected but still
-    /// syncing), so we don't switch back to it. This is a timestamp check only —
-    /// it does not compare block heights.
+    /// Used by the background recovery probe: an endpoint whose head timestamp is
+    /// older than this is treated as stale (e.g. reconnected but still syncing),
+    /// so we keep it inactive. This is a timestamp check only — it does not
+    /// compare block heights.
     max_head_age: Duration,
     is_network_error: fn(&E) -> bool,
 }
@@ -174,8 +187,8 @@ impl<C, E> Failover<C, E> {
     ///
     /// The first endpoint is the most preferred. `is_network_error` decides
     /// which errors trigger failover; `probe_timeout` bounds a single
-    /// health-check probe; `max_head_age` is how recent a preferred endpoint's
-    /// head must be for the switch-back to consider it healthy.
+    /// health-check probe; `max_head_age` is how recent an endpoint's head must
+    /// be for the recovery probe to consider it healthy again.
     ///
     /// Returns `None` if `endpoints` is empty.
     pub fn new(
@@ -200,7 +213,6 @@ impl<C, E> Failover<C, E> {
 
         Some(Failover {
             endpoints,
-            active: AtomicUsize::new(0),
             probe_timeout,
             max_head_age,
             is_network_error,
@@ -217,11 +229,16 @@ impl<C, E> Failover<C, E> {
         self.endpoints.is_empty()
     }
 
-    /// Index of the endpoint requests currently start from.
+    /// Index of the endpoint requests currently prefer: the lowest-index healthy
+    /// endpoint, or `0` if none are currently healthy.
+    ///
+    /// This is *derived* from the per-endpoint health flags, not stored, so it
+    /// always reflects the latest health information without any writer that
+    /// could race a concurrent recovery.
     pub fn active(&self) -> usize {
-        self.active
-            .load(Ordering::Acquire)
-            .min(self.endpoints.len() - 1)
+        (0..self.endpoints.len())
+            .find(|&i| self.endpoints[i].is_healthy())
+            .unwrap_or(0)
     }
 
     /// The cached client of the currently active endpoint, building it if needed.
@@ -232,21 +249,20 @@ impl<C, E> Failover<C, E> {
         self.endpoints[self.active()].get_or_build().await
     }
 
-    /// Order in which endpoints are attempted: the active endpoint first, then
-    /// all others in priority order (so we always re-try the preferred ones).
+    /// Order in which endpoints are attempted: currently-healthy endpoints in
+    /// priority order, then currently-unhealthy ones (also in priority order) as
+    /// a last resort.
+    ///
+    /// So requests prefer the most-preferred *healthy* endpoint, an unhealthy
+    /// endpoint is skipped until the background probe (or a total outage) brings
+    /// it back, and even when everything is marked unhealthy we still attempt the
+    /// preferred endpoint first.
     fn attempt_order(&self) -> Vec<usize> {
         let n = self.endpoints.len();
-        let active = self.active();
-        let mut order = Vec::with_capacity(n);
-        order.push(active);
-        order.extend((0..n).filter(|&i| i != active));
-        order
-    }
-
-    fn select(&self, idx: usize) {
-        if self.active.load(Ordering::Acquire) != idx {
-            self.active.store(idx, Ordering::Release);
-        }
+        let (mut healthy, unhealthy): (Vec<usize>, Vec<usize>) =
+            (0..n).partition(|&i| self.endpoints[i].is_healthy());
+        healthy.extend(unhealthy);
+        healthy
     }
 
     /// Whether a head produced at `head_unix_secs` is recent enough (within
@@ -289,8 +305,10 @@ impl<C, E> Failover<C, E> {
 
             match call(client).await {
                 Ok(value) => {
+                    // Marking only this endpoint healthy is enough; routing is
+                    // derived from the flags, so a fallback success cannot demote
+                    // or override a more-preferred endpoint.
                     slot.set_healthy(true);
-                    self.select(idx);
                     return Ok(value);
                 }
                 Err(err) if (self.is_network_error)(&err) => {
@@ -307,56 +325,56 @@ impl<C, E> Failover<C, E> {
         Err(last_err.expect("attempt_order is never empty"))
     }
 
-    /// If the preferred endpoint (index `0`) is not the active one and has
-    /// recovered, switch the active endpoint back to it.
+    /// Probe every currently-unhealthy endpoint and bring back the ones that have
+    /// recovered, so routing can again prefer them.
     ///
-    /// The preferred endpoint counts as healthy only if it answers the probe
-    /// **and** its head is fresh (within `max_head_age`). A reconnected-but-still
-    /// -syncing endpoint reports an old head, so we keep using the fallback
-    /// rather than switch back to stale data.
+    /// An endpoint is brought back only if it answers the probe **and** its head
+    /// is fresh (within `max_head_age`). A reconnected-but-still-syncing endpoint
+    /// reports an old head, so it stays inactive rather than serving stale data.
+    /// Healthy endpoints are left untouched (they are presumably in use and would
+    /// be marked unhealthy by [`run`](Failover::run) on a real failure).
+    ///
+    /// Because the active endpoint is derived as the lowest-index healthy one,
+    /// reviving a more-preferred endpoint here automatically routes subsequent
+    /// requests back to it — without any switch that an in-flight request could
+    /// clobber.
     ///
     /// `probe` returns the endpoint's current head time (unix seconds) if it
     /// answers, or `None` if it is unreachable (the engine applies
     /// `probe_timeout`).
-    pub async fn switch_back_with<F, Fut>(&self, probe: F)
+    pub async fn recover_unhealthy_with<F, Fut>(&self, probe: F)
     where
         F: Fn(Arc<C>) -> Fut,
         Fut: std::future::Future<Output = Option<i64>>,
     {
-        if self.active() == 0 {
-            return;
-        }
-
-        let slot = &self.endpoints[0];
-        let client = match slot.get_or_build().await {
-            Ok(client) => client,
-            Err(_) => {
-                slot.set_healthy(false);
-                return;
+        for idx in 0..self.endpoints.len() {
+            let slot = &self.endpoints[idx];
+            if slot.is_healthy() {
+                continue;
             }
-        };
 
-        let Some(head) = self.probe(&probe, client).await else {
-            slot.set_healthy(false);
-            return;
-        };
+            let Ok(client) = slot.get_or_build().await else {
+                // Still cannot even build a client; remains inactive.
+                continue;
+            };
 
-        if !self.is_fresh(head) {
-            slot.set_healthy(false);
-            debug!(
-                "failover: preferred endpoint {} recovered but its head is stale \
-                 (older than {:?}); staying on the active endpoint",
-                slot.label, self.max_head_age
-            );
-            return;
+            let Some(head) = self.probe(&probe, client).await else {
+                // Unreachable; remains inactive.
+                continue;
+            };
+
+            if !self.is_fresh(head) {
+                debug!(
+                    "failover: endpoint {} reachable but its head is stale \
+                     (older than {:?}); keeping it inactive",
+                    slot.label, self.max_head_age
+                );
+                continue;
+            }
+
+            slot.set_healthy(true);
+            debug!("failover: endpoint {} recovered and is active again", slot.label);
         }
-
-        slot.set_healthy(true);
-        self.select(0);
-        debug!(
-            "failover: switched back to preferred endpoint {}",
-            slot.label
-        );
     }
 
     async fn probe<F, Fut>(&self, probe: &F, client: Arc<C>) -> Option<i64>
@@ -391,11 +409,12 @@ where
 {
     /// Spawn the background health-check task.
     ///
-    /// Every `interval` it probes the preferred endpoint via `probe` and, once
-    /// it has recovered and its head is recent enough, switches the active
-    /// endpoint back to it (see
-    /// [`switch_back_with`](Failover::switch_back_with)). The task holds a
-    /// [`Weak`] reference, so it stops on its own once the engine is dropped.
+    /// Every `interval` it probes each currently-unhealthy endpoint via `probe`
+    /// and brings back the ones that have recovered and whose head is recent
+    /// enough (see
+    /// [`recover_unhealthy_with`](Failover::recover_unhealthy_with)). The task
+    /// holds a [`Weak`] reference, so it stops on its own once the engine is
+    /// dropped.
     ///
     /// Does nothing when only a single endpoint is configured.
     pub fn spawn_health_check<F, Fut>(self: &Arc<Self>, interval: Duration, probe: F)
@@ -440,7 +459,7 @@ where
         let Some(engine) = weak.upgrade() else {
             break;
         };
-        engine.switch_back_with(&probe).await;
+        engine.recover_unhealthy_with(&probe).await;
     }
 }
 
@@ -538,7 +557,6 @@ mod tests {
 
         Failover {
             endpoints,
-            active: AtomicUsize::new(0),
             probe_timeout: Duration::from_secs(1),
             max_head_age: Duration::from_secs(30),
             is_network_error: is_network,
@@ -549,10 +567,10 @@ mod tests {
         engine.run(|client| async move { client.request() }).await
     }
 
-    /// A switch-back probe reporting a reachable endpoint's head height.
-    async fn do_switch_back(engine: &Failover<FakeClient, FakeError>) {
+    /// Run one recovery pass, probing reachable endpoints for their head time.
+    async fn do_health_check(engine: &Failover<FakeClient, FakeError>) {
         engine
-            .switch_back_with(|client| async move {
+            .recover_unhealthy_with(|client| async move {
                 match client.request() {
                     Ok(_) => Some(client.head()),
                     Err(_) => None,
@@ -626,7 +644,7 @@ mod tests {
         assert_eq!(engine.active(), 1);
 
         preferred.set_up(true);
-        do_switch_back(&engine).await;
+        do_health_check(&engine).await;
 
         assert_eq!(engine.active(), 0, "should switch back to preferred");
 
@@ -644,7 +662,7 @@ mod tests {
         do_request(&engine).await.unwrap();
         assert_eq!(engine.active(), 1);
 
-        do_switch_back(&engine).await;
+        do_health_check(&engine).await;
 
         assert_eq!(engine.active(), 1, "must stay on fallback");
     }
@@ -662,7 +680,7 @@ mod tests {
         // still catching up.
         preferred.set_up(true);
         preferred.set_stale_head();
-        do_switch_back(&engine).await;
+        do_health_check(&engine).await;
         assert_eq!(
             engine.active(),
             1,
@@ -671,12 +689,12 @@ mod tests {
 
         // Once its head is fresh again, the next health-check switches back.
         preferred.set_fresh_head();
-        do_switch_back(&engine).await;
+        do_health_check(&engine).await;
         assert_eq!(engine.active(), 0, "switches back once caught up");
     }
 
     #[tokio::test]
-    async fn only_switches_back_to_preferred_not_intermediate() {
+    async fn recovery_prefers_higher_priority_endpoint() {
         let preferred = Arc::new(FakeClient::new(false));
         let middle = Arc::new(FakeClient::new(false));
         let last = Arc::new(FakeClient::new(true));
@@ -685,19 +703,49 @@ mod tests {
         do_request(&engine).await.unwrap();
         assert_eq!(engine.active(), 2);
 
-        // The intermediate endpoint recovers but the preferred is still down.
+        // The intermediate endpoint recovers while the preferred is still down:
+        // routing prefers it over the lower-priority `last` endpoint.
         middle.set_up(true);
-        do_switch_back(&engine).await;
+        do_health_check(&engine).await;
         assert_eq!(
             engine.active(),
-            2,
-            "intermediate recovery must not switch back"
+            1,
+            "a recovered higher-priority endpoint is preferred over a lower one"
         );
 
-        // Once the preferred recovers, the next probe switches straight back.
+        // Once the preferred recovers too, it takes precedence again.
         preferred.set_up(true);
-        do_switch_back(&engine).await;
-        assert_eq!(engine.active(), 0, "should switch back to preferred");
+        do_health_check(&engine).await;
+        assert_eq!(engine.active(), 0, "preferred takes precedence once recovered");
+    }
+
+    #[tokio::test]
+    async fn fallback_success_does_not_demote_preferred() {
+        // The flapping bug, at the routing level: once the preferred endpoint is
+        // healthy again, ongoing successful fallback usage must not pull routing
+        // back to the fallback. With routing derived from per-endpoint health
+        // flags there is no shared "active" pointer for a fallback success to
+        // clobber.
+        let preferred = Arc::new(FakeClient::new(true));
+        let fallback = Arc::new(FakeClient::new(true));
+        let engine = engine(vec![preferred.clone(), fallback.clone()]);
+
+        // Force a failover to the fallback, then let the preferred recover.
+        engine.endpoints[0].set_healthy(false);
+        do_request(&engine).await.unwrap();
+        assert_eq!(engine.active(), 1);
+
+        do_health_check(&engine).await;
+        assert_eq!(engine.active(), 0, "preferred is active again after recovery");
+
+        // Further requests go to the preferred and never touch the fallback, no
+        // matter how many succeed.
+        let before = fallback.calls();
+        for _ in 0..5 {
+            do_request(&engine).await.unwrap();
+        }
+        assert_eq!(fallback.calls(), before, "fallback must not be re-pinned");
+        assert_eq!(engine.active(), 0);
     }
 
     #[tokio::test]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -5,6 +5,9 @@ pub mod cond_send;
 /// async executor platform independent utilities
 #[cfg(feature = "executor")]
 pub mod executor;
+/// transport-agnostic multi-endpoint failover engine
+#[cfg(feature = "failover")]
+pub mod failover;
 /// JS object utils
 #[cfg(all(target_arch = "wasm32", feature = "make-object"))]
 mod object;


### PR DESCRIPTION
## What & why

RPC and gRPC each had their own multi-endpoint failover with different
semantics and duplicated logic. This extracts a single transport-agnostic
engine and reuses it from both, with principled, non-flapping switch-back to
the most-preferred endpoint once it recovers.

## The shared engine — `lumina-utils::failover` (new `failover` feature)

`Failover<C, E>` is generic over the transport client (`C`) and its error
type (`E`). Routing is a **pure function of per-endpoint health flags** — there
is deliberately no stored "active" index:

- a priority-ordered endpoint list (`[0]` = most preferred) with lazy or
  pre-built clients, each carrying a `healthy` flag,
- `active()` is **derived** as the lowest-index healthy endpoint, so an
  in-flight fallback request can never clobber a concurrent recovery of a
  more-preferred endpoint,
- network-error classification is injected as `fn(&E) -> bool`,
- `run()` — try healthy endpoints in priority order (unhealthy ones only as a
  last resort), fail over **only on network errors** (application / JSON-RPC
  errors are surfaced as-is), and mark only the touched endpoint healthy /
  unhealthy,
- `recover_unhealthy_with()` / `spawn_health_check()` — a background task that
  probes every currently-unhealthy endpoint and revives the ones that have
  recovered; reviving a higher-priority endpoint automatically routes back to
  it.

### Why health flags instead of an `active` pointer

A single mutable `active` index meant any successful request re-pinned it. An
in-flight fallback request finishing *after* the health-check switched back to
the preferred endpoint would silently re-pin the fallback (no warn — it
succeeded), causing perpetual ping-pong at the health-check cadence and a flood
of "switched back to preferred endpoint" debug logs. Deriving routing from
per-endpoint flags removes the shared winner pointer, so that bug class is gone
structurally. Logs now fire only on genuine `unhealthy -> healthy` transitions.

## RPC (`celestia-rpc`)

`FailoverClient` is a thin jsonrpsee adapter (`ClientT` / `SubscriptionClientT`)
over the engine. Probe: `header.NetworkHead`.

## gRPC (`celestia-grpc`)

The `#[grpc_method]` macro now delegates to `failover.run(|transport| …)`
instead of the hand-rolled per-method `ArcSwap` swap-to-front loop; the
`arc-swap` dependency is dropped. The background health-check is **enabled by
default** (a no-op for a single endpoint, so a task only starts when a fallback
exists). Probe: lightweight node `Status` (no full block), carrying
per-endpoint auth metadata.

## Head-freshness recovery (configurable)

An endpoint is revived only if it answers the probe **and** its **head
timestamp** is within `max_head_age` (default 30s) — a timestamp check, not a
block-height comparison, so a node that reconnected but is still syncing (old
head) won't be routed back to. Configurable via `ClientBuilder::rpc_max_head_age`
and `GrpcClientBuilder::max_head_age`.

## Configuration example

All failover knobs are optional and default sensibly. Endpoints are tried in the
order given — the first is the most preferred:

```rust
use std::time::Duration;
use celestia_client::{Client, Endpoint, RpcEndpoint};

let client = Client::builder()
    // Preferred RPC endpoint (index 0), then fallbacks tried in order.
    .rpc_url("ws://localhost:26658")
    .rpc_endpoints([
        // A fallback that needs its own auth token (e.g. a provider).
        RpcEndpoint::new("wss://rpc.example.com").auth_token("my-token"),
        "wss://backup.example.com",
    ])
    // gRPC preferred + fallback (per-endpoint metadata / timeout supported).
    .grpc_endpoints([
        Endpoint::from("http://localhost:9090"),
        Endpoint::from("https://grpc.example.com").metadata("x-token", "my-token"),
    ])
    // Failover tuning (optional; defaults shown).
    .rpc_health_check_interval(Duration::from_secs(3)) // recovery probe cadence
    .rpc_max_head_age(Duration::from_secs(30))         // freshness bar to switch back
    .connect_timeout(Duration::from_secs(2))           // detect a down host faster
    .timeout(Duration::from_secs(10))                  // per-request timeout
    .build()
    .await?;
```

A single endpoint works exactly as before — no background task is started. With
two or more, the health-check runs automatically. The gRPC side exposes the
equivalent `GrpcClientBuilder::health_check_interval` / `max_head_age` when
building a `GrpcClient` directly.

## Defaults

- health-check interval: **3s** (lowered from 10s so a recovered endpoint is
  preferred again sooner; overridable per client),
- probe timeout: 5s, max head age: 30s.

## Verification

- `cargo build` (workspace) and `cargo build --target wasm32-unknown-unknown`
  for `celestia-rpc` / `celestia-grpc` / `celestia-client`
- `cargo test -p lumina-utils --features failover` (engine unit tests:
  failover, app-errors-don't-fail-over, recovery + higher-priority promotion,
  stale-head guard, fallback-success-does-not-demote-preferred)
- gRPC / RPC integration tests require a local devnet and were not run in the
  CI-less env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
