### PR TITLE
chore: release v1.1.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "blockstore",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-fibre"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bech32",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "prost",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3483,7 +3483,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-cli"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blockstore",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "rsema1d"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "getrandom 0.2.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "async-stream",
  "blockstore",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-fibre"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "async-trait",
  "bech32",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "bytes",
  "prost",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3483,7 +3483,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-cli"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-uniffi"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "anyhow",
  "blockstore",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "rsema1d"
-version = "2.0.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "criterion",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,23 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "2.0.0"
 edition = "2024"
 
 [workspace.dependencies]
 blockstore = "0.8"
 leopard-codec = "0.2"
-lumina-node = { version = "=1.0.0", path = "node" }
-lumina-node-wasm = { version = "=1.0.0", path = "node-wasm" }
-lumina-utils = { version = "=1.0.0", path = "utils" }
-celestia-client = { version = "=1.0.0", path = "client" }
-celestia-proto = { version = "=1.0.0", path = "proto" }
-celestia-grpc = { version = "=1.0.0", path = "grpc", default-features = false }
-celestia-grpc-macros = { version = "=1.0.0", path = "grpc/grpc-macros" }
-celestia-rpc = { version = "=1.0.0", path = "rpc", default-features = false }
-celestia-types = { version = "=1.0.0", path = "types", default-features = false }
-celestia-fibre = { version = "=1.0.0", path = "fibre" }
-rsema1d = { version = "=1.0.0", path = "rsema1d" }
+lumina-node = { version = "=2.0.0", path = "node" }
+lumina-node-wasm = { version = "=2.0.0", path = "node-wasm" }
+lumina-utils = { version = "=2.0.0", path = "utils" }
+celestia-client = { version = "=2.0.0", path = "client" }
+celestia-proto = { version = "=2.0.0", path = "proto" }
+celestia-grpc = { version = "=2.0.0", path = "grpc", default-features = false }
+celestia-grpc-macros = { version = "=2.0.0", path = "grpc/grpc-macros" }
+celestia-rpc = { version = "=2.0.0", path = "rpc", default-features = false }
+celestia-types = { version = "=2.0.0", path = "types", default-features = false }
+celestia-fibre = { version = "=2.0.0", path = "fibre" }
+rsema1d = { version = "=2.0.0", path = "rsema1d" }
 
 anyhow = "1.0.40"
 async-stream = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,23 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "1.1.0-rc.1"
 edition = "2024"
 
 [workspace.dependencies]
 blockstore = "0.8"
 leopard-codec = "0.2"
-lumina-node = { version = "=2.0.0", path = "node" }
-lumina-node-wasm = { version = "=2.0.0", path = "node-wasm" }
-lumina-utils = { version = "=2.0.0", path = "utils" }
-celestia-client = { version = "=2.0.0", path = "client" }
-celestia-proto = { version = "=2.0.0", path = "proto" }
-celestia-grpc = { version = "=2.0.0", path = "grpc", default-features = false }
-celestia-grpc-macros = { version = "=2.0.0", path = "grpc/grpc-macros" }
-celestia-rpc = { version = "=2.0.0", path = "rpc", default-features = false }
-celestia-types = { version = "=2.0.0", path = "types", default-features = false }
-celestia-fibre = { version = "=2.0.0", path = "fibre" }
-rsema1d = { version = "=2.0.0", path = "rsema1d" }
+lumina-node = { version = "=1.1.0-rc.1", path = "node" }
+lumina-node-wasm = { version = "=1.1.0-rc.1", path = "node-wasm" }
+lumina-utils = { version = "=1.1.0-rc.1", path = "utils" }
+celestia-client = { version = "=1.1.0-rc.1", path = "client" }
+celestia-proto = { version = "=1.1.0-rc.1", path = "proto" }
+celestia-grpc = { version = "=1.1.0-rc.1", path = "grpc", default-features = false }
+celestia-grpc-macros = { version = "=1.1.0-rc.1", path = "grpc/grpc-macros" }
+celestia-rpc = { version = "=1.1.0-rc.1", path = "rpc", default-features = false }
+celestia-types = { version = "=1.1.0-rc.1", path = "types", default-features = false }
+celestia-fibre = { version = "=1.1.0-rc.1", path = "fibre" }
+rsema1d = { version = "=1.1.0-rc.1", path = "rsema1d" }
 
 anyhow = "1.0.40"
 async-stream = "0.3.5"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0...celestia-client-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0...celestia-client-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0...celestia-client-v2.0.0) - 2026-06-24
+
+### Added
+
+- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
+- *(client)* expose get_tx on StateApi for reading submitted transactions ([#974](https://github.com/celestiaorg/lumina/pull/974))
+- add fibre download client and lumina client integration ([#971](https://github.com/celestiaorg/lumina/pull/971))
+
+### Other
+
+- Add support for connect timeout ([#975](https://github.com/celestiaorg/lumina/pull/975))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0-rc.2...celestia-client-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/fibre/CHANGELOG.md
+++ b/fibre/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-fibre-v1.0.0...celestia-fibre-v2.0.0) - 2026-06-24
+
+### Added
+
+- add fibre download client and lumina client integration ([#971](https://github.com/celestiaorg/lumina/pull/971))
+- add fibre gRPC transport and upload client ([#969](https://github.com/celestiaorg/lumina/pull/969))
+- add fibre validator tracking and signature collection ([#965](https://github.com/celestiaorg/lumina/pull/965))
+- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))

--- a/fibre/CHANGELOG.md
+++ b/fibre/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-fibre-v1.0.0...celestia-fibre-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-fibre-v1.0.0...celestia-fibre-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0...celestia-grpc-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0...celestia-grpc-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0...celestia-grpc-v2.0.0) - 2026-06-24
+
+### Added
+
+- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
+- add multi-account TX service and refactor tx client ([#963](https://github.com/celestiaorg/lumina/pull/963))
+- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
+- add fibre gRPC service client and account signer ([#958](https://github.com/celestiaorg/lumina/pull/958))
+
+### Other
+
+- Add support for connect timeout ([#975](https://github.com/celestiaorg/lumina/pull/975))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0-rc.2...celestia-grpc-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/grpc/grpc-macros/CHANGELOG.md
+++ b/grpc/grpc-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-grpc-macros-v1.0.0...celestia-grpc-macros-v2.0.0) - 2026-06-24
+
+### Added
+
+- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
+
 ## [1.0.0-rc.2](https://github.com/celestiaorg/lumina/compare/celestia-grpc-macros-v0.7.0...celestia-grpc-macros-v1.0.0-rc.2) - 2026-02-25
 
 ### Added

--- a/grpc/grpc-macros/CHANGELOG.md
+++ b/grpc/grpc-macros/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-grpc-macros-v1.0.0...celestia-grpc-macros-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-grpc-macros-v1.0.0...celestia-grpc-macros-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-uniffi-v1.0.0...lumina-node-uniffi-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-node-uniffi-v1.0.0...lumina-node-uniffi-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/node-uniffi/CHANGELOG.md
+++ b/node-uniffi/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-uniffi-v1.0.0...lumina-node-uniffi-v2.0.0) - 2026-06-24
+
+### Added
+
+- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))
+
+### Other
+
+- [**breaking**] remove iOS, Android, and uniffi binding CI jobs ([#960](https://github.com/celestiaorg/lumina/pull/960))
+
 ### Deprecated
 
 - iOS/Android CI jobs, release automation, and binary artifact builds have been removed ([#960](https://github.com/celestiaorg/lumina/pull/960)). The builds will be removed in future versions.

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-wasm-v1.0.0...lumina-node-wasm-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-node-wasm-v1.0.0...lumina-node-wasm-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-wasm-v1.0.0...lumina-node-wasm-v2.0.0) - 2026-06-24
+
+### Added
+
+- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))
+
 ## [1.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-wasm-v1.0.0-rc.3...lumina-node-wasm-v1.0.0) - 2026-04-03
 
 ### Other

--- a/node-wasm/js/README.md
+++ b/node-wasm/js/README.md
@@ -6326,7 +6326,7 @@ lumina\_node\_wasm.d.ts:2317
 > **requestAllBlobs**(`namespace`, `block_height`, `timeout_secs`?): `Promise`\<[`Blob`](#classesblobmd)[]\>
 
 Request all blobs with provided namespace in the block corresponding to this header
-using bitswap protocol.
+using the shrex protocol.
 
 ##### Parameters
 

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package-lock.json
+++ b/node-wasm/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lumina-node",
-    "version": "2.0.0",
+    "version": "1.1.0-rc.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lumina-node",
-            "version": "2.0.0",
+            "version": "1.1.0-rc.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "lumina-node-wasm": "file:../pkg"
@@ -20,7 +20,7 @@
         },
         "../pkg": {
             "name": "lumina-node-wasm",
-            "version": "2.0.0",
+            "version": "1.1.0-rc.1",
             "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Celestia <contact@celestia.org>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Celestia <contact@celestia.org>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "2.0.0",
+    "version": "1.1.0-rc.1",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0...lumina-node-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0...lumina-node-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0...lumina-node-v2.0.0) - 2026-06-24
+
+### Added
+
+- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
+- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))
+- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
+
 ## [1.0.0](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0-rc.3...lumina-node-v1.0.0) - 2026-04-03
 
 ### Added

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0...celestia-proto-v2.0.0) - 2026-06-24
+
+### Added
+
+- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0-rc.2...celestia-proto-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0...celestia-proto-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0...celestia-proto-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-rpc-v1.0.0...celestia-rpc-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-rpc-v1.0.0...celestia-rpc-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-rpc-v1.0.0...celestia-rpc-v2.0.0) - 2026-06-24
+
+### Added
+
+- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
+- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-rpc-v1.0.0-rc.2...celestia-rpc-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/rsema1d/CHANGELOG.md
+++ b/rsema1d/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0...rsema1d-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0...rsema1d-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/rsema1d/CHANGELOG.md
+++ b/rsema1d/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0...rsema1d-v2.0.0) - 2026-06-24
+
+### Added
+
+- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
+- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0-rc.2...rsema1d-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0...celestia-types-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0...celestia-types-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0...celestia-types-v2.0.0) - 2026-06-24
+
+### Added
+
+- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))
+- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
+- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))
+
+### Other
+
+- Add support for connect timeout ([#975](https://github.com/celestiaorg/lumina/pull/975))
+
 ## [1.0.0-rc.3](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0-rc.2...celestia-types-v1.0.0-rc.3) - 2026-03-19
 
 ### Added

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-utils-v1.0.0...lumina-utils-v2.0.0) - 2026-06-24
+## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-utils-v1.0.0...lumina-utils-v1.1.0-rc.1) - 2026-06-24
 
 ### Added
 

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/celestiaorg/lumina/compare/lumina-utils-v1.0.0...lumina-utils-v2.0.0) - 2026-06-24
+
+### Added
+
+- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
+- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
+
 ## [1.0.0-rc.2](https://github.com/celestiaorg/lumina/compare/lumina-utils-v0.5.2...lumina-utils-v1.0.0-rc.2) - 2026-02-25
 
 ### Added


### PR DESCRIPTION
> [!NOTE]
> Released as **`1.1.0-rc.1`** (a release candidate), **not `2.0.0`**.
> release-plz proposed a major bump because `cargo-semver-checks` detected
> API-breaking changes (listed below). We are intentionally shipping these as a
> `1.1.0` release candidate, so the workspace version, internal dependency pins,
> changelog headers, and the `lumina-node` npm package have all been pinned to
> `1.1.0-rc.1`. The breaking-change report is kept below for reviewer awareness.
> Subsequent RCs (`-rc.2`, …) will auto-increment without manual edits.




## What's in this release

`1.1.0-rc.1` covers everything merged since `1.0.0`. The headline is the new
**Fibre** blob-storage stack, a **unified failover engine** shared by the RPC and
gRPC clients, and a **node data-fetch switch from shwap to shrex**. Several
public APIs changed or were removed (`cargo-semver-checks` report below), which
is why release-plz proposed a major bump.

### ✨ Added
- **Unified failover engine** shared across the RPC and gRPC clients ([#977]) —
  new `utils/src/failover.rs` and `rpc/src/failover.rs`.
- **Multi-account TX service** and tx-client refactor ([#963]).
- `get_tx` on `StateApi` to read back submitted transactions ([#974]).
- Connect-timeout support on the clients ([#975]).
- `CondSend` trait and updated `rsema1d` codec API ([#955]).

### 🔄 Changed (breaking)

- **node data fetching: shwap → shrex** ([#976]). Sample and row requests now go
  over shrex; `node/src/p2p/shwap.rs` and its tests were **removed** and replaced
  by `node/tests/shrex.rs`. Affects `lumina-node`, `lumina-node-wasm`, and
  `lumina-node-uniffi`.
- **`celestia-grpc` TX API** ([#963], [#977]):
  - `TxServiceConfig` gained a required `signer` field, so `TxServiceConfig::new`
    now takes **2 parameters** instead of 1;
  - `TxPayload::Tx` was **removed/renamed** to `TxPayload::Message`;
  - `TxRequest::tx` method was **removed**;
  - new error variants `Error::UnknownAccount`.
- **`celestia-proto`** ([#954]): the `proto::blob::v2` module and its types
  (`BlobTx`, `IndexWrapper`, `BlobProto`) were **removed** — blob protos moved to
  `v4`; the vendored `go-square/blob/v2/blob.proto` was dropped.
- New (exhaustive-enum) error variants, breaking downstream `match` arms:
  - `celestia-rpc`: `Error::NoEndpoints` ([#977]);
  - `celestia-client`: `Error::Fibre`.

### 🗑️ Removed / Deprecated

- `proto::blob::v2` module and the `go-square/blob/v2` vendor (see above).
- `node/src/p2p/shwap.rs` and `node/tests/shwap.rs` (replaced by shrex).
- **iOS / Android / uniffi CI jobs, release automation, and binary-artifact
  builds** were removed ([#960]). The `node-uniffi` crate remains for now but its
  builds will be removed in a future version.

[#954]: https://github.com/celestiaorg/lumina/pull/954
[#955]: https://github.com/celestiaorg/lumina/pull/955
[#958]: https://github.com/celestiaorg/lumina/pull/958
[#959]: https://github.com/celestiaorg/lumina/pull/959
[#960]: https://github.com/celestiaorg/lumina/pull/960
[#963]: https://github.com/celestiaorg/lumina/pull/963
[#965]: https://github.com/celestiaorg/lumina/pull/965
[#969]: https://github.com/celestiaorg/lumina/pull/969
[#971]: https://github.com/celestiaorg/lumina/pull/971
[#974]: https://github.com/celestiaorg/lumina/pull/974
[#975]: https://github.com/celestiaorg/lumina/pull/975
[#976]: https://github.com/celestiaorg/lumina/pull/976
[#977]: https://github.com/celestiaorg/lumina/pull/977

## 🤖 New release

* `celestia-proto`: 1.0.0 -> 1.1.0-rc.1 (⚠ API breaking changes)
* `lumina-utils`: 1.0.0 -> 1.1.0-rc.1 (✓ API compatible changes)
* `celestia-types`: 1.0.0 -> 1.1.0-rc.1 (✓ API compatible changes)
* `celestia-rpc`: 1.0.0 -> 1.1.0-rc.1 (⚠ API breaking changes)
* `lumina-node`: 1.0.0 -> 1.1.0-rc.1 (✓ API compatible changes)
* `lumina-cli`: 1.0.0 -> 1.1.0-rc.1
* `celestia-grpc-macros`: 1.0.0 -> 1.1.0-rc.1
* `celestia-grpc`: 1.0.0 -> 1.1.0-rc.1 (⚠ API breaking changes)
* `rsema1d`: 1.0.0 -> 1.1.0-rc.1 (✓ API compatible changes)
* `celestia-fibre`: 1.0.0 -> 1.1.0-rc.1
* `celestia-client`: 1.0.0 -> 1.1.0-rc.1 (⚠ API breaking changes)
* `lumina-node-wasm`: 1.0.0 -> 1.1.0-rc.1 (✓ API compatible changes)
* `lumina-node-uniffi`: 1.0.0 -> 1.1.0-rc.1 (✓ API compatible changes)

### ⚠ `celestia-proto` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod celestia_proto::proto::blob::v2, previously in file /tmp/.tmp8xj1FS/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-x86_64_unknown_linux_gnu-8282aa9c8a17b8ed/target/debug/build/celestia-proto-c12a2a5638c74ed6/out/mod.rs:126

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct celestia_proto::proto::blob::v2::BlobTx, previously in file /tmp/.tmp8xj1FS/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-x86_64_unknown_linux_gnu-8282aa9c8a17b8ed/target/debug/build/celestia-proto-c12a2a5638c74ed6/out/proto.blob.v2.rs:40
  struct celestia_proto::proto::blob::v2::IndexWrapper, previously in file /tmp/.tmp8xj1FS/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-x86_64_unknown_linux_gnu-8282aa9c8a17b8ed/target/debug/build/celestia-proto-c12a2a5638c74ed6/out/proto.blob.v2.rs:61
  struct celestia_proto::proto::blob::v2::BlobProto, previously in file /tmp/.tmp8xj1FS/celestia-proto/target/semver-checks/local-celestia_proto-1_0_0-x86_64_unknown_linux_gnu-8282aa9c8a17b8ed/target/debug/build/celestia-proto-c12a2a5638c74ed6/out/proto.blob.v2.rs:8
```

### ⚠ `celestia-rpc` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:NoEndpoints in /tmp/.tmpH8Mbp8/lumina/rpc/src/error.rs:22
```

### ⚠ `celestia-grpc` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TxServiceConfig.signer in /tmp/.tmpH8Mbp8/lumina/grpc/src/tx_client_impl.rs:60

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:UnknownAccount in /tmp/.tmpH8Mbp8/lumina/grpc/src/error.rs:112
  variant TxPayload:Message in /tmp/.tmpH8Mbp8/lumina/grpc/src/tx_client_v2/mod.rs:133

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant TxPayload::Tx, previously in file /tmp/.tmp8xj1FS/celestia-grpc/src/tx_client_v2/mod.rs:133

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  TxRequest::tx, previously in file /tmp/.tmp8xj1FS/celestia-grpc/src/tx_client_v2/mod.rs:265
  TxRequest::tx, previously in file /tmp/.tmp8xj1FS/celestia-grpc/src/tx_client_v2/mod.rs:265

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  celestia_grpc::TxServiceConfig::new takes 1 parameters in /tmp/.tmp8xj1FS/celestia-grpc/src/tx_client_impl.rs:68, but now takes 2 parameters in /tmp/.tmpH8Mbp8/lumina/grpc/src/tx_client_impl.rs:71
```

### ⚠ `celestia-client` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:Fibre in /tmp/.tmpH8Mbp8/lumina/client/src/lib.rs:150
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `celestia-proto`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-proto-v1.0.0...celestia-proto-v1.1.0-rc.1) - 2026-06-24

### Added

- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))
</blockquote>

## `lumina-utils`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-utils-v1.0.0...lumina-utils-v1.1.0-rc.1) - 2026-06-24

### Added

- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
</blockquote>

## `celestia-types`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-types-v1.0.0...celestia-types-v1.1.0-rc.1) - 2026-06-24

### Added

- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))
- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
- add fibre and valaddr proto definitions ([#954](https://github.com/celestiaorg/lumina/pull/954))

### Other

- Add support for connect timeout ([#975](https://github.com/celestiaorg/lumina/pull/975))
</blockquote>

## `celestia-rpc`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-rpc-v1.0.0...celestia-rpc-v1.1.0-rc.1) - 2026-06-24

### Added

- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
</blockquote>

## `lumina-node`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-node-v1.0.0...lumina-node-v1.1.0-rc.1) - 2026-06-24

### Added

- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))
- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
</blockquote>

## `lumina-cli`

<blockquote>

## [1.0.0](https://github.com/celestiaorg/lumina/compare/lumina-cli-v1.0.0-rc.4...lumina-cli-v1.0.0) - 2026-04-03

### Other

- update Cargo.lock dependencies
</blockquote>

## `celestia-grpc-macros`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-grpc-macros-v1.0.0...celestia-grpc-macros-v1.1.0-rc.1) - 2026-06-24

### Added

- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
</blockquote>

## `celestia-grpc`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-grpc-v1.0.0...celestia-grpc-v1.1.0-rc.1) - 2026-06-24

### Added

- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
- add multi-account TX service and refactor tx client ([#963](https://github.com/celestiaorg/lumina/pull/963))
- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
- add fibre gRPC service client and account signer ([#958](https://github.com/celestiaorg/lumina/pull/958))

### Other

- Add support for connect timeout ([#975](https://github.com/celestiaorg/lumina/pull/975))
</blockquote>

## `rsema1d`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/rsema1d-v1.0.0...rsema1d-v1.1.0-rc.1) - 2026-06-24

### Added

- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
- add CondSend trait and update rsema1d codec API ([#955](https://github.com/celestiaorg/lumina/pull/955))
</blockquote>

## `celestia-fibre`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-fibre-v1.0.0...celestia-fibre-v1.1.0-rc.1) - 2026-06-24

### Added

- add fibre download client and lumina client integration ([#971](https://github.com/celestiaorg/lumina/pull/971))
- add fibre gRPC transport and upload client ([#969](https://github.com/celestiaorg/lumina/pull/969))
- add fibre validator tracking and signature collection ([#965](https://github.com/celestiaorg/lumina/pull/965))
- add fibre crate with domain types ([#959](https://github.com/celestiaorg/lumina/pull/959))
</blockquote>

## `celestia-client`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0...celestia-client-v1.1.0-rc.1) - 2026-06-24

### Added

- share one failover engine across RPC and gRPC clients ([#977](https://github.com/celestiaorg/lumina/pull/977))
- *(client)* expose get_tx on StateApi for reading submitted transactions ([#974](https://github.com/celestiaorg/lumina/pull/974))
- add fibre download client and lumina client integration ([#971](https://github.com/celestiaorg/lumina/pull/971))

### Other

- Add support for connect timeout ([#975](https://github.com/celestiaorg/lumina/pull/975))
</blockquote>

## `lumina-node-wasm`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-node-wasm-v1.0.0...lumina-node-wasm-v1.1.0-rc.1) - 2026-06-24

### Added

- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))
</blockquote>

## `lumina-node-uniffi`

<blockquote>

## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/lumina-node-uniffi-v1.0.0...lumina-node-uniffi-v1.1.0-rc.1) - 2026-06-24

### Added

- *(node)* [**breaking**] switch sample and row requests to shrex ([#976](https://github.com/celestiaorg/lumina/pull/976))

### Other

- [**breaking**] remove iOS, Android, and uniffi binding CI jobs ([#960](https://github.com/celestiaorg/lumina/pull/960))

### Deprecated

- iOS/Android CI jobs, release automation, and binary artifact builds have been removed ([#960](https://github.com/celestiaorg/lumina/pull/960)). The builds will be removed in future versions.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
